### PR TITLE
chore: fix linting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,16 +46,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: perses/github-actions@v0.1.0
+      - uses: perses/github-actions@v0.6.0
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
-          go_version: 1.22
+          enable_go_cache: false
+          enable_npm: false
       - name: generate files
         run: make generate
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54.2
+          version: v1.61.0
           args: --timeout 5m

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+          go_version: 1.22
       - name: generate files
         run: make generate
       - name: golangci-lint

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -11,7 +11,7 @@ import (
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	dashboardcontroller "github.com/perses/perses-operator/controllers/dashboards"
 	internal "github.com/perses/perses-operator/internal/perses"
-	common "github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/perses/common"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persescommon "github.com/perses/perses/pkg/model/api/v1/common"
@@ -171,7 +171,7 @@ var _ = Describe("Dashboard controller", func() {
 				dashboardWithStatus := &persesv1alpha1.PersesDashboard{}
 				err = k8sClient.Get(ctx, dashboardNamespaceName, dashboardWithStatus)
 
-				if dashboardWithStatus.Status.Conditions == nil || len(dashboardWithStatus.Status.Conditions) == 0 {
+				if len(dashboardWithStatus.Status.Conditions) == 0 {
 					return fmt.Errorf("No status condition was added to the perses dashboard instance")
 				} else {
 					latestStatusCondition := dashboardWithStatus.Status.Conditions[len(dashboardWithStatus.Status.Conditions)-1]

--- a/controllers/dashboards/dasboard_controller.go
+++ b/controllers/dashboards/dasboard_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
-	perseshttp "github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	logger "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -30,8 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -103,7 +103,7 @@ func (r *PersesDashboardReconciler) setStatusToUnknown(ctx context.Context, req 
 		return r, err
 	}
 
-	if dashboard.Status.Conditions == nil || len(dashboard.Status.Conditions) == 0 {
+	if len(dashboard.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err := r.Status().Update(ctx, dashboard); err != nil {
 			log.WithError(err).Error("Failed to update Perses dashboard status")

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -11,7 +11,7 @@ import (
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	datasourcecontroller "github.com/perses/perses-operator/controllers/datasources"
 	internal "github.com/perses/perses-operator/internal/perses"
-	common "github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/perses/common"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persescommon "github.com/perses/perses/pkg/model/api/v1/common"
@@ -160,7 +160,7 @@ var _ = Describe("Datasource controller", func() {
 				datasourceWithStatus := &persesv1alpha1.PersesDatasource{}
 				err = k8sClient.Get(ctx, datasourceNamespaceName, datasourceWithStatus)
 
-				if datasourceWithStatus.Status.Conditions == nil || len(datasourceWithStatus.Status.Conditions) == 0 {
+				if len(datasourceWithStatus.Status.Conditions) == 0 {
 					return fmt.Errorf("No status condition was added to the perses datasource instance")
 				} else {
 					latestStatusCondition := datasourceWithStatus.Status.Conditions[len(datasourceWithStatus.Status.Conditions)-1]

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
-	perseshttp "github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	logger "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -30,8 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -103,7 +103,7 @@ func (r *PersesDatasourceReconciler) setStatusToUnknown(ctx context.Context, req
 		return r, err
 	}
 
-	if datasource.Status.Conditions == nil || len(datasource.Status.Conditions) == 0 {
+	if len(datasource.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&datasource.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err := r.Status().Update(ctx, datasource); err != nil {
 			log.WithError(err).Error("Failed to update Perses datasource status")

--- a/controllers/perses/configmap_controller.go
+++ b/controllers/perses/configmap_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	logger "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/perses/deployment_controller.go
+++ b/controllers/perses/deployment_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	logger "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	logger "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -106,7 +106,7 @@ func (r *PersesReconciler) setStatusToUnknown(ctx context.Context, req ctrl.Requ
 	}
 
 	// Let's just set the status as Unknown when no status are available
-	if perses.Status.Conditions == nil || len(perses.Status.Conditions) == 0 {
+	if len(perses.Status.Conditions) == 0 {
 		meta.SetStatusCondition(&perses.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err := r.Status().Update(ctx, perses); err != nil {
 			log.WithError(err).Error("Failed to update Perses status")

--- a/controllers/perses/service_controller.go
+++ b/controllers/perses/service_controller.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"github.com/perses/perses-operator/api/v1alpha1"
-	common "github.com/perses/perses-operator/internal/perses/common"
-	subreconciler "github.com/perses/perses-operator/internal/subreconciler"
+	"github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 	logger "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	persescontroller "github.com/perses/perses-operator/controllers/perses"
-	common "github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/perses/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -144,7 +144,7 @@ var _ = Describe("Perses controller", func() {
 
 			By("Checking the latest Status Condition added to the Perses instance")
 			Eventually(func() error {
-				if perses.Status.Conditions != nil && len(perses.Status.Conditions) != 0 {
+				if len(perses.Status.Conditions) != 0 {
 					latestStatusCondition := perses.Status.Conditions[len(perses.Status.Conditions)-1]
 					expectedLatestStatusCondition := metav1.Condition{Type: common.TypeAvailablePerses,
 						Status: metav1.ConditionTrue, Reason: "Reconciling",
@@ -184,7 +184,7 @@ var _ = Describe("Perses controller", func() {
 
 			By("Checking the latest Status Condition added to the Perses instance")
 			Eventually(func() error {
-				if perses.Status.Conditions != nil && len(perses.Status.Conditions) != 0 {
+				if len(perses.Status.Conditions) != 0 {
 					latestStatusCondition := perses.Status.Conditions[len(perses.Status.Conditions)-1]
 					expectedLatestStatusCondition := metav1.Condition{Type: common.TypeAvailablePerses,
 						Status: metav1.ConditionTrue, Reason: "Finalizing",

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -5,7 +5,7 @@ import (
 
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
-	perseshttp "github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/client/perseshttp"
 )
 
 type PersesClientFactory interface {


### PR DESCRIPTION
* pin the Go version used to run golangci-lint to Go 1.22
* fix linting issues reported by golangci-lint (superfluos nil checks for slices)
* remove redundant package aliases