### PR TITLE
[IGNORE] Include jsonnet directories in bundle-check CI target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-check
 bundle-check: bundle
-	git diff --exit-code bundle config
+	git diff --exit-code bundle config jsonnet/generated jsonnet/examples
 
 .PHONY: bundle-build
 bundle-build: generate bundle ## Build the bundle image.


### PR DESCRIPTION


<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Previously bundle-check only verified bundle and config directories, allowing jsonnet/generated and jsonnet/examples to drift out of sync without CI catching it.

Triggered by https://github.com/perses/perses-operator/commit/c1a6cf75b48cedf17b2cad6b63d459028b2e55dd#diff-183b52b7e661d2f23db7504774663de5bedec756632633207ab4bf3e0b2922a8R66-R67 
(jsonnet/generated/manager.json)
as I didn't update this but make manifests regenerated but it looks like it was out of sync hence when I ran `make manifests` it was updated back to how it was before. 

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
