### PR TITLE
fix: Use secret and configmap data in client tls configuration when provided

### DIFF
--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -21,14 +21,15 @@ import (
 	"errors"
 	"time"
 
-	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	"github.com/perses/perses-operator/internal/subreconciler"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
 	logger "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
+	"github.com/perses/perses-operator/internal/subreconciler"
 )
 
 var dlog = logger.WithField("module", "dashboard_controller")
@@ -63,7 +64,7 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 }
 
 func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, perses persesv1alpha1.Perses, dashboard *persesv1alpha1.PersesDashboard) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
@@ -163,7 +164,7 @@ func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Co
 }
 
 func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses persesv1alpha1.Perses, dashboardNamespace string, dashboardName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")

--- a/internal/perses/common/tls_cert.go
+++ b/internal/perses/common/tls_cert.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/perses/perses-operator/api/v1alpha1"
+)
+
+// GetTLSCertData get tls certs from a Certificate resoruce
+func GetTLSCertData(ctx context.Context, client client.Client, namespace string, name string, cert *v1alpha1.Certificate) (string, string, error) {
+	var certData string
+	var keyData string
+
+	if cert.Type == v1alpha1.CertificateTypeConfigMap || cert.Type == v1alpha1.CertificateTypeSecret {
+		if len(cert.Name) == 0 {
+			return "", "", fmt.Errorf("No name found for tls certificate: %s with type: %s", cert.CertPath, cert.Type)
+		}
+
+		switch cert.Type {
+		case v1alpha1.CertificateTypeSecret:
+			secret := &corev1.Secret{}
+
+			err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cert.Name}, secret)
+
+			if err != nil {
+				return "", "", err
+			}
+
+			certData = string(secret.Data[cert.CertPath])
+			keyData = string(secret.Data[cert.PrivateKeyPath])
+		case v1alpha1.CertificateTypeConfigMap:
+			cm := &corev1.ConfigMap{}
+			err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cert.Name}, cm)
+
+			if err != nil {
+				return "", "", err
+			}
+
+			certData = cm.Data[cert.CertPath]
+			keyData = cm.Data[cert.PrivateKeyPath]
+		}
+
+		if certData == "" {
+			return "", "", fmt.Errorf("No data found for certificate: %s in namespace: %s for %s", cert.CertPath, namespace, name)
+		}
+
+		return certData, keyData, nil
+	}
+
+	return "", "", nil
+}


### PR DESCRIPTION
Use secret and configmap data in client tls configuration when provided)

Closes #125