### PR TITLE
fix: fallback to docker when podman is not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,25 @@ export DATE
 .PHONY: check-container-runtime
 check-container-runtime:
 	@if podman ps >/dev/null 2>&1; then \
-		echo "Using podman as container runtime"; \
-		echo podman > .container_runtime; \
+		echo ""; \
+		echo "============================================"; \
+		echo " ✅ Using Podman the container runtime"; \
+		echo "============================================"; \
+		CONTAINER_RUNTIME=podman; \
 	elif docker ps >/dev/null 2>&1; then \
-		echo "Using docker as container runtime"; \
-		echo docker > .container_runtime; \
+		echo ""; \
+		echo "============================================"; \
+		echo " ✅ Using Docker the container runtime"; \
+		echo "============================================"; \
+		CONTAINER_RUNTIME=docker; \
 	else \
-		echo "Error: Neither podman nor docker daemon is running" >&2; \
+		echo ""; \
+		echo "============================================"; \
+		echo " ❌ Neither Podman nor Docker daemon is running"; \
+		echo "============================================"; \
 		exit 1; \
 	fi
+
 
 CONTAINER_RUNTIME := $(shell cat .container_runtime 2>/dev/null || echo docker)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DATE := $(shell date +%Y-%m-%d)
 export DATE
 
 # CONTAINER_RUNTIME defines the container runtime to use for building the bundle image.
-CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
+CONTAINER_RUNTIME := $(shell if podman ps >/dev/null 2>&1; then echo podman; else echo docker; fi)
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")


### PR DESCRIPTION
This PR improves the container runtime selection process by adding pre-build validation and clearer user feedback.

Changes:
- Add a new check-container-runtime target for runtime validation
- Check podman first, fallback to docker if podman isn't running
- Add clear user feedback about which runtime is being used
- Fail gracefully with descriptive error if no runtime is available

cc: @jgbernalp 