### PR TITLE
[ENHANCEMENT] Add kubebuilder validations for containerPort

### DIFF
--- a/api/v1alpha1/perses_types.go
+++ b/api/v1alpha1/perses_types.go
@@ -36,6 +36,9 @@ type PersesSpec struct {
 	// Args extra arguments to pass to perses
 	Args []string `json:"args,omitempty"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:default=8080
 	ContainerPort int32 `json:"containerPort,omitempty"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -36,6 +36,9 @@ type PersesSpec struct {
 	// Args extra arguments to pass to perses
 	Args []string `json:"args,omitempty"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:default=8080
 	ContainerPort int32 `json:"containerPort,omitempty"`
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -2214,7 +2214,10 @@ spec:
                     type: object
                 type: object
               containerPort:
+                default: 8080
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
                 description: Image specifies the container image that should be used
@@ -4950,7 +4953,10 @@ spec:
                     type: object
                 type: object
               containerPort:
+                default: 8080
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
                 description: Image specifies the container image that should be used

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -2075,7 +2075,10 @@ spec:
                     type: object
                 type: object
               containerPort:
+                default: 8080
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
                 description: Image specifies the container image that should be used for the Perses deployment.
@@ -4657,7 +4660,10 @@ spec:
                     type: object
                 type: object
               containerPort:
+                default: 8080
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
                 description: Image specifies the container image that should be used for the Perses deployment.

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -2273,7 +2273,10 @@
                     "type": "object"
                   },
                   "containerPort": {
+                    "default": 8080,
                     "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
                     "type": "integer"
                   },
                   "image": {
@@ -5096,7 +5099,10 @@
                     "type": "object"
                   },
                   "containerPort": {
+                    "default": 8080,
                     "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
                     "type": "integer"
                   },
                   "image": {


### PR DESCRIPTION
Add kubebuilder validations for containerPort. Allows the range between 1-65535 and sets default port 8080 for backward compatibility.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
