### PR TITLE
add Ephemeral volume, fix security defaults and add testing namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,6 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 
-##@ Deployment
-
 ifndef ignore-not-found
   ignore-not-found = false
 endif

--- a/README.md
+++ b/README.md
@@ -16,22 +16,29 @@ You’ll need:
 make install
 ```
 
-2. Install custom resources:
+2. Create a namespace for the resources:
+```sh
+kubectl create namespace perses-dev
+```
+
+3. Install custom resources:
 
 ```sh
 kubectl apply -k config/samples
 ```
 
-3. Using the the location specified by `IMG`, build a testing image and push it to the registry, then deploy the controller to the cluster:
+4. Using the the location specified by `IMG`, build a testing image and push it to the registry, then deploy the controller to the cluster:
 
 ```sh
 IMG=<some-registry>/perses-operator:tag make test-image-build image-push deploy
 ```
 
-4. Port forward the service so you can access the Perses UI at `http://localhost:8080`:
+> **Note:** If you already have an image built, you can deploy it to the cluster using `IMG=<some-registry>/perses-operator:tag make deploy`.
+
+5. Port forward the service so you can access the Perses UI at `http://localhost:8080`:
 
 ```sh
-kubectl port-forward svc/perses-sample 8080:8080
+kubectl -n perses-dev port-forward svc/perses-sample 8080:8080
 ```
 
 ### Uninstall CRDs
@@ -102,7 +109,7 @@ More information can be found via the [Kubebuilder Documentation](https://book.k
 
 ## License
 
-Copyright 2023 The Perses Authors.
+Copyright 2025 The Perses Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,10 +56,6 @@ spec:
       #             operator: In
       #             values:
       #               - linux
-      securityContext:
-        runAsNonRoot: true
-        runAsGroup: 65532
-        runAsUser: 65532
       containers:
       - args:
         - --leader-elect

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     verbs:
       - create
       - delete
@@ -27,7 +28,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - deployments
       - services
       - configmaps
     verbs:

--- a/config/samples/perses.dev_v1alpha1_perses.yaml
+++ b/config/samples/perses.dev_v1alpha1_perses.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-sample
+  namespace: perses-dev
 spec:
   config:
     database:

--- a/config/samples/perses.dev_v1alpha1_persesdashboard.yaml
+++ b/config/samples/perses.dev_v1alpha1_persesdashboard.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-dashboard-sample
+  namespace: perses-dev
 spec:
   display:
     name: Perses Dashboard Sample

--- a/config/samples/perses.dev_v1alpha1_persesdatasource.yaml
+++ b/config/samples/perses.dev_v1alpha1_persesdatasource.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: perses-operator
   name: perses-datasource-sample
+  namespace: perses-dev
 spec:
   display:
     name: "Default Datasource"

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -39,12 +39,12 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 	err := r.Client.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithError(err)
+		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
 	}
 
 	if len(persesInstances.Items) == 0 {
-		dlog.Info("No Perses instances found")
-		return subreconciler.DoNotRequeue()
+		dlog.Info("No Perses instances found, retrying in 1 minute")
+		return subreconciler.RequeueWithDelay(time.Minute)
 	}
 
 	dashboard := &persesv1alpha1.PersesDashboard{}

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -84,8 +84,8 @@ func (r *PersesDashboardReconciler) handleDelete(ctx context.Context, req ctrl.R
 
 	if err := r.Get(ctx, req.NamespacedName, dashboard); err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.WithError(err).Error("Failed to get perses dashboard")
-			return subreconciler.RequeueWithError(err)
+			dlog.Info("No Perses instances found, retrying in 1 minute")
+			return subreconciler.RequeueWithDelay(time.Minute)
 		}
 
 		log.Infof("perses dashboard resource not found. Deleting '%s' in '%s'", req.Name, req.Namespace)

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -39,12 +39,12 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 	err := r.Client.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithError(err)
+		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
 	}
 
 	if len(persesInstances.Items) == 0 {
-		dlog.Info("No Perses instances found")
-		return subreconciler.DoNotRequeue()
+		dlog.Info("No Perses instances found, requeue in 1 minute")
+		return subreconciler.RequeueWithDelay(time.Minute)
 	}
 
 	datasource := &persesv1alpha1.PersesDatasource{}

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -56,10 +56,9 @@ var log = logger.WithField("module", "perses_controller")
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	subreconcilersForPerses := []subreconciler.FnWithRequest{
 		r.setStatusToUnknown,
 		r.addFinalizer,
@@ -67,6 +66,7 @@ func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		r.reconcileService,
 		r.reconcileConfigMap,
 		r.reconcileDeployment,
+		r.reconcileStatefulSet,
 	}
 
 	// Run all subreconcilers sequentially
@@ -241,6 +241,7 @@ func (r *PersesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Perses{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Complete(r)

--- a/controllers/perses/statefulset_controller.go
+++ b/controllers/perses/statefulset_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Perses Authors.
+Copyright 2025 The Perses Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,31 +29,31 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var dlog = logger.WithField("module", "deployment_controller")
+var stlog = logger.WithField("module", "statefulset_controller")
 
-func (r *PersesReconciler) reconcileDeployment(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
+func (r *PersesReconciler) reconcileStatefulSet(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
 	perses := &v1alpha1.Perses{}
 
 	if r, err := r.getLatestPerses(ctx, req, perses); subreconciler.ShouldHaltOrRequeue(r, err) {
 		return r, err
 	}
 
-	if perses.Spec.Config.Database.SQL == nil {
-		stlog.Info("Database SQL configuration is not set, skipping Deployment creation")
+	if perses.Spec.Config.Database.File == nil {
+		stlog.Info("Database file configuration is not set, skipping StatefulSet creation")
 
-		found := &appsv1.Deployment{}
+		found := &appsv1.StatefulSet{}
 		err := r.Get(ctx, types.NamespacedName{Name: perses.Name, Namespace: perses.Namespace}, found)
 		if err == nil {
-			stlog.Info("Deleting Deployment since database configuration changed")
+			stlog.Info("Deleting StatefulSet since database configuration changed")
 			if err := r.Delete(ctx, found); err != nil {
-				stlog.WithError(err).Error("Failed to delete Deployment")
+				stlog.WithError(err).Error("Failed to delete StatefulSet")
 				return subreconciler.RequeueWithError(err)
 			}
 		}
@@ -61,35 +61,35 @@ func (r *PersesReconciler) reconcileDeployment(ctx context.Context, req ctrl.Req
 		return subreconciler.ContinueReconciling()
 	}
 
-	found := &appsv1.Deployment{}
+	found := &appsv1.StatefulSet{}
 	err := r.Get(ctx, types.NamespacedName{Name: perses.Name, Namespace: perses.Namespace}, found)
 	if err != nil && apierrors.IsNotFound(err) {
 
-		dep, err := r.createPersesDeployment(perses)
+		dep, err := r.createPersesStatefulSet(perses)
 		if err != nil {
-			dlog.WithError(err).Error("Failed to define new Deployment resource for perses")
+			stlog.WithError(err).Error("Failed to define new StatefulSet resource for perses")
 
 			meta.SetStatusCondition(&perses.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses,
 				Status: metav1.ConditionFalse, Reason: "Reconciling",
-				Message: fmt.Sprintf("Failed to create Deployment for the custom resource (%s): (%s)", perses.Name, err)})
+				Message: fmt.Sprintf("Failed to create StatefulSet for the custom resource (%s): (%s)", perses.Name, err)})
 
 			if err := r.Status().Update(ctx, perses); err != nil {
-				dlog.Error(err, "Failed to update perses status")
+				stlog.Error(err, "Failed to update perses status")
 				return subreconciler.RequeueWithError(err)
 			}
 
 			return subreconciler.RequeueWithError(err)
 		}
 
-		dlog.Infof("Creating a new Deployment: Deployment.Namespace %s Deployment.Name %s", dep.Namespace, dep.Name)
+		stlog.Infof("Creating a new StatefulSet: StatefulSet.Namespace %s StatefulSet.Name %s", dep.Namespace, dep.Name)
 		if err = r.Create(ctx, dep); err != nil {
-			dlog.WithError(err).Errorf("Failed to create new Deployment: Deployment.Namespace %s Deployment.Name %s", dep.Namespace, dep.Name)
+			stlog.WithError(err).Errorf("Failed to create new StatefulSet: StatefulSet.Namespace %s StatefulSet.Name %s", dep.Namespace, dep.Name)
 			return subreconciler.RequeueWithError(err)
 		}
 
 		return subreconciler.RequeueWithDelay(time.Minute)
 	} else if err != nil {
-		dlog.WithError(err).Error("Failed to get Deployment")
+		stlog.WithError(err).Error("Failed to get StatefulSet")
 
 		return subreconciler.RequeueWithError(err)
 	}
@@ -97,8 +97,8 @@ func (r *PersesReconciler) reconcileDeployment(ctx context.Context, req ctrl.Req
 	return subreconciler.ContinueReconciling()
 }
 
-func (r *PersesReconciler) createPersesDeployment(
-	perses *v1alpha1.Perses) (*appsv1.Deployment, error) {
+func (r *PersesReconciler) createPersesStatefulSet(
+	perses *v1alpha1.Perses) (*appsv1.StatefulSet, error) {
 	configName := common.GetConfigName(perses.Name)
 
 	ls, err := common.LabelsForPerses(r.Config.PersesImage, perses.Name, perses.Name)
@@ -112,13 +112,15 @@ func (r *PersesReconciler) createPersesDeployment(
 		return nil, err
 	}
 
-	dep := &appsv1.Deployment{
+	storageName := common.GetStorageName(perses.Name)
+
+	dep := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      perses.Name,
 			Namespace: perses.Namespace,
 			Labels:    ls,
 		},
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,
 			},
@@ -189,7 +191,7 @@ func (r *PersesReconciler) createPersesDeployment(
 								MountPath: "/perses/config",
 							},
 							{
-								Name:      "storage",
+								Name:      storageName,
 								ReadOnly:  false,
 								MountPath: "/etc/perses/storage",
 							},
@@ -208,12 +210,6 @@ func (r *PersesReconciler) createPersesDeployment(
 								},
 							},
 						},
-						{
-							Name: "storage",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
 						// {
 						// 	Name: "serving-cert",
 						// 	VolumeSource: corev1.VolumeSource{
@@ -228,23 +224,27 @@ func (r *PersesReconciler) createPersesDeployment(
 					DNSPolicy:     "ClusterFirst",
 				},
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				Type: "RollingUpdate",
-				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Type(1),
-						StrVal: "25%",
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: storageName,
 					},
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Type(1),
-						StrVal: "25%",
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
 					},
 				},
 			},
 		},
 	}
 
-	// Set the ownerRef for the Deployment
+	// Set the ownerRef for the StatefulSet
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
 	if err := ctrl.SetControllerReference(perses, dep, r.Scheme); err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/client-go v0.32.0
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.19.4
 )
 
@@ -133,7 +134,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/internal/perses/common/labels.go
+++ b/internal/perses/common/labels.go
@@ -70,3 +70,7 @@ func ImageForPerses(persesImageFromFlags string) (string, error) {
 func GetConfigName(instanceName string) string {
 	return fmt.Sprintf("%s-config", instanceName)
 }
+
+func GetStorageName(instanceName string) string {
+	return fmt.Sprintf("%s-storage", instanceName)
+}

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&persesImage, "perses-default-base-image", "docker.io/persesdev/perses:latest", "The default image used for the Perses deployment operands")
+	flag.StringVar(&persesImage, "perses-default-base-image", "docker.io/persesdev/perses:latest", "The default image used for the Perses Deployment or StatefulSet operands")
 	flag.StringVar(&persesServerURL, "perses-server-url", "", "The Perses backend server URL")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	opts := zap.Options{


### PR DESCRIPTION
This PR:

- Based on `config.database` add StatefulSet with PVC for `config.database.file` and a Deployment for `config.database.sql`
- Uses the perses-dev namespace for local testing
- Removes the specific runAsNonRoot user, to use the default security config from the cluster
- fixes: #49