### PR TITLE
feat: start pprof endpoint on localhost

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		PprofBindAddress: "127.0.0.1:8083",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
It can be handy to get profiling data about the operator containers. controller-runtime can expose the go runtime pprof endpoints and this commit adds this on localhost port 8083.