### PR TITLE
FEATURE: Add shortNames to Perses CRDs

### DIFF
--- a/api/v1alpha1/perses_types.go
+++ b/api/v1alpha1/perses_types.go
@@ -134,7 +134,7 @@ type PersesStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=pr
+//+kubebuilder:resource:shortName=per
 
 // Perses is the Schema for the perses API
 type Perses struct {

--- a/api/v1alpha1/persesdashboard_types.go
+++ b/api/v1alpha1/persesdashboard_types.go
@@ -28,7 +28,7 @@ type PersesDashboardStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=prdb
+//+kubebuilder:resource:shortName=perdb
 
 // PersesDashboard is the Schema for the persesdashboards API
 type PersesDashboard struct {

--- a/api/v1alpha1/persesdatasource_types.go
+++ b/api/v1alpha1/persesdatasource_types.go
@@ -36,7 +36,7 @@ type DatasourceSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=prds
+// +kubebuilder:resource:shortName=perds
 
 // PersesDatasource is the Schema for the PersesDatasources API
 type PersesDatasource struct {

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: PersesList
     plural: perses
     shortNames:
-    - pr
+    - per
     singular: perses
   scope: Namespaced
   versions:

--- a/config/crd/bases/perses.dev_persesdashboards.yaml
+++ b/config/crd/bases/perses.dev_persesdashboards.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: PersesDashboardList
     plural: persesdashboards
     shortNames:
-    - prdb
+    - perdb
     singular: persesdashboard
   scope: Namespaced
   versions:

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: PersesDatasourceList
     plural: persesdatasources
     shortNames:
-    - prds
+    - perds
     singular: persesdatasource
   scope: Namespaced
   versions:


### PR DESCRIPTION
This PR adds `shortName` annotations to the following CustomResourceDefinitions (CRDs) to simplify CLI interactions using `kubectl`:

| Kind                     | Short Name |
|--------------------------|------------|
| `Perses`                 | `per`       |
| `PersesDatasource`       | `perds`     |
| `PersesDashboard`        | `perdb`     |

#### ✨ Motivation

Currently, interacting with Perses CRs via `kubectl` requires typing the full resource name (e.g., `kubectl get perses`). With these short names:

- `kubectl get per` → `Perses`
- `kubectl get perds` → `PersesDatasource`
- `kubectl get perdb` → `PersesDashboard`
