### PR TITLE
[BUGFIX] fix ConfigMap change check for reconciliation

### DIFF
--- a/controllers/perses/configmap_controller.go
+++ b/controllers/perses/configmap_controller.go
@@ -91,7 +91,7 @@ func (r *PersesReconciler) reconcileConfigMap(ctx context.Context, req ctrl.Requ
 		return subreconciler.RequeueWithError(err)
 	}
 
-	if !equality.Semantic.DeepEqual(found, cm) {
+	if needsUpdate(found, cm, configName, perses) {
 		if err := r.Update(ctx, cm); err != nil {
 			cmlog.Error(err, "Failed to update ConfigMap")
 			return subreconciler.RequeueWithError(err)
@@ -101,13 +101,37 @@ func (r *PersesReconciler) reconcileConfigMap(ctx context.Context, req ctrl.Requ
 	return subreconciler.ContinueReconciling()
 }
 
+func needsUpdate(existing, updated *corev1.ConfigMap, name string, perses *v1alpha2.Perses) bool {
+	if existing == nil && updated == nil {
+		return false
+	}
+	if existing == nil || updated == nil {
+		return true
+	}
+	if existing.Name != updated.Name || existing.Namespace != updated.Namespace {
+		return true
+	}
+	if !equality.Semantic.DeepEqual(existing.Data, updated.Data) {
+		return true
+	}
+	if !equality.Semantic.DeepEqual(existing.Annotations, updated.Annotations) {
+		return true
+	}
+
+	// check for differences only in the labels that are set by the operator
+	labels := common.LabelsForPerses(name, perses)
+	for k := range labels {
+		if existing.Labels[k] != updated.Labels[k] {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (r *PersesReconciler) createPersesConfigMap(perses *v1alpha2.Perses) (*corev1.ConfigMap, error) {
 	configName := common.GetConfigName(perses.Name)
-	ls, err := common.LabelsForPerses(configName, perses)
-
-	if err != nil {
-		return nil, err
-	}
+	ls := common.LabelsForPerses(configName, perses)
 
 	annotations := map[string]string{}
 	if perses.Spec.Metadata != nil && perses.Spec.Metadata.Annotations != nil {

--- a/controllers/perses/deployment_controller.go
+++ b/controllers/perses/deployment_controller.go
@@ -119,10 +119,7 @@ func (r *PersesReconciler) reconcileDeployment(ctx context.Context, req ctrl.Req
 func (r *PersesReconciler) createPersesDeployment(
 	perses *v1alpha2.Perses) (*appsv1.Deployment, error) {
 
-	ls, err := common.LabelsForPerses(perses.Name, perses)
-	if err != nil {
-		return nil, err
-	}
+	ls := common.LabelsForPerses(perses.Name, perses)
 
 	annotations := map[string]string{}
 	if perses.Spec.Metadata != nil && perses.Spec.Metadata.Annotations != nil {

--- a/controllers/perses/service_controller.go
+++ b/controllers/perses/service_controller.go
@@ -103,11 +103,7 @@ func (r *PersesReconciler) reconcileService(ctx context.Context, req ctrl.Reques
 
 func (r *PersesReconciler) createPersesService(
 	perses *v1alpha2.Perses) (*corev1.Service, error) {
-	ls, err := common.LabelsForPerses(perses.Name, perses)
-
-	if err != nil {
-		return nil, err
-	}
+	ls := common.LabelsForPerses(perses.Name, perses)
 
 	annotations := map[string]string{}
 	if perses.Spec.Metadata != nil && perses.Spec.Metadata.Annotations != nil {

--- a/controllers/perses/statefulset_controller.go
+++ b/controllers/perses/statefulset_controller.go
@@ -120,10 +120,7 @@ func (r *PersesReconciler) reconcileStatefulSet(ctx context.Context, req ctrl.Re
 func (r *PersesReconciler) createPersesStatefulSet(
 	perses *v1alpha2.Perses) (*appsv1.StatefulSet, error) {
 
-	ls, err := common.LabelsForPerses(perses.Name, perses)
-	if err != nil {
-		return nil, err
-	}
+	ls := common.LabelsForPerses(perses.Name, perses)
 
 	annotations := map[string]string{}
 	if perses.Spec.Metadata != nil && perses.Spec.Metadata.Annotations != nil {

--- a/internal/perses/common/labels.go
+++ b/internal/perses/common/labels.go
@@ -51,7 +51,7 @@ func sanitizeLabel(label string) string {
 	return sanitized
 }
 
-func LabelsForPerses(name string, perses *v1alpha2.Perses) (map[string]string, error) {
+func LabelsForPerses(name string, perses *v1alpha2.Perses) map[string]string {
 	instanceName := perses.Name
 
 	persesLabels := map[string]string{
@@ -71,7 +71,7 @@ func LabelsForPerses(name string, perses *v1alpha2.Perses) (map[string]string, e
 		}
 	}
 
-	return persesLabels, nil
+	return persesLabels
 
 }
 

--- a/internal/perses/common/labels_test.go
+++ b/internal/perses/common/labels_test.go
@@ -37,8 +37,7 @@ func TestLabels(t *testing.T) {
 var _ = Describe("LabelsForPerses", func() {
 	DescribeTable("when creating labels for Perses components",
 		func(persesImageFromFlag string, componentName string, perses *v1alpha2.Perses, verifyFunc func(labels map[string]string)) {
-			labels, err := LabelsForPerses(componentName, perses)
-			Expect(err).NotTo(HaveOccurred())
+			labels := LabelsForPerses(componentName, perses)
 			verifyFunc(labels)
 		},
 		Entry("Long name is trimmed to 63 characters",


### PR DESCRIPTION
Checking all the labels caused an infinite reconciliation loop. This fix checks only for the fields that are required for reconciliation