### PR TITLE
[ENHANCEMENT] refactor reconcillers to avoid status update conflicts

### DIFF
--- a/config/samples/perses.dev_v1alpha2_perses.yaml
+++ b/config/samples/perses.dev_v1alpha2_perses.yaml
@@ -12,11 +12,6 @@ spec:
       file:
         folder: '/perses'
         extension: 'yaml'
-    schemas:
-      panels_path: '/etc/perses/cue/schemas/panels'
-      queries_path: '/etc/perses/cue/schemas/queries'
-      datasources_path: '/etc/perses/cue/schemas/datasources'
-      variables_path: '/etc/perses/cue/schemas/variables'
     ephemeral_dashboard:
       enable: false
       cleanup_interval: '1s'

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -19,6 +19,7 @@ package dashboards
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/perses/perses/pkg/client/perseshttp"
@@ -53,9 +54,10 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 
 	}
 
-	dashboard := &persesv1alpha2.PersesDashboard{}
-
-	if res, err := r.getLatestPersesDashboard(ctx, req, dashboard); subreconciler.ShouldHaltOrRequeue(res, err) {
+	dashboard, ok := dashboardFromContext(ctx)
+	if !ok {
+		dlog.Error("dashboard not found in context")
+		res, err := subreconciler.RequeueWithError(fmt.Errorf("dashboard not found in context"))
 		return r.setStatusToDegraded(ctx, req, res, common.ReasonMissingResource, err)
 	}
 

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -57,9 +57,10 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 
 	}
 
-	datasource := &persesv1alpha2.PersesDatasource{}
-
-	if res, err := r.getLatestPersesDatasource(ctx, req, datasource); subreconciler.ShouldHaltOrRequeue(res, err) {
+	datasource, ok := datasourceFromContext(ctx)
+	if !ok {
+		dlog.Error("datasource not found in context")
+		res, err := subreconciler.RequeueWithError(fmt.Errorf("datasource not found in context"))
 		return r.setStatusToDegraded(ctx, req, res, persescommon.ReasonMissingResource, err)
 	}
 

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -54,9 +54,10 @@ func (r *PersesGlobalDatasourceReconciler) reconcileGlobalDatasourcesInAllInstan
 		return r.setStatusToDegraded(ctx, req, res, persescommon.ReasonMissingPerses, err)
 	}
 
-	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
-
-	if res, err := r.getLatestPersesGlobalDatasource(ctx, req, globaldatasource); subreconciler.ShouldHaltOrRequeue(res, err) {
+	globaldatasource, ok := globalDatasourceFromContext(ctx)
+	if !ok {
+		gdlog.Error("globaldatasource not found in context")
+		res, err := subreconciler.RequeueWithError(fmt.Errorf("globaldatasource not found in context"))
 		return r.setStatusToDegraded(ctx, req, res, persescommon.ReasonMissingResource, err)
 	}
 

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,6 +34,19 @@ import (
 	"github.com/perses/perses-operator/internal/perses/common"
 	"github.com/perses/perses-operator/internal/subreconciler"
 )
+
+type globalDatasourceContextKey string
+
+const contextKey globalDatasourceContextKey = "globaldatasource"
+
+func withGlobalDatasource(ctx context.Context, gds *persesv1alpha2.PersesGlobalDatasource) context.Context {
+	return context.WithValue(ctx, contextKey, gds)
+}
+
+func globalDatasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesGlobalDatasource, bool) {
+	gds, ok := ctx.Value(contextKey).(*persesv1alpha2.PersesGlobalDatasource)
+	return gds, ok
+}
 
 // PersesGlobalDatasourceReconciler reconciles a PersesDatasource object
 type PersesGlobalDatasourceReconciler struct {
@@ -50,8 +64,21 @@ var log = logger.WithField("module", "perses_globaldatasource_controller")
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=watch;get
 func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log.Infof("Reconciling PersesGlobalDatasource: %s", req.Name)
+
+	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
+	if err := r.Get(ctx, req.NamespacedName, globaldatasource); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Infof("perses globaldatasource resource not found. Deleting '%s'", req.Name)
+			return subreconciler.Evaluate(r.deleteGlobalDatasourceInAllInstances(ctx, req.Name))
+		}
+		log.WithError(err).Error("Failed to get perses globaldatasource")
+		return subreconciler.Evaluate(subreconciler.RequeueWithError(err))
+	}
+
+	// Store globaldatasource in context for all sub-reconcilers
+	ctx = withGlobalDatasource(ctx, globaldatasource)
+
 	subreconcilersForPerses := []subreconciler.FnWithRequest{
-		r.handleDelete,
 		r.setStatusToUnknown,
 		r.reconcileGlobalDatasourcesInAllInstances,
 		r.setStatusToComplete,
@@ -66,71 +93,54 @@ func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ct
 	return subreconciler.Evaluate(subreconciler.DoNotRequeue())
 }
 
-func (r *PersesGlobalDatasourceReconciler) getLatestPersesGlobalDatasource(ctx context.Context, req ctrl.Request, globaldatasource *persesv1alpha2.PersesGlobalDatasource) (*ctrl.Result, error) {
-	if err := r.Get(ctx, req.NamespacedName, globaldatasource); err != nil {
+func (r *PersesGlobalDatasourceReconciler) updateGlobalDatasourceStatus(
+	ctx context.Context,
+	req ctrl.Request,
+	updateFn func(*persesv1alpha2.PersesGlobalDatasource),
+) (*ctrl.Result, error) {
+	_, ok := globalDatasourceFromContext(ctx)
+	if !ok {
+		log.Error("globaldatasource not found in context")
+		return subreconciler.RequeueWithError(fmt.Errorf("globaldatasource not found in context"))
+	}
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh := &persesv1alpha2.PersesGlobalDatasource{}
+		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
+			return err
+		}
+		updateFn(fresh)
+		return r.Status().Update(ctx, fresh)
+	})
+
+	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("perses globaldatasource resource not found. Ignoring since object must be deleted")
 			return subreconciler.DoNotRequeue()
 		}
-		log.WithError(err).Error("Failed to get perses globaldatasource")
+		log.WithError(err).Error("Failed to update Perses globaldatasource status")
 		return subreconciler.RequeueWithError(err)
-	}
-
-	return subreconciler.ContinueReconciling()
-}
-
-func (r *PersesGlobalDatasourceReconciler) handleDelete(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
-
-	if err := r.Get(ctx, req.NamespacedName, globaldatasource); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.WithError(err).Error("Failed to get perses globaldatasource")
-			return subreconciler.RequeueWithError(err)
-		}
-
-		log.Infof("perses globaldatasource resource not found. Deleting '%s'", req.Name)
-
-		return r.deleteGlobalDatasourceInAllInstances(ctx, req.Name)
 	}
 
 	return subreconciler.ContinueReconciling()
 }
 
 func (r *PersesGlobalDatasourceReconciler) setStatusToUnknown(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
-
-	if r, err := r.getLatestPersesGlobalDatasource(ctx, req, globaldatasource); subreconciler.ShouldHaltOrRequeue(r, err) {
-		return r, err
-	}
-
-	if len(globaldatasource.Status.Conditions) == 0 {
-		meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
-		if err := r.Status().Update(ctx, globaldatasource); err != nil {
-			log.WithError(err).Error("Failed to update Perses globaldatasource status")
-			return subreconciler.RequeueWithError(err)
+	return r.updateGlobalDatasourceStatus(ctx, req, func(globaldatasource *persesv1alpha2.PersesGlobalDatasource) {
+		if len(globaldatasource.Status.Conditions) == 0 {
+			meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{
+				Type: common.TypeAvailablePerses, Status: metav1.ConditionUnknown,
+				Reason: "Reconciling", Message: "Starting reconciliation"})
 		}
-	}
-
-	return subreconciler.ContinueReconciling()
+	})
 }
 
 func (r *PersesGlobalDatasourceReconciler) setStatusToComplete(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
-
-	if r, err := r.getLatestPersesGlobalDatasource(ctx, req, globaldatasource); subreconciler.ShouldHaltOrRequeue(r, err) {
-		return r, err
-	}
-
-	meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{Type: common.TypeAvailablePerses,
-		Status: metav1.ConditionTrue, Reason: "Reconciled",
-		Message: fmt.Sprintf("GlobalDatasource (%s) created successfully", globaldatasource.Name)})
-
-	if err := r.Status().Update(ctx, globaldatasource); err != nil {
-		log.WithError(err).Error("Failed to update Perses globaldatasource status")
-		return subreconciler.RequeueWithError(err)
-	}
-
-	return subreconciler.ContinueReconciling()
+	return r.updateGlobalDatasourceStatus(ctx, req, func(globaldatasource *persesv1alpha2.PersesGlobalDatasource) {
+		meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{
+			Type: common.TypeAvailablePerses, Status: metav1.ConditionTrue,
+			Reason: "Reconciled", Message: fmt.Sprintf("GlobalDatasource (%s) created successfully", globaldatasource.Name)})
+	})
 }
 
 func (r *PersesGlobalDatasourceReconciler) setStatusToDegraded(
@@ -140,26 +150,16 @@ func (r *PersesGlobalDatasourceReconciler) setStatusToDegraded(
 	degradedReason common.ConditionStatusReason,
 	degradedError error,
 ) (*ctrl.Result, error) {
-	// Attempt to update the globaldatasource CR status, setting it to degraded
-	// If updating the globaldatasource CR fails then return the info from the update
-	// rather than the main logic flow's, forcing a requeue
-	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
+	result, err := r.updateGlobalDatasourceStatus(ctx, req, func(globaldatasource *persesv1alpha2.PersesGlobalDatasource) {
+		meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{
+			Type: common.TypeDegradedPerses, Status: metav1.ConditionTrue,
+			Reason: string(degradedReason), Message: degradedError.Error()})
+	})
 
-	if res, err := r.getLatestPersesGlobalDatasource(ctx, req, globaldatasource); subreconciler.ShouldHaltOrRequeue(res, err) {
-		return res, err
+	if err != nil {
+		return result, err
 	}
 
-	meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{Type: common.TypeDegradedPerses,
-		Status: metav1.ConditionTrue, Reason: string(degradedReason),
-		Message: degradedError.Error()})
-
-	if err := r.Status().Update(ctx, globaldatasource); err != nil {
-		log.WithError(err).Error("Failed to update Perses globaldatasource status")
-		return subreconciler.RequeueWithError(err)
-	}
-
-	// If the status was able to be set to degraded perform the main logic loop's
-	// handling of the result and error
 	return degradedResult, degradedError
 }
 

--- a/controllers/perses/configmap_controller.go
+++ b/controllers/perses/configmap_controller.go
@@ -39,10 +39,10 @@ import (
 var cmlog = logger.WithField("module", "configmap_controller")
 
 func (r *PersesReconciler) reconcileConfigMap(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	perses := &v1alpha2.Perses{}
-
-	if result, err := r.getLatestPerses(ctx, req, perses); subreconciler.ShouldHaltOrRequeue(result, err) {
-		return result, err
+	perses, ok := persesFromContext(ctx)
+	if !ok {
+		cmlog.Error("perses not found in context")
+		return subreconciler.RequeueWithError(fmt.Errorf("perses not found in context"))
 	}
 
 	configName := common.GetConfigName(perses.Name)

--- a/controllers/perses/deployment_controller.go
+++ b/controllers/perses/deployment_controller.go
@@ -40,14 +40,14 @@ import (
 var dlog = logger.WithField("module", "deployment_controller")
 
 func (r *PersesReconciler) reconcileDeployment(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	perses := &v1alpha2.Perses{}
-
-	if result, err := r.getLatestPerses(ctx, req, perses); subreconciler.ShouldHaltOrRequeue(result, err) {
-		return result, err
+	perses, ok := persesFromContext(ctx)
+	if !ok {
+		dlog.Error("perses not found in context")
+		return subreconciler.RequeueWithError(fmt.Errorf("perses not found in context"))
 	}
 
 	if perses.Spec.Config.Database.SQL == nil {
-		dlog.Info("Database SQL configuration is not set, skipping Deployment creation")
+		dlog.Debug("Database SQL configuration is not set, skipping Deployment creation")
 
 		found := &appsv1.Deployment{}
 		err := r.Get(ctx, types.NamespacedName{Name: perses.Name, Namespace: perses.Namespace}, found)

--- a/controllers/perses/service_controller.go
+++ b/controllers/perses/service_controller.go
@@ -40,10 +40,10 @@ import (
 var slog = logger.WithField("module", "service_controller")
 
 func (r *PersesReconciler) reconcileService(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	perses := &v1alpha2.Perses{}
-
-	if result, err := r.getLatestPerses(ctx, req, perses); subreconciler.ShouldHaltOrRequeue(result, err) {
-		return result, err
+	perses, ok := persesFromContext(ctx)
+	if !ok {
+		slog.Error("perses not found in context")
+		return subreconciler.RequeueWithError(fmt.Errorf("perses not found in context"))
 	}
 
 	serviceName := perses.Name

--- a/controllers/perses/statefulset_controller.go
+++ b/controllers/perses/statefulset_controller.go
@@ -41,14 +41,14 @@ import (
 var stlog = logger.WithField("module", "statefulset_controller")
 
 func (r *PersesReconciler) reconcileStatefulSet(ctx context.Context, req ctrl.Request) (*ctrl.Result, error) {
-	perses := &v1alpha2.Perses{}
-
-	if result, err := r.getLatestPerses(ctx, req, perses); subreconciler.ShouldHaltOrRequeue(result, err) {
-		return result, err
+	perses, ok := persesFromContext(ctx)
+	if !ok {
+		stlog.Error("perses not found in context")
+		return subreconciler.RequeueWithError(fmt.Errorf("perses not found in context"))
 	}
 
 	if perses.Spec.Config.Database.File == nil {
-		stlog.Info("Database file configuration is not set, skipping StatefulSet creation")
+		stlog.Debug("Database file configuration is not set, skipping StatefulSet creation")
 
 		found := &appsv1.StatefulSet{}
 		err := r.Get(ctx, types.NamespacedName{Name: perses.Name, Namespace: perses.Namespace}, found)

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -103,6 +104,7 @@ var _ = Describe("Perses controller", func() {
 			}
 
 			// Errors might arise during reconciliation, but we are checking the final state of the resources
+			//nolint:ineffassign
 			_, err = persesReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespaceName,
 			})
@@ -383,6 +385,89 @@ var _ = Describe("Perses controller", func() {
 				}
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())
+		})
+
+		It("should successfully delete Perses and remove the finalizer", func() {
+			PersesDeleteName := "perses-delete-test"
+			typeNamespaceName := types.NamespacedName{Name: PersesDeleteName, Namespace: persesNamespace}
+
+			By("Creating the custom resource for the Kind Perses")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PersesDeleteName,
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					Image: persesImage,
+					Config: persesv1alpha2.PersesConfig{
+						Config: persesconfig.Config{
+							Database: persesconfig.Database{
+								File: &persesconfig.File{
+									Folder: "/etc/perses/storage",
+								},
+							},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, perses)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Checking if the custom resource was successfully created")
+			Eventually(func() error {
+				found := &persesv1alpha2.Perses{}
+				return k8sClient.Get(ctx, typeNamespaceName, found)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			persesReconciler := &persescontroller.PersesReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to add the finalizer")
+			// First reconcile sets status to unknown
+			_, err = persesReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Second reconcile adds the finalizer and creates resources
+			_, err = persesReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Checking if the finalizer was added")
+			Eventually(func() bool {
+				found := &persesv1alpha2.Perses{}
+				err := k8sClient.Get(ctx, typeNamespaceName, found)
+				if err != nil {
+					return false
+				}
+				return slices.Contains(found.Finalizers, common.PersesFinalizer)
+			}, time.Minute, time.Second).Should(BeTrue())
+
+			By("Deleting the custom resource")
+			persesToDelete := &persesv1alpha2.Perses{}
+			err = k8sClient.Get(ctx, typeNamespaceName, persesToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, persesToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Reconciling after deletion to trigger finalizer removal")
+			//nolint:staticcheck,ineffassign
+			_, err = persesReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespaceName,
+			})
+			// Error is expected if the resource is already gone, or nil if handleDelete succeeded
+			// We just care that the reconcile doesn't panic
+
+			By("Checking if the Perses resource was fully deleted (finalizer removed)")
+			Eventually(func() bool {
+				found := &persesv1alpha2.Perses{}
+				err := k8sClient.Get(ctx, typeNamespaceName, found)
+				return errors.IsNotFound(err)
+			}, time.Minute, time.Second).Should(BeTrue(), "Perses resource should be deleted after finalizer removal")
 		})
 	})
 })


### PR DESCRIPTION
## Description

This PR 

- Refactors the reconcilers to use a pointer resource from context, avoiding updates conflicts
- Creates an updateStatus function to reuse for different type of statuses
- Adds a test for check that finalizers are added and removed

## Type of change

- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)

## Verification

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
