### PR TITLE
[BREAKINGCHANGE] Rename BasicAuth field from password_path to passwordPath

### DIFF
--- a/api/v1alpha1/perses_conversion.go
+++ b/api/v1alpha1/perses_conversion.go
@@ -8,6 +8,12 @@ import (
 )
 
 // ConvertTo converts Perses (v1alpha1) to the Hub version (v1alpha2)
+//
+// NOTE: BasicAuth.PasswordPath uses different JSON field names between versions:
+//   - v1alpha1: "password_path" (snake_case for backward compatibility)
+//   - v1alpha2: "passwordPath" (camelCase per Kubernetes conventions)
+//
+// The conversion is handled automatically since the Go field name is identical.
 func (src *Perses) ConvertTo(dstRaw conv.Hub) error {
 	dst := dstRaw.(*v1alpha2.Perses)
 

--- a/api/v1alpha1/perses_conversion_test.go
+++ b/api/v1alpha1/perses_conversion_test.go
@@ -1,0 +1,74 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/perses/perses-operator/api/v1alpha2"
+)
+
+func TestBasicAuthConversion(t *testing.T) {
+	v1alpha1JSON := `{"type":"secret","name":"test","username":"user","password_path":"/etc/pass"}`
+
+	// Unmarshal v1alpha1 JSON (snake_case)
+	var v1Auth BasicAuth
+	if err := json.Unmarshal([]byte(v1alpha1JSON), &v1Auth); err != nil {
+		t.Fatalf("unmarshal v1alpha1: %v", err)
+	}
+	if v1Auth.PasswordPath != "/etc/pass" {
+		t.Errorf("expected PasswordPath='/etc/pass', got '%s'", v1Auth.PasswordPath)
+	}
+
+	// Convert to v1alpha2
+	var v2Auth v1alpha2.BasicAuth
+	if err := Convert_v1alpha1_BasicAuth_To_v1alpha2_BasicAuth(&v1Auth, &v2Auth, nil); err != nil {
+		t.Fatalf("conversion v1->v2: %v", err)
+	}
+	if v2Auth.PasswordPath != v1Auth.PasswordPath {
+		t.Errorf("conversion failed: expected '%s', got '%s'", v1Auth.PasswordPath, v2Auth.PasswordPath)
+	}
+
+	// Marshal v1alpha2 (should use camelCase)
+	v2JSON, err := json.Marshal(v2Auth)
+	if err != nil {
+		t.Fatalf("marshal v1alpha2: %v", err)
+	}
+	if !strings.Contains(string(v2JSON), `"passwordPath"`) {
+		t.Errorf("v1alpha2 should use 'passwordPath', got: %s", string(v2JSON))
+	}
+	if strings.Contains(string(v2JSON), `"password_path"`) {
+		t.Errorf("v1alpha2 should not use 'password_path', got: %s", string(v2JSON))
+	}
+
+	// Reverse conversion
+	var v1AuthReverse BasicAuth
+	if err := Convert_v1alpha2_BasicAuth_To_v1alpha1_BasicAuth(&v2Auth, &v1AuthReverse, nil); err != nil {
+		t.Fatalf("conversion v2->v1: %v", err)
+	}
+
+	// Marshal v1alpha1 (should use snake_case)
+	v1JSONReverse, err := json.Marshal(v1AuthReverse)
+	if err != nil {
+		t.Fatalf("marshal v1alpha1: %v", err)
+	}
+	if !strings.Contains(string(v1JSONReverse), `"password_path"`) {
+		t.Errorf("v1alpha1 should use 'password_path', got: %s", string(v1JSONReverse))
+	}
+	if strings.Contains(string(v1JSONReverse), `"passwordPath"`) {
+		t.Errorf("v1alpha1 should not use 'passwordPath', got: %s", string(v1JSONReverse))
+	}
+}

--- a/api/v1alpha1/persesdatasource_conversion.go
+++ b/api/v1alpha1/persesdatasource_conversion.go
@@ -8,6 +8,12 @@ import (
 )
 
 // ConvertTo converts PersesDatasource (v1alpha1) to the Hub version (v1alpha2)
+//
+// NOTE: BasicAuth.PasswordPath uses different JSON field names between versions:
+//   - v1alpha1: "password_path" (snake_case for backward compatibility)
+//   - v1alpha2: "passwordPath" (camelCase per Kubernetes conventions)
+//
+// The conversion is handled automatically since the Go field name is identical.
 func (src *PersesDatasource) ConvertTo(dstRaw conv.Hub) error {
 	dst := dstRaw.(*v1alpha2.PersesDatasource)
 

--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -159,7 +159,7 @@ type BasicAuth struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// Path to password
-	PasswordPath string `json:"password_path"`
+	PasswordPath string `json:"passwordPath"`
 }
 
 type OAuth struct {

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -3713,7 +3713,7 @@ spec:
                         description: Namespace of certificate k8s resource (when type
                           is secret or configmap)
                         type: string
-                      password_path:
+                      passwordPath:
                         description: Path to password
                         minLength: 1
                         type: string
@@ -3729,7 +3729,7 @@ spec:
                         minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -343,7 +343,7 @@ spec:
                         description: Namespace of certificate k8s resource (when type
                           is secret or configmap)
                         type: string
-                      password_path:
+                      passwordPath:
                         description: Path to password
                         minLength: 1
                         type: string
@@ -359,7 +359,7 @@ spec:
                         minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object

--- a/config/crd/bases/perses.dev_persesglobaldatasources.yaml
+++ b/config/crd/bases/perses.dev_persesglobaldatasources.yaml
@@ -56,7 +56,7 @@ spec:
                         description: Namespace of certificate k8s resource (when type
                           is secret or configmap)
                         type: string
-                      password_path:
+                      passwordPath:
                         description: Path to password
                         minLength: 1
                         type: string
@@ -72,7 +72,7 @@ spec:
                         minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object

--- a/controllers/api_validation_test.go
+++ b/controllers/api_validation_test.go
@@ -63,8 +63,8 @@ var _ = Describe("API Validation", func() {
 			Expect(errors.IsInvalid(err)).To(BeTrue())
 		})
 
-		It("should reject BasicAuth with empty password_path", func() {
-			By("Creating a Perses resource with empty BasicAuth password_path")
+		It("should reject BasicAuth with empty passwordPath", func() {
+			By("Creating a Perses resource with empty BasicAuth passwordPath")
 			perses := &persesv1alpha2.Perses{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid-basicauth-no-password",

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ _Appears in:_
 | `name` _string_ | Name of basic auth k8s resource (when type is secret or configmap) |  | Optional: \{\} <br /> |
 | `namespace` _string_ | Namespace of certificate k8s resource (when type is secret or configmap) |  | Optional: \{\} <br /> |
 | `username` _string_ | Username for basic auth |  | MinLength: 1 <br />Required: \{\} <br /> |
-| `password_path` _string_ | Path to password |  | MinLength: 1 <br />Required: \{\} <br /> |
+| `passwordPath` _string_ | Path to password |  | MinLength: 1 <br />Required: \{\} <br /> |
 
 
 #### Certificate

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -283,7 +283,7 @@ spec:
       name: k8s-basicauth-secret-name
       namespace: optional-namespacename # if the secret resides in another namespace
       username: "actual-username"
-      password_path: "password-key-in-secret" # or an actual path if type is `file`
+      passwordPath: "password-key-in-secret" # or an actual path if type is `file`
     oauth:
       type: secret
       name: k8s-oauth-secret-name

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -3517,7 +3517,7 @@ spec:
                       namespace:
                         description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
-                      password_path:
+                      passwordPath:
                         description: Path to password
                         minLength: 1
                         type: string
@@ -3533,7 +3533,7 @@ spec:
                         minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object

--- a/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
@@ -330,7 +330,7 @@ spec:
                       namespace:
                         description: Namespace of certificate k8s resource (when type is secret or configmap)
                         type: string
-                      password_path:
+                      passwordPath:
                         description: Path to password
                         minLength: 1
                         type: string
@@ -346,7 +346,7 @@ spec:
                         minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -3644,7 +3644,7 @@
                             "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
-                          "password_path": {
+                          "passwordPath": {
                             "description": "Path to password",
                             "minLength": 1,
                             "type": "string"
@@ -3665,7 +3665,7 @@
                           }
                         },
                         "required": [
-                          "password_path",
+                          "passwordPath",
                           "type",
                           "username"
                         ],

--- a/jsonnet/generated/perses.dev_persesdatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesdatasources-crd.json
@@ -396,7 +396,7 @@
                             "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
-                          "password_path": {
+                          "passwordPath": {
                             "description": "Path to password",
                             "minLength": 1,
                             "type": "string"
@@ -417,7 +417,7 @@
                           }
                         },
                         "required": [
-                          "password_path",
+                          "passwordPath",
                           "type",
                           "username"
                         ],

--- a/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
@@ -54,7 +54,7 @@
                             "description": "Namespace of certificate k8s resource (when type is secret or configmap)",
                             "type": "string"
                           },
-                          "password_path": {
+                          "passwordPath": {
                             "description": "Path to password",
                             "minLength": 1,
                             "type": "string"
@@ -75,7 +75,7 @@
                           }
                         },
                         "required": [
-                          "password_path",
+                          "passwordPath",
                           "type",
                           "username"
                         ],


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Fix API field naming to follow Kubernetes camelCase convention for JSON tags. The BasicAuth.PasswordPath field used snake_case (password_path) which is inconsistent with Kubernetes API conventions that mandate camelCase for JSON fields.

Ref: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer
- [ ] Code follows project conventions and passes linting
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
