### PR TITLE
Add `make bin` command for Konflux CI pipeline to build binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,3 +334,7 @@ cross-build: generate-goreleaser manifests generate fmt vet ## Cross build binar
 .PHONY: cross-release
 cross-release: generate-goreleaser manifests generate fmt vet
 	goreleaser release --clean
+
+.PHONY: bin
+bin: 
+	go build -mod=readonly -o bin/manager main.go


### PR DESCRIPTION
Add the `make bin` command for the Konflux CI pipeline to build binaries. Konflux is a CI/CD service used by Red Hat. 

The Konflux pipeline will be configured to point to release branches like `release-v0.1` instead of `main` branch. 