### PR TITLE
use StatefulSet instead of a deployment to persist dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,6 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 
-##@ Deployment
-
 ifndef ignore-not-found
   ignore-not-found = false
 endif

--- a/README.md
+++ b/README.md
@@ -16,22 +16,27 @@ You’ll need:
 make install
 ```
 
-2. Install custom resources:
+2. Create a namespace for the resources:
+```sh
+kubectl create namespace perses-dev
+```
+
+3. Install custom resources:
 
 ```sh
 kubectl apply -k config/samples
 ```
 
-3. Using the the location specified by `IMG`, build a testing image and push it to the registry, then deploy the controller to the cluster:
+4. Using the the location specified by `IMG`, build a testing image and push it to the registry, then deploy the controller to the cluster:
 
 ```sh
 IMG=<some-registry>/perses-operator:tag make test-image-build image-push deploy
 ```
 
-4. Port forward the service so you can access the Perses UI at `http://localhost:8080`:
+5. Port forward the service so you can access the Perses UI at `http://localhost:8080`:
 
 ```sh
-kubectl port-forward svc/perses-sample 8080:8080
+kubectl -n perses-dev port-forward svc/perses-sample 8080:8080
 ```
 
 ### Uninstall CRDs
@@ -65,7 +70,7 @@ Each instance of the CRD deploys the following resources:
 
 - A ConfigMap holding the perses configuration
 - A Service so perses API can be accessed from within the cluster
-- A Deployment holding the perses API
+- A StatefulSet holding the perses API
 
 ### Test It Out
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,10 +56,6 @@ spec:
       #             operator: In
       #             values:
       #               - linux
-      securityContext:
-        runAsNonRoot: true
-        runAsGroup: 65532
-        runAsUser: 65532
       containers:
       - args:
         - --leader-elect

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     verbs:
       - create
       - delete
@@ -30,6 +31,7 @@ rules:
       - deployments
       - services
       - configmaps
+      - statefulsets
     verbs:
       - get
       - patch

--- a/config/samples/perses.dev_v1alpha1_perses.yaml
+++ b/config/samples/perses.dev_v1alpha1_perses.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-sample
+  namespace: perses-dev
 spec:
   config:
     database:

--- a/config/samples/perses.dev_v1alpha1_persesdashboard.yaml
+++ b/config/samples/perses.dev_v1alpha1_persesdashboard.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-dashboard-sample
+  namespace: perses-dev
 spec:
   display:
     name: Perses Dashboard Sample

--- a/config/samples/perses.dev_v1alpha1_persesdatasource.yaml
+++ b/config/samples/perses.dev_v1alpha1_persesdatasource.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-datasource-sample
+  namespace: perses-dev
 spec:
   display:
     name: "Default Datasource"

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -39,12 +39,12 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 	err := r.Client.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithError(err)
+		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
 	}
 
 	if len(persesInstances.Items) == 0 {
-		dlog.Info("No Perses instances found")
-		return subreconciler.DoNotRequeue()
+		dlog.Info("No Perses instances found, retrying in 1 minute")
+		return subreconciler.RequeueWithDelay(time.Minute)
 	}
 
 	dashboard := &persesv1alpha1.PersesDashboard{}

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -84,8 +84,8 @@ func (r *PersesDashboardReconciler) handleDelete(ctx context.Context, req ctrl.R
 
 	if err := r.Get(ctx, req.NamespacedName, dashboard); err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.WithError(err).Error("Failed to get perses dashboard")
-			return subreconciler.RequeueWithError(err)
+			dlog.Info("No Perses instances found, retrying in 1 minute")
+			return subreconciler.RequeueWithDelay(time.Minute)
 		}
 
 		log.Infof("perses dashboard resource not found. Deleting '%s' in '%s'", req.Name, req.Namespace)

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -39,12 +39,12 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 	err := r.Client.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithError(err)
+		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
 	}
 
 	if len(persesInstances.Items) == 0 {
 		dlog.Info("No Perses instances found")
-		return subreconciler.DoNotRequeue()
+		return subreconciler.RequeueWithDelay(time.Minute)
 	}
 
 	datasource := &persesv1alpha1.PersesDatasource{}

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -56,7 +56,7 @@ var log = logger.WithField("module", "perses_controller")
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
@@ -66,7 +66,7 @@ func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		r.handleDelete,
 		r.reconcileService,
 		r.reconcileConfigMap,
-		r.reconcileDeployment,
+		r.reconcileStatefulSet,
 	}
 
 	// Run all subreconcilers sequentially
@@ -241,6 +241,7 @@ func (r *PersesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Perses{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Complete(r)

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -119,23 +119,23 @@ var _ = Describe("Perses controller", func() {
 				return k8sClient.Get(ctx, configMapNamespaceName, found)
 			}, time.Minute*3, time.Second).Should(Succeed())
 
-			By("Checking if Deployment was successfully created in the reconciliation")
+			By("Checking if StatefulSet was successfully created in the reconciliation")
 			Eventually(func() error {
-				found := &appsv1.Deployment{}
+				found := &appsv1.StatefulSet{}
 				err = k8sClient.Get(ctx, typeNamespaceName, found)
 
 				if err == nil {
 					if len(found.Spec.Template.Spec.Containers) < 1 {
-						return fmt.Errorf("The number of containers used in the deployment is not the one expected")
+						return fmt.Errorf("The number of containers used in the StatefulSet is not the one expected")
 					}
 					if found.Spec.Template.Spec.Containers[0].Image != persesImage {
-						return fmt.Errorf("The image used in the deployment is not the one expected")
+						return fmt.Errorf("The image used in the StatefulSet is not the one expected")
 					}
 					if len(found.Spec.Template.Spec.Containers[0].Ports) < 1 && found.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != 8080 {
-						return fmt.Errorf("The port used in the deployment is not the one defined in the custom resource")
+						return fmt.Errorf("The port used in the StatefulSet is not the one defined in the custom resource")
 					}
 					if len(found.Spec.Template.Spec.Containers[0].Args) < 1 && found.Spec.Template.Spec.Containers[0].Args[0] != "--config=/etc/perses/config/config.yaml" {
-						return fmt.Errorf("The config path used in the deployment is not the one defined in the custom resource")
+						return fmt.Errorf("The config path used in the StatefulSet is not the one defined in the custom resource")
 					}
 				}
 
@@ -148,7 +148,7 @@ var _ = Describe("Perses controller", func() {
 					latestStatusCondition := perses.Status.Conditions[len(perses.Status.Conditions)-1]
 					expectedLatestStatusCondition := metav1.Condition{Type: common.TypeAvailablePerses,
 						Status: metav1.ConditionTrue, Reason: "Reconciling",
-						Message: fmt.Sprintf("Deployment for custom resource (%s) created successfully", perses.Name)}
+						Message: fmt.Sprintf("StatefulSet for custom resource (%s) created successfully", perses.Name)}
 					if latestStatusCondition != expectedLatestStatusCondition {
 						return fmt.Errorf("The latest status condition added to the perses instance is not as expected")
 					}
@@ -164,15 +164,15 @@ var _ = Describe("Perses controller", func() {
 			err = k8sClient.Delete(ctx, persesToDelete)
 			Expect(err).To(Not(HaveOccurred()))
 
-			By("Checking if Deployment was successfully deleted in the reconciliation")
+			By("Checking if StatefulSet was successfully deleted in the reconciliation")
 			Eventually(func() error {
-				found := &appsv1.Deployment{}
+				found := &appsv1.StatefulSet{}
 				return k8sClient.Get(ctx, typeNamespaceName, found)
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("Checking if Service was successfully deleted in the reconciliation")
 			Eventually(func() error {
-				found := &appsv1.Deployment{}
+				found := &appsv1.StatefulSet{}
 				return k8sClient.Get(ctx, typeNamespaceName, found)
 			}, time.Minute, time.Second).Should(Succeed())
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.19.4
 )
 
@@ -133,7 +134,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&persesImage, "perses-default-base-image", "docker.io/persesdev/perses:latest", "The default image used for the Perses deployment operands")
+	flag.StringVar(&persesImage, "perses-default-base-image", "docker.io/persesdev/perses:latest", "The default image used for the Perses statefulset operands")
 	flag.StringVar(&persesServerURL, "perses-server-url", "", "The Perses backend server URL")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	opts := zap.Options{


### PR DESCRIPTION
This PR:

- Uses StatefulSet instead of deployment to hold the Perses backend
- Uses the `perses-dev` namespace for local testing
- Removes the specific runAsNonRoot user, to use the default security config from the cluster

fixes: #49 