### PR TITLE
Don't add version labels in Service selector

### DIFF
--- a/controllers/perses/service_controller.go
+++ b/controllers/perses/service_controller.go
@@ -140,7 +140,15 @@ func (r *PersesReconciler) createPersesService(
 				Protocol:   corev1.ProtocolTCP,
 				TargetPort: intstr.FromInt32(8080),
 			}},
-			Selector: ls,
+			Selector: func() map[string]string {
+				selector := make(map[string]string)
+				for k, v := range ls {
+					if k != "app.kubernetes.io/version" {
+						selector[k] = v
+					}
+				}
+				return selector
+			}(),
 		},
 	}
 


### PR DESCRIPTION
Having app.kubernetes.io/version label in the service selector, might lead to issues where pod gets orphaned from service when versions mismatch (reconcile hasn't caught up service/statefulset)