### PR TITLE
[BUGFIX] Add Perses test for storage size and fix reconciliation errors

### DIFF
--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -40,7 +40,7 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 	err := r.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	if len(persesInstances.Items) == 0 {
@@ -68,7 +68,7 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	_, err = persesClient.Project().Get(dashboard.Namespace)
@@ -117,7 +117,7 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create dashboard: %s", dashboard.Name)
-				return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+				return subreconciler.RequeueWithError(err)
 			}
 
 			dlog.Infof("Dashboard created: %s", dashboard.Name)
@@ -131,7 +131,7 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
-			return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+			return subreconciler.RequeueWithError(err)
 		}
 
 		dlog.Infof("Dashboard updated: %s", dashboard.Name)
@@ -168,7 +168,7 @@ func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses 
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	_, err = persesClient.Project().Get(dashboardNamespace)

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -73,7 +73,7 @@ func (r *PersesDashboardReconciler) getLatestPersesDashboard(ctx context.Context
 			return subreconciler.DoNotRequeue()
 		}
 		log.WithError(err).Error("Failed to get perses dashboard")
-		return subreconciler.RequeueWithDelayAndError(time.Second, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	return subreconciler.ContinueReconciling()
@@ -107,7 +107,7 @@ func (r *PersesDashboardReconciler) setStatusToUnknown(ctx context.Context, req 
 		meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err := r.Status().Update(ctx, dashboard); err != nil {
 			log.WithError(err).Error("Failed to update Perses dashboard status")
-			return subreconciler.RequeueWithDelayAndError(time.Second*10, err)
+			return subreconciler.RequeueWithError(err)
 		}
 	}
 

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -23,9 +23,6 @@ import (
 	"os"
 	"time"
 
-	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
-	persescommon "github.com/perses/perses-operator/internal/perses/common"
-	"github.com/perses/perses-operator/internal/subreconciler"
 	v1 "github.com/perses/perses/pkg/client/api/v1"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
@@ -34,6 +31,10 @@ import (
 	logger "github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
+	persescommon "github.com/perses/perses-operator/internal/perses/common"
+	"github.com/perses/perses-operator/internal/subreconciler"
 )
 
 const secretNameSuffix = "-secret"
@@ -46,7 +47,7 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 	err := r.List(ctx, persesInstances, opts...)
 	if err != nil {
 		dlog.WithError(err).Error("Failed to get perses instances")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	if len(persesInstances.Items) == 0 {
@@ -74,7 +75,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	_, err = persesClient.Project().Get(datasource.Namespace)
@@ -111,7 +112,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to create datasource secret: %s", datasource.Name)
-			return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+			return subreconciler.RequeueWithError(err)
 		}
 	}
 
@@ -133,7 +134,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create datasource: %s", datasource.Name)
-				return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+				return subreconciler.RequeueWithError(err)
 			}
 
 			dlog.Infof("Datasource created: %s", datasource.Name)
@@ -147,7 +148,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
-			return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+			return subreconciler.RequeueWithError(err)
 		}
 
 		dlog.Infof("Datasource updated: %s", datasource.Name)
@@ -303,7 +304,7 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create secret: %s", secretName)
-				return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+				return subreconciler.RequeueWithError(err)
 			}
 
 			dlog.Infof("Secret created: %s", secretName)
@@ -317,7 +318,7 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to update secret: %s", secretName)
-			return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+			return subreconciler.RequeueWithError(err)
 		}
 
 		dlog.Infof("Secret updated: %s", secretName)
@@ -354,7 +355,7 @@ func (r *PersesDatasourceReconciler) deleteDatasource(ctx context.Context, perse
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
-		return subreconciler.RequeueWithDelayAndError(time.Minute, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	_, err = persesClient.Project().Get(datasourceNamespace)

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -19,11 +19,11 @@ package datasources
 import (
 	"context"
 	"fmt"
-	"time"
 
 	logger "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,7 +32,6 @@ import (
 	persesv1alpha1 "github.com/perses/perses-operator/api/v1alpha1"
 	"github.com/perses/perses-operator/internal/perses/common"
 	"github.com/perses/perses-operator/internal/subreconciler"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PersesDatasourceReconciler reconciles a PersesDatasource object
@@ -74,7 +73,7 @@ func (r *PersesDatasourceReconciler) getLatestPersesDatasource(ctx context.Conte
 			return subreconciler.DoNotRequeue()
 		}
 		log.WithError(err).Error("Failed to get perses datasource")
-		return subreconciler.RequeueWithDelayAndError(time.Second, err)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	return subreconciler.ContinueReconciling()
@@ -108,7 +107,7 @@ func (r *PersesDatasourceReconciler) setStatusToUnknown(ctx context.Context, req
 		meta.SetStatusCondition(&datasource.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		if err := r.Status().Update(ctx, datasource); err != nil {
 			log.WithError(err).Error("Failed to update Perses datasource status")
-			return subreconciler.RequeueWithDelayAndError(time.Second*10, err)
+			return subreconciler.RequeueWithError(err)
 		}
 	}
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -23,6 +23,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -46,6 +48,8 @@ var k8sClient client.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
+
+const persesNamespace = "perses-test"
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -96,6 +100,15 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
+	By("Creating Perses test namespace")
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      persesNamespace,
+			Namespace: persesNamespace,
+		},
+	}
+	err = k8sClient.Create(ctx, namespace)
+	Expect(err).To(Not(HaveOccurred()))
 })
 
 var _ = AfterSuite(func() {

--- a/internal/subreconciler/subreconciler.go
+++ b/internal/subreconciler/subreconciler.go
@@ -43,7 +43,7 @@ func DoNotRequeue() (*reconcile.Result, error) { return &ctrl.Result{Requeue: fa
 
 // RequeueWithError returns a controller result pairing specifying to
 // requeue with an error message.
-func RequeueWithError(e error) (*reconcile.Result, error) { return &ctrl.Result{Requeue: true}, e }
+func RequeueWithError(e error) (*reconcile.Result, error) { return &ctrl.Result{}, e }
 
 // Requeue returns a controller result pairing specifying to
 // requeue with no error message implied. This returns no error.
@@ -52,13 +52,7 @@ func Requeue() (*reconcile.Result, error) { return &ctrl.Result{Requeue: true}, 
 // RequeueWithDelay returns a controller result pairing specifying to
 // requeue after a delay. This returns no error.
 func RequeueWithDelay(dur time.Duration) (*reconcile.Result, error) {
-	return &ctrl.Result{Requeue: true, RequeueAfter: dur}, nil
-}
-
-// RequeueWithDelayAndError returns a controller result pairing specifying to
-// requeue after a delay with an error message.
-func RequeueWithDelayAndError(dur time.Duration, e error) (*reconcile.Result, error) {
-	return &ctrl.Result{Requeue: true, RequeueAfter: dur}, e
+	return &ctrl.Result{RequeueAfter: dur}, nil
 }
 
 // ShouldRequeue returns true if the reconciler result indicates


### PR DESCRIPTION
Closes #156

Adds another Perses test to create an instance with a specific storage size

Replaces `RequeueWithDelayAndError` with `RequeueWithError` because if you return an error, the ctrl.Result is never used.