### PR TITLE
[DOCS] improve Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make install
 2. Install custom resources:
 
 ```sh
-bin/kustomize build config/samples | kubectl apply -f -
+kubectl apply -k config/samples
 ```
 
 3. Build and push your image to the location specified by `IMG`:


### PR DESCRIPTION
Since Kubernetes version 1.14,[ kustomize has been included directly within the kubectl binary](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/). This means we don't need to install kustomize separately to use its features. 