### PR TITLE
[ENHANCEMENT] Enable Ginkgo verbose mode in the test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"  go test $(shell go list ./...) -v -ginkgo.v -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)"  go test $(shell go list ./...) -v -coverprofile cover.out
 
 .PHONY: lint-jsonnet
 lint-jsonnet: $(JSONNETLINT_BINARY)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,7 +54,11 @@ const persesNamespace = "perses-test"
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Controller Suite")
+	suiteCfg, reporterCfg := GinkgoConfiguration()
+	// turns on verbosity for Ginkgo
+	reporterCfg.Verbose = true
+
+	RunSpecs(t, "Controller Suite", suiteCfg, reporterCfg)
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
This allows non-ginkgo tests to run without the ginkgo flag added