### PR TITLE
feat: add kubebuilder validation markers for required API fields

### DIFF
--- a/api/v1alpha1/perses_types.go
+++ b/api/v1alpha1/perses_types.go
@@ -117,8 +117,12 @@ type KubernetesAuth struct {
 
 type BasicAuth struct {
 	SecretSource `json:",inline"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Username for basic auth
 	Username string `json:"username"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Path to password
 	PasswordPath string `json:"password_path"`
 }
@@ -127,10 +131,12 @@ type OAuth struct {
 	SecretSource `json:",inline"`
 	// Path to client id
 	// +optional
-	ClientIDPath string `json:"clientIDPath"`
+	ClientIDPath string `json:"clientIDPath,omitempty"`
 	// Path to client secret
 	// +optional
-	ClientSecretPath string `json:"clientSecretPath"`
+	ClientSecretPath string `json:"clientSecretPath,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// TokenURL is the resource server's token endpoint
 	// URL. This is a constant specific to each server.
 	TokenURL string `json:"tokenURL"`
@@ -172,19 +178,22 @@ const (
 
 // SecretSource configuration for a perses secret source
 type SecretSource struct {
-	// +kubebuilder:validation:Enum:={"secret", "configmap", "file"}
+	// +kubebuilder:validation:Enum=secret;configmap;file
+	// +kubebuilder:validation:Required
 	// Type source type of secret
 	Type SecretSourceType `json:"type"`
 	// Name of basic auth k8s resource (when type is secret or configmap)
 	// +optional
 	Name string `json:"name,omitempty"`
-	// Namsespace of certificate k8s resource (when type is secret or configmap)
+	// Namespace of certificate k8s resource (when type is secret or configmap)
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
 
 type Certificate struct {
 	SecretSource `json:",inline"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Path to Certificate
 	CertPath string `json:"certPath"`
 	// Path to Private key certificate

--- a/api/v1alpha1/persesdatasource_types.go
+++ b/api/v1alpha1/persesdatasource_types.go
@@ -28,7 +28,8 @@ type PersesDatasourceStatus struct {
 
 type DatasourceSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	Config Datasource `json:"config,omitempty"`
+	// +kubebuilder:validation:Required
+	Config Datasource `json:"config"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	Client *Client `json:"client,omitempty"`

--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -123,8 +123,12 @@ type KubernetesAuth struct {
 
 type BasicAuth struct {
 	SecretSource `json:",inline"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Username for basic auth
 	Username string `json:"username"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Path to password
 	PasswordPath string `json:"password_path"`
 }
@@ -133,10 +137,12 @@ type OAuth struct {
 	SecretSource `json:",inline"`
 	// Path to client id
 	// +optional
-	ClientIDPath string `json:"clientIDPath"`
+	ClientIDPath string `json:"clientIDPath,omitempty"`
 	// Path to client secret
 	// +optional
-	ClientSecretPath string `json:"clientSecretPath"`
+	ClientSecretPath string `json:"clientSecretPath,omitempty"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// TokenURL is the resource server's token endpoint
 	// URL. This is a constant specific to each server.
 	TokenURL string `json:"tokenURL"`
@@ -178,19 +184,22 @@ const (
 
 // SecretSource configuration for a perses secret source
 type SecretSource struct {
-	// +kubebuilder:validation:Enum:={"secret", "configmap", "file"}
+	// +kubebuilder:validation:Enum=secret;configmap;file
+	// +kubebuilder:validation:Required
 	// Type source type of secret
 	Type SecretSourceType `json:"type"`
 	// Name of basic auth k8s resource (when type is secret or configmap)
 	// +optional
 	Name string `json:"name,omitempty"`
-	// Namsespace of certificate k8s resource (when type is secret or configmap)
+	// Namespace of certificate k8s resource (when type is secret or configmap)
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
 
 type Certificate struct {
 	SecretSource `json:",inline"`
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// Path to Certificate
 	CertPath string `json:"certPath"`
 	// Path to Private key certificate

--- a/api/v1alpha2/persesdashboard_types.go
+++ b/api/v1alpha2/persesdashboard_types.go
@@ -28,6 +28,7 @@ type PersesDashboardStatus struct {
 
 type PersesDashboardSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Required
 	Config Dashboard `json:"config"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/api/v1alpha2/persesdatasource_types.go
+++ b/api/v1alpha2/persesdatasource_types.go
@@ -28,6 +28,7 @@ type PersesDatasourceStatus struct {
 
 type DatasourceSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Required
 	Config Datasource `json:"config"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -971,11 +971,12 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -986,6 +987,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -1029,8 +1031,8 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -1041,6 +1043,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -1061,13 +1064,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -1095,13 +1099,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -2583,14 +2588,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -2617,14 +2623,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -3700,11 +3707,12 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -3715,6 +3723,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -3758,8 +3767,8 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -3770,6 +3779,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -3790,13 +3800,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -3824,13 +3835,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -5546,14 +5558,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -5580,14 +5593,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -52,11 +52,12 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -67,6 +68,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -110,8 +112,8 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -122,6 +124,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -142,13 +145,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -176,13 +180,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -231,6 +236,8 @@ spec:
                 - default
                 - plugin
                 type: object
+            required:
+            - config
             type: object
           status:
             description: PersesDatasourceStatus defines the observed state of PersesDatasource
@@ -331,11 +338,12 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -346,6 +354,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -389,8 +398,8 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -401,6 +410,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -421,13 +431,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -455,13 +466,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:

--- a/config/crd/bases/perses.dev_persesglobaldatasources.yaml
+++ b/config/crd/bases/perses.dev_persesglobaldatasources.yaml
@@ -51,11 +51,12 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -66,6 +67,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -109,8 +111,8 @@ spec:
                           secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when
-                          type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -121,6 +123,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -141,13 +144,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:
@@ -175,13 +179,14 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type
                               is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when
+                            description: Namespace of certificate k8s resource (when
                               type is secret or configmap)
                             type: string
                           privateKeyPath:

--- a/controllers/api_validation_test.go
+++ b/controllers/api_validation_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2026 The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	persesv1 "github.com/perses/perses/pkg/model/api/v1"
+	persescommon "github.com/perses/perses/pkg/model/api/v1/common"
+	persesdashboard "github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+)
+
+var _ = Describe("API Validation", func() {
+	Context("BasicAuth validation", func() {
+		ctx := context.Background()
+
+		It("should reject BasicAuth with empty username", func() {
+			By("Creating a Perses resource with empty BasicAuth username")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-basicauth-no-user",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						BasicAuth: &persesv1alpha2.BasicAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: persesv1alpha2.SecretSourceTypeSecret,
+								Name: "my-secret",
+							},
+							Username:     "", // Invalid: required
+							PasswordPath: "/path/to/password",
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to fail with validation error")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should reject BasicAuth with empty password_path", func() {
+			By("Creating a Perses resource with empty BasicAuth password_path")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-basicauth-no-password",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						BasicAuth: &persesv1alpha2.BasicAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: persesv1alpha2.SecretSourceTypeSecret,
+								Name: "my-secret",
+							},
+							Username:     "admin",
+							PasswordPath: "", // Invalid: required
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to fail with validation error")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should accept BasicAuth with valid configuration", func() {
+			By("Creating a Perses resource with valid BasicAuth configuration")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-basicauth",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						BasicAuth: &persesv1alpha2.BasicAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: persesv1alpha2.SecretSourceTypeSecret,
+								Name: "my-secret",
+							},
+							Username:     "admin",
+							PasswordPath: "password",
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to succeed")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Cleaning up the created resource")
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, perses)
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("OAuth validation", func() {
+		ctx := context.Background()
+
+		It("should reject OAuth with empty tokenURL", func() {
+			By("Creating a Perses resource with empty OAuth tokenURL")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-oauth-no-url",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						OAuth: &persesv1alpha2.OAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: persesv1alpha2.SecretSourceTypeSecret,
+								Name: "oauth-secret",
+							},
+							TokenURL: "", // Invalid: required
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to fail with validation error")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should accept OAuth with valid tokenURL", func() {
+			By("Creating a Perses resource with valid OAuth tokenURL")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-oauth",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						OAuth: &persesv1alpha2.OAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: persesv1alpha2.SecretSourceTypeSecret,
+								Name: "oauth-secret",
+							},
+							TokenURL: "https://auth.example.com/token",
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to succeed")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Cleaning up the created resource")
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, perses)
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("TLS Certificate validation", func() {
+		ctx := context.Background()
+
+		It("should reject Certificate with empty certPath", func() {
+			By("Creating a Perses resource with empty Certificate certPath")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-cert-no-path",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						TLS: &persesv1alpha2.TLS{
+							Enable: true,
+							CaCert: &persesv1alpha2.Certificate{
+								SecretSource: persesv1alpha2.SecretSource{
+									Type: persesv1alpha2.SecretSourceTypeSecret,
+									Name: "tls-secret",
+								},
+								CertPath: "", // Invalid: required
+							},
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to fail with validation error")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsInvalid(err)).To(BeTrue())
+		})
+
+		It("should accept Certificate with valid certPath", func() {
+			By("Creating a Perses resource with valid Certificate certPath")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-cert",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						TLS: &persesv1alpha2.TLS{
+							Enable: true,
+							CaCert: &persesv1alpha2.Certificate{
+								SecretSource: persesv1alpha2.SecretSource{
+									Type: persesv1alpha2.SecretSourceTypeSecret,
+									Name: "tls-secret",
+								},
+								CertPath: "ca.crt",
+							},
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to succeed")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Cleaning up the created resource")
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, perses)
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("SecretSource validation", func() {
+		ctx := context.Background()
+
+		It("should reject SecretSource with invalid type", func() {
+			By("Creating a Perses resource with invalid SecretSource type")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-secretsource-type",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: 8080,
+					Client: &persesv1alpha2.Client{
+						BasicAuth: &persesv1alpha2.BasicAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type: "invalid-type", // Invalid: must be secret, configmap, or file
+								Name: "my-secret",
+							},
+							Username:     "admin",
+							PasswordPath: "password",
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to fail with validation error")
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsInvalid(err)).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("PersesDashboard API Validation", func() {
+	Context("PersesDashboard config validation", func() {
+		ctx := context.Background()
+
+		It("should accept PersesDashboard with valid config", func() {
+			By("Creating a PersesDashboard resource with valid config")
+			dashboard := &persesv1alpha2.PersesDashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-dashboard",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesDashboardSpec{
+					Config: persesv1alpha2.Dashboard{
+						DashboardSpec: persesv1.DashboardSpec{
+							Display: &persescommon.Display{
+								Name: "valid-dashboard",
+							},
+							Layouts: []persesdashboard.Layout{},
+							Panels:  map[string]*persesv1.Panel{},
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to succeed")
+			err := k8sClient.Create(ctx, dashboard)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Cleaning up the created resource")
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, dashboard)
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("PersesDatasource API Validation", func() {
+	Context("PersesDatasource config validation", func() {
+		ctx := context.Background()
+
+		It("should accept PersesDatasource with valid config", func() {
+			By("Creating a PersesDatasource resource with valid config")
+			datasource := &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-datasource",
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.DatasourceSpec{
+					Config: persesv1alpha2.Datasource{
+						DatasourceSpec: persesv1.DatasourceSpec{
+							Display: &persescommon.Display{
+								Name: "valid-datasource",
+							},
+							Plugin: persescommon.Plugin{
+								Kind: "PrometheusDatasource",
+								Spec: map[string]interface{}{},
+							},
+						},
+					},
+				},
+			}
+
+			By("Expecting the creation to succeed")
+			err := k8sClient.Create(ctx, datasource)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Cleaning up the created resource")
+			Eventually(func() error {
+				return k8sClient.Delete(ctx, datasource)
+			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+})

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -930,10 +930,11 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -944,6 +945,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -985,7 +987,7 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -996,6 +998,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -1016,12 +1019,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -1048,12 +1052,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -2433,12 +2438,13 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -2465,12 +2471,13 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -3505,10 +3512,11 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -3519,6 +3527,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -3560,7 +3569,7 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -3571,6 +3580,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -3591,12 +3601,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -3623,12 +3634,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -5237,12 +5249,13 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -5269,12 +5282,13 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate

--- a/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
@@ -50,10 +50,11 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -64,6 +65,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -105,7 +107,7 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -116,6 +118,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -136,12 +139,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -168,12 +172,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -221,6 +226,8 @@ spec:
                 - default
                 - plugin
                 type: object
+            required:
+            - config
             type: object
           status:
             description: PersesDatasourceStatus defines the observed state of PersesDatasource
@@ -319,10 +326,11 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -333,6 +341,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -374,7 +383,7 @@ spec:
                         description: Name of basic auth k8s resource (when type is secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -385,6 +394,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -405,12 +415,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -437,12 +448,13 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
                             description: Name of basic auth k8s resource (when type is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -815,11 +815,12 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "password_path": {
                             "description": "Path to password",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -833,6 +834,7 @@
                           },
                           "username": {
                             "description": "Username for basic auth",
+                            "minLength": 1,
                             "type": "string"
                           }
                         },
@@ -886,7 +888,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "scopes": {
@@ -898,6 +900,7 @@
                           },
                           "tokenURL": {
                             "description": "TokenURL is the resource server's token endpoint\nURL. This is a constant specific to each server.",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -924,6 +927,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -931,7 +935,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -967,6 +971,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -974,7 +979,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -2656,6 +2661,7 @@
                         "properties": {
                           "certPath": {
                             "description": "Path to Certificate",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "name": {
@@ -2663,7 +2669,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "privateKeyPath": {
@@ -2699,6 +2705,7 @@
                         "properties": {
                           "certPath": {
                             "description": "Path to Certificate",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "name": {
@@ -2706,7 +2713,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "privateKeyPath": {
@@ -3631,11 +3638,12 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "password_path": {
                             "description": "Path to password",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -3649,6 +3657,7 @@
                           },
                           "username": {
                             "description": "Username for basic auth",
+                            "minLength": 1,
                             "type": "string"
                           }
                         },
@@ -3702,7 +3711,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "scopes": {
@@ -3714,6 +3723,7 @@
                           },
                           "tokenURL": {
                             "description": "TokenURL is the resource server's token endpoint\nURL. This is a constant specific to each server.",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -3740,6 +3750,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -3747,7 +3758,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -3783,6 +3794,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -3790,7 +3802,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -5619,6 +5631,7 @@
                         "properties": {
                           "certPath": {
                             "description": "Path to Certificate",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "name": {
@@ -5626,7 +5639,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "privateKeyPath": {
@@ -5662,6 +5675,7 @@
                         "properties": {
                           "certPath": {
                             "description": "Path to Certificate",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "name": {
@@ -5669,7 +5683,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "privateKeyPath": {

--- a/jsonnet/generated/perses.dev_persesdatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesdatasources-crd.json
@@ -51,11 +51,12 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "password_path": {
                             "description": "Path to password",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -69,6 +70,7 @@
                           },
                           "username": {
                             "description": "Username for basic auth",
+                            "minLength": 1,
                             "type": "string"
                           }
                         },
@@ -122,7 +124,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "scopes": {
@@ -134,6 +136,7 @@
                           },
                           "tokenURL": {
                             "description": "TokenURL is the resource server's token endpoint\nURL. This is a constant specific to each server.",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -160,6 +163,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -167,7 +171,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -203,6 +207,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -210,7 +215,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -282,6 +287,9 @@
                     "type": "object"
                   }
                 },
+                "required": [
+                  "config"
+                ],
                 "type": "object"
               },
               "status": {
@@ -383,11 +391,12 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "password_path": {
                             "description": "Path to password",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -401,6 +410,7 @@
                           },
                           "username": {
                             "description": "Username for basic auth",
+                            "minLength": 1,
                             "type": "string"
                           }
                         },
@@ -454,7 +464,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "scopes": {
@@ -466,6 +476,7 @@
                           },
                           "tokenURL": {
                             "description": "TokenURL is the resource server's token endpoint\nURL. This is a constant specific to each server.",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -492,6 +503,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -499,7 +511,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -535,6 +547,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -542,7 +555,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {

--- a/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
@@ -49,11 +49,12 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "password_path": {
                             "description": "Path to password",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -67,6 +68,7 @@
                           },
                           "username": {
                             "description": "Username for basic auth",
+                            "minLength": 1,
                             "type": "string"
                           }
                         },
@@ -120,7 +122,7 @@
                             "type": "string"
                           },
                           "namespace": {
-                            "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                            "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
                           "scopes": {
@@ -132,6 +134,7 @@
                           },
                           "tokenURL": {
                             "description": "TokenURL is the resource server's token endpoint\nURL. This is a constant specific to each server.",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "type": {
@@ -158,6 +161,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -165,7 +169,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -201,6 +205,7 @@
                             "properties": {
                               "certPath": {
                                 "description": "Path to Certificate",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "name": {
@@ -208,7 +213,7 @@
                                 "type": "string"
                               },
                               "namespace": {
-                                "description": "Namsespace of certificate k8s resource (when type is secret or configmap)",
+                                "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                                 "type": "string"
                               },
                               "privateKeyPath": {


### PR DESCRIPTION
Adds kubebuilder required and minlength validations to required fields in Perses, PersesDashboard, and PersesDatasource types. Include integration tests to verify validation behavior.