### PR TITLE
[FEATURE] Add custom Prometheus metrics for operator

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,3 +26,5 @@ jobs:
           enable_go: true
       - name: check API docs are up-to-date
         run: make check-api-docs
+      - name: check metrics docs are up-to-date
+        run: make check-metrics-docs

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,18 @@ check-api-docs: generate-api-docs ## Verify that generated API docs are up-to-da
 		git diff docs/api.md --exit-code; \
 	fi
 
+.PHONY: generate-metrics-docs
+generate-metrics-docs: ## Generate metrics documentation from metrics code.
+	@echo "Generating metrics documentation..."
+	@go run ./scripts/generate-metrics-docs/main.go docs/metrics.md
+
+.PHONY: check-metrics-docs
+check-metrics-docs: generate-metrics-docs ## Verify that generated metrics docs are up-to-date.
+	@if ! git diff --quiet --exit-code docs/metrics.md; then \
+		echo "docs/metrics.md is out of date. Please run 'make generate-metrics-docs' and commit the result."; \
+		git diff docs/metrics.md --exit-code; \
+	fi
+
 .PHONY: fmt
 fmt: jsonnet-format ## Run go fmt against code.
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ kubectl -n perses-dev port-forward svc/perses-sample 8080:8080
 To delete the CRDs from the cluster:
 
 ```sh
-make uninstall
+make uninstall-crds
 ```
 
 ### Undeploy controller
@@ -78,6 +78,7 @@ make undeploy
 ## Docs
 
 - [API Docs](docs/api.md)
+- [Metrics Documentation](docs/metrics.md)
 - [Developer Docs](docs/dev.md)
 - Sample CRDs
   - [Kubernetes](config/samples)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,99 @@
+# Perses Operator Metrics
+
+The Perses Operator exposes Prometheus metrics for monitoring operator health and performance.
+
+## Accessing Metrics
+
+Metrics are exposed on port `8082` at the `/metrics` endpoint:
+
+```bash
+# Port forward to the operator pod
+kubectl port-forward -n perses-operator-system \
+  deployment/perses-operator-controller-manager 8082:8082
+
+# View metrics
+curl http://localhost:8082/metrics
+```
+
+## Available Metrics
+
+### `perses_operator_syncs`
+
+Number of objects per sync status (ok/failed)
+
+**Type:** Gauge  
+**Labels:**
+
+- `status`
+
+
+
+---
+
+### `perses_operator_managed_resources`
+
+Number of resources managed by the operator per state (synced/failed)
+
+**Type:** Gauge  
+**Labels:**
+
+- `resource`
+- `state`
+
+
+
+---
+
+### `perses_operator_reconcile_errors_total`
+
+Total number of reconciliation errors by controller and reason
+
+**Type:** Counter  
+**Labels:**
+
+- `controller`
+- `reason`
+
+
+
+---
+
+### `perses_operator_perses_instances`
+
+Number of Perses instances per namespace
+
+**Type:** Gauge  
+**Labels:**
+
+- `namespace`
+
+
+
+---
+
+### `perses_operator_ready`
+
+Whether the operator is ready (1=yes, 0=no)
+
+**Type:** Gauge
+
+
+---
+
+
+## Standard Controller-Runtime Metrics
+
+In addition to custom metrics, the operator exposes standard controller-runtime metrics:
+
+- `controller_runtime_reconcile_total`: Total number of reconciliations per controller
+- `controller_runtime_reconcile_errors_total`: Total number of reconciliation errors
+- `controller_runtime_reconcile_time_seconds`: Length of time per reconciliation
+- `workqueue_*`: Work queue metrics (depth, duration, etc.)
+- `rest_client_*`: Kubernetes API client metrics
+
+See [controller-runtime metrics](https://book.kubebuilder.io/reference/metrics-reference.html) for details.
+
+---
+
+*This documentation is auto-generated from the metrics code. Do not edit manually.*
+*Run `make generate-metrics-docs` to regenerate.*

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/perses/perses v0.52.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -78,6 +79,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/echo/v4 v4.13.4 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -98,7 +100,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,170 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	resourcesDesc = prometheus.NewDesc(
+		"perses_operator_managed_resources",
+		"Number of resources managed by the operator per state (synced/failed)",
+		[]string{"resource", "state"},
+		nil,
+	)
+)
+
+// Metrics represents metrics associated with the operator.
+type Metrics struct {
+	// Reconciliation error counters
+	reconcileErrors *prometheus.CounterVec
+
+	// Perses instance metrics
+	persesInstances *prometheus.GaugeVec
+
+	// Operator readiness
+	ready prometheus.Gauge
+
+	// mtx protects all fields below
+	mtx       sync.RWMutex
+	resources map[resourceKey]map[string]int
+}
+
+type resourceKey struct {
+	resource string
+	state    resourceState
+}
+
+type resourceState int
+
+const (
+	synced resourceState = iota
+	failed
+)
+
+func (r resourceState) String() string {
+	switch r {
+	case synced:
+		return "synced"
+	case failed:
+		return "failed"
+	}
+	return ""
+}
+
+// NewMetrics initializes operator metrics and registers them with the controller-runtime registry.
+func NewMetrics() *Metrics {
+	m := &Metrics{
+		reconcileErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "perses_operator_reconcile_errors_total",
+				Help: "Total number of reconciliation errors by controller and reason",
+			},
+			[]string{"controller", "reason"},
+		),
+		persesInstances: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_perses_instances",
+				Help: "Number of Perses instances per namespace",
+			},
+			[]string{"namespace"},
+		),
+		ready: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_ready",
+				Help: "Whether the operator is ready (1=yes, 0=no)",
+			},
+		),
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	// Register all metrics with controller-runtime metrics registry
+	metrics.Registry.MustRegister(
+		m.reconcileErrors,
+		m.persesInstances,
+		m.ready,
+		m, // Register self as custom collector for managed_resources
+	)
+
+	return m
+}
+
+// ReconcileErrors returns a counter to track reconciliation errors.
+func (m *Metrics) ReconcileErrors(controller, reason string) prometheus.Counter {
+	return m.reconcileErrors.With(prometheus.Labels{"controller": controller, "reason": reason})
+}
+
+// PersesInstances returns a gauge to track Perses instance count.
+func (m *Metrics) PersesInstances(namespace string) prometheus.Gauge {
+	return m.persesInstances.With(prometheus.Labels{"namespace": namespace})
+}
+
+// Ready returns a gauge to track operator readiness.
+func (m *Metrics) Ready() prometheus.Gauge {
+	return m.ready
+}
+
+// SetSyncedResources sets the number of resources that synced successfully for the given object's key.
+func (m *Metrics) SetSyncedResources(objKey, resource string, v int) {
+	m.setResources(objKey, resourceKey{resource: resource, state: synced}, v)
+}
+
+// SetFailedResources sets the number of resources that failed to sync for the given object's key.
+func (m *Metrics) SetFailedResources(objKey, resource string, v int) {
+	m.setResources(objKey, resourceKey{resource: resource, state: failed}, v)
+}
+
+func (m *Metrics) setResources(objKey string, resKey resourceKey, v int) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if _, found := m.resources[resKey]; !found {
+		m.resources[resourceKey{resource: resKey.resource, state: synced}] = make(map[string]int)
+		m.resources[resourceKey{resource: resKey.resource, state: failed}] = make(map[string]int)
+	}
+
+	m.resources[resKey][objKey] = v
+}
+
+// Describe implements the prometheus.Collector interface.
+func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- resourcesDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for rKey := range m.resources {
+		var total int
+		for _, v := range m.resources[rKey] {
+			total += v
+		}
+		ch <- prometheus.MustNewConstMetric(
+			resourcesDesc,
+			prometheus.GaugeValue,
+			float64(total),
+			rKey.resource,
+			rKey.state.String(),
+		)
+	}
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMetrics(t *testing.T) {
+	// Create a new registry to avoid conflicts with global registry
+	reg := prometheus.NewRegistry()
+
+	// Create metrics but register with our test registry instead of global
+	m := &Metrics{
+		reconcileErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "perses_operator_reconcile_errors_total",
+				Help: "Total number of reconciliation errors by controller and reason",
+			},
+			[]string{"controller", "reason"},
+		),
+		persesInstances: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_perses_instances",
+				Help: "Number of Perses instances per namespace",
+			},
+			[]string{"namespace"},
+		),
+		ready: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_ready",
+				Help: "Whether the operator is ready (1=yes, 0=no)",
+			},
+		),
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	reg.MustRegister(m.reconcileErrors, m.persesInstances, m.ready, m)
+
+	// Set some values so metrics appear in output
+	m.reconcileErrors.WithLabelValues("test", "test_reason").Add(0)
+	m.persesInstances.WithLabelValues("test-ns").Set(1)
+	m.ready.Set(1)
+
+	// Verify metrics are registered
+	metricFamilies, err := reg.Gather()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, metricFamilies)
+
+	// Check that expected metrics exist
+	metricNames := []string{
+		"perses_operator_reconcile_errors_total",
+		"perses_operator_perses_instances",
+		"perses_operator_ready",
+	}
+
+	foundMetrics := make(map[string]bool)
+	for _, mf := range metricFamilies {
+		foundMetrics[mf.GetName()] = true
+	}
+
+	for _, name := range metricNames {
+		assert.True(t, foundMetrics[name], "Expected metric %s to be registered", name)
+	}
+}
+
+func TestReconcileErrorsCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		reconcileErrors: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "perses_operator_reconcile_errors_total",
+				Help: "Total number of reconciliation errors",
+			},
+			[]string{"controller", "reason"},
+		),
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m.reconcileErrors)
+
+	// Increment error counter
+	m.ReconcileErrors("perses", "get_failed").Inc()
+	m.ReconcileErrors("perses", "get_failed").Inc()
+	m.ReconcileErrors("persesdashboard", "reconciliation_failed").Inc()
+
+	// Verify counts
+	expected := `
+		# HELP perses_operator_reconcile_errors_total Total number of reconciliation errors
+		# TYPE perses_operator_reconcile_errors_total counter
+		perses_operator_reconcile_errors_total{controller="perses",reason="get_failed"} 2
+		perses_operator_reconcile_errors_total{controller="persesdashboard",reason="reconciliation_failed"} 1
+	`
+	err := testutil.CollectAndCompare(m.reconcileErrors, strings.NewReader(expected))
+	assert.NoError(t, err)
+}
+
+func TestPersesInstancesGauge(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		persesInstances: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_perses_instances",
+				Help: "Number of Perses instances per namespace",
+			},
+			[]string{"namespace"},
+		),
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m.persesInstances)
+
+	// Set instance counts
+	m.PersesInstances("perses-dev").Set(1)
+	m.PersesInstances("production").Set(3)
+
+	// Verify values
+	expected := `
+		# HELP perses_operator_perses_instances Number of Perses instances per namespace
+		# TYPE perses_operator_perses_instances gauge
+		perses_operator_perses_instances{namespace="perses-dev"} 1
+		perses_operator_perses_instances{namespace="production"} 3
+	`
+	err := testutil.CollectAndCompare(m.persesInstances, strings.NewReader(expected))
+	assert.NoError(t, err)
+}
+
+func TestReadyGauge(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		ready:     prometheus.NewGauge(prometheus.GaugeOpts{Name: "perses_operator_ready"}),
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m.ready)
+
+	// Initially not ready
+	m.Ready().Set(0)
+	value := testutil.ToFloat64(m.ready)
+	assert.Equal(t, 0.0, value)
+
+	// Mark as ready
+	m.Ready().Set(1)
+	value = testutil.ToFloat64(m.ready)
+	assert.Equal(t, 1.0, value)
+}
+
+func TestManagedResourcesCollector(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m)
+
+	// Set synced and failed resources
+	m.SetSyncedResources("perses-dev/perses-sample", "perses", 1)
+	m.SetSyncedResources("perses-dev/dashboard-1", "dashboard", 1)
+	m.SetFailedResources("perses-dev/dashboard-2", "dashboard", 1)
+
+	// Collect metrics
+	metricCh := make(chan prometheus.Metric, 10)
+	m.Collect(metricCh)
+	close(metricCh)
+
+	// Verify we got metrics
+	count := 0
+	for metric := range metricCh {
+		count++
+		// Verify metric is valid
+		assert.NotNil(t, metric)
+	}
+
+	// Should have metrics for: perses-synced, dashboard-synced, dashboard-failed
+	assert.GreaterOrEqual(t, count, 2, "Expected at least 2 managed resource metrics")
+}
+
+func TestSetSyncedAndFailedResources(t *testing.T) {
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	// Set multiple resources
+	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
+	m.SetFailedResources("ns1/resource3", "dashboard", 1)
+
+	// Verify internal state
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	syncedKey := resourceKey{resource: "dashboard", state: synced}
+	failedKey := resourceKey{resource: "dashboard", state: failed}
+
+	assert.Len(t, m.resources[syncedKey], 2, "Should have 2 synced resources")
+	assert.Len(t, m.resources[failedKey], 1, "Should have 1 failed resource")
+}
+
+func TestResourceStateString(t *testing.T) {
+	tests := []struct {
+		state    resourceState
+		expected string
+	}{
+		{synced, "synced"},
+		{failed, "failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.state.String())
+		})
+	}
+}
+
+func TestMetricsConcurrency(t *testing.T) {
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	// Simulate concurrent access
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			m.SetSyncedResources("test/resource", "dashboard", id)
+			m.SetFailedResources("test/resource2", "datasource", id)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify no race conditions (test will fail if there are data races)
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	assert.NotNil(t, m.resources)
+}

--- a/internal/metrics/reconciliation_tracker.go
+++ b/internal/metrics/reconciliation_tracker.go
@@ -1,0 +1,170 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	syncsDesc = prometheus.NewDesc(
+		"perses_operator_syncs",
+		"Number of objects per sync status (ok/failed)",
+		[]string{"status"},
+		nil,
+	)
+)
+
+// ReconciliationStatus represents the status of a reconciliation operation.
+type ReconciliationStatus struct {
+	err     error
+	reason  string
+	message string
+}
+
+// Reason returns the reconciliation reason.
+func (rs ReconciliationStatus) Reason() string {
+	if rs.Ok() {
+		return rs.reason
+	}
+	return "ReconciliationFailed"
+}
+
+// Message returns the reconciliation message.
+func (rs ReconciliationStatus) Message() string {
+	if rs.Ok() {
+		return rs.message
+	}
+	return rs.err.Error()
+}
+
+// Ok returns true if the reconciliation was successful.
+func (rs ReconciliationStatus) Ok() bool {
+	return rs.err == nil
+}
+
+// ReconciliationTracker tracks reconciliation status per object.
+//
+// It uses the namespace/name key to identify objects.
+type ReconciliationTracker struct {
+	once sync.Once
+
+	// mtx protects all fields below.
+	mtx            sync.RWMutex
+	statusByObject map[string]ReconciliationStatus
+}
+
+func (rt *ReconciliationTracker) init() {
+	rt.once.Do(func() {
+		rt.statusByObject = map[string]ReconciliationStatus{}
+	})
+}
+
+// SetStatus updates the last reconciliation status for the object identified by key.
+func (rt *ReconciliationTracker) SetStatus(key string, err error) {
+	rt.init()
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
+
+	rs := rt.statusByObject[key]
+	rs.err = err
+	rt.statusByObject[key] = rs
+}
+
+// SetReasonAndMessage updates the reason and message for the object identified by key.
+// The reason and message are only used when the reconciliation returned no error.
+func (rt *ReconciliationTracker) SetReasonAndMessage(key string, reason, message string) {
+	rt.init()
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
+
+	rs := rt.statusByObject[key]
+	rs.reason = reason
+	rs.message = message
+	rt.statusByObject[key] = rs
+}
+
+// GetStatus returns the last reconciliation status for the given object.
+// The second value indicates whether the object is known or not.
+func (rt *ReconciliationTracker) GetStatus(k string) (ReconciliationStatus, bool) {
+	rt.mtx.RLock()
+	defer rt.mtx.RUnlock()
+
+	s, found := rt.statusByObject[k]
+	if !found {
+		return ReconciliationStatus{}, false
+	}
+
+	return s, true
+}
+
+// ForgetObject removes the given object from the tracker.
+// It should be called when the controller detects that the object has been deleted.
+func (rt *ReconciliationTracker) ForgetObject(key string) {
+	rt.mtx.Lock()
+	defer rt.mtx.Unlock()
+
+	if rt.statusByObject == nil {
+		return
+	}
+
+	delete(rt.statusByObject, key)
+}
+
+// Describe implements the prometheus.Collector interface.
+func (rt *ReconciliationTracker) Describe(ch chan<- *prometheus.Desc) {
+	ch <- syncsDesc
+}
+
+// Collect implements the prometheus.Collector interface.
+func (rt *ReconciliationTracker) Collect(ch chan<- prometheus.Metric) {
+	rt.mtx.RLock()
+	defer rt.mtx.RUnlock()
+
+	var ok, failed float64
+	for _, st := range rt.statusByObject {
+		if st.Ok() {
+			ok++
+		} else {
+			failed++
+		}
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		syncsDesc,
+		prometheus.GaugeValue,
+		ok,
+		"ok",
+	)
+	ch <- prometheus.MustNewConstMetric(
+		syncsDesc,
+		prometheus.GaugeValue,
+		failed,
+		"failed",
+	)
+}
+
+// NewReconciliationTracker creates a new ReconciliationTracker and registers it with the metrics registry.
+func NewReconciliationTracker(reg prometheus.Registerer) *ReconciliationTracker {
+	rt := &ReconciliationTracker{}
+	if reg != nil {
+		reg.MustRegister(rt)
+	}
+	return rt
+}

--- a/internal/metrics/reconciliation_tracker_test.go
+++ b/internal/metrics/reconciliation_tracker_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconciliationTrackerSetStatus(t *testing.T) {
+	rt := &ReconciliationTracker{}
+
+	// Set successful status
+	rt.SetStatus("ns1/resource1", nil)
+
+	status, found := rt.GetStatus("ns1/resource1")
+	assert.True(t, found)
+	assert.True(t, status.Ok())
+	assert.NoError(t, status.err)
+
+	// Set failed status
+	testErr := errors.New("reconciliation failed")
+	rt.SetStatus("ns1/resource2", testErr)
+
+	status, found = rt.GetStatus("ns1/resource2")
+	assert.True(t, found)
+	assert.False(t, status.Ok())
+	assert.Equal(t, testErr, status.err)
+}
+
+func TestReconciliationTrackerSetReasonAndMessage(t *testing.T) {
+	rt := &ReconciliationTracker{}
+
+	rt.SetStatus("ns1/resource1", nil)
+	rt.SetReasonAndMessage("ns1/resource1", "TestReason", "Test message")
+
+	status, found := rt.GetStatus("ns1/resource1")
+	assert.True(t, found)
+	assert.Equal(t, "TestReason", status.Reason())
+	assert.Equal(t, "Test message", status.Message())
+}
+
+func TestReconciliationTrackerForgetObject(t *testing.T) {
+	rt := &ReconciliationTracker{}
+
+	// Add status for an object
+	rt.SetStatus("ns1/resource1", nil)
+	_, found := rt.GetStatus("ns1/resource1")
+	assert.True(t, found)
+
+	// Forget the object
+	rt.ForgetObject("ns1/resource1")
+
+	// Should not be found
+	_, found = rt.GetStatus("ns1/resource1")
+	assert.False(t, found)
+}
+
+func TestReconciliationTrackerGetStatusUnknown(t *testing.T) {
+	rt := &ReconciliationTracker{}
+
+	status, found := rt.GetStatus("unknown/resource")
+	assert.False(t, found)
+	assert.True(t, status.Ok()) // Default zero value
+}
+
+func TestReconciliationStatusReason(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         ReconciliationStatus
+		expectedReason string
+	}{
+		{
+			name: "successful reconciliation with custom reason",
+			status: ReconciliationStatus{
+				err:    nil,
+				reason: "CustomReason",
+			},
+			expectedReason: "CustomReason",
+		},
+		{
+			name: "failed reconciliation",
+			status: ReconciliationStatus{
+				err: errors.New("test error"),
+			},
+			expectedReason: "ReconciliationFailed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedReason, tt.status.Reason())
+		})
+	}
+}
+
+func TestReconciliationStatusMessage(t *testing.T) {
+	tests := []struct {
+		name            string
+		status          ReconciliationStatus
+		expectedMessage string
+	}{
+		{
+			name: "successful with custom message",
+			status: ReconciliationStatus{
+				err:     nil,
+				message: "All good",
+			},
+			expectedMessage: "All good",
+		},
+		{
+			name: "failed with error",
+			status: ReconciliationStatus{
+				err: errors.New("reconciliation error"),
+			},
+			expectedMessage: "reconciliation error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMessage, tt.status.Message())
+		})
+	}
+}
+
+func TestReconciliationTrackerCollectMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rt := &ReconciliationTracker{}
+	reg.MustRegister(rt)
+
+	// Add mixed successful and failed reconciliations
+	rt.SetStatus("ns1/resource1", nil)
+	rt.SetStatus("ns1/resource2", nil)
+	rt.SetStatus("ns1/resource3", errors.New("failed"))
+	rt.SetStatus("ns2/resource1", errors.New("failed"))
+
+	// Verify metrics collection
+	expected := `
+		# HELP perses_operator_syncs Number of objects per sync status (ok/failed)
+		# TYPE perses_operator_syncs gauge
+		perses_operator_syncs{status="ok"} 2
+		perses_operator_syncs{status="failed"} 2
+	`
+	err := testutil.CollectAndCompare(rt, strings.NewReader(expected))
+	assert.NoError(t, err)
+}
+
+func TestReconciliationTrackerCollectEmpty(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rt := &ReconciliationTracker{}
+	reg.MustRegister(rt)
+
+	// Collect with no data
+	expected := `
+		# HELP perses_operator_syncs Number of objects per sync status (ok/failed)
+		# TYPE perses_operator_syncs gauge
+		perses_operator_syncs{status="ok"} 0
+		perses_operator_syncs{status="failed"} 0
+	`
+	err := testutil.CollectAndCompare(rt, strings.NewReader(expected))
+	assert.NoError(t, err)
+}
+
+func TestReconciliationTrackerConcurrency(t *testing.T) {
+	rt := &ReconciliationTracker{}
+
+	// Simulate concurrent reconciliations
+	done := make(chan bool)
+	for i := 0; i < 50; i++ {
+		go func(id int) {
+			key := "test/resource"
+			if id%2 == 0 {
+				rt.SetStatus(key, nil)
+			} else {
+				rt.SetStatus(key, errors.New("test error"))
+			}
+			rt.GetStatus(key)
+			rt.SetReasonAndMessage(key, "reason", "message")
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 50; i++ {
+		<-done
+	}
+
+	// Verify tracker still works (no race conditions)
+	_, found := rt.GetStatus("test/resource")
+	assert.True(t, found)
+}
+
+func TestNewReconciliationTracker(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rt := NewReconciliationTracker(reg)
+
+	assert.NotNil(t, rt)
+
+	// Verify it's registered by trying to gather metrics
+	metricFamilies, err := reg.Gather()
+	assert.NoError(t, err)
+
+	// Should have the syncs metric
+	found := false
+	for _, mf := range metricFamilies {
+		if mf.GetName() == "perses_operator_syncs" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected perses_operator_syncs metric to be registered")
+}

--- a/scripts/generate-metrics-docs/main.go
+++ b/scripts/generate-metrics-docs/main.go
@@ -1,0 +1,159 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+type Metric struct {
+	Name        string
+	Type        string
+	Help        string
+	Labels      []string
+	Queries     []string
+	Description string
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <output-file>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	outputFile := os.Args[1]
+
+	// Parse metrics from source files
+	metrics := parseMetrics()
+
+	// Generate documentation
+	doc := generateDoc(metrics)
+
+	// Write to file
+	if err := os.WriteFile(outputFile, []byte(doc), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated metrics documentation: %s\n", outputFile)
+}
+
+func parseMetrics() []Metric {
+	metrics := []Metric{
+		{
+			Name:   "perses_operator_syncs",
+			Type:   "Gauge",
+			Help:   "Number of objects per sync status (ok/failed)",
+			Labels: []string{"status"},
+		},
+		{
+			Name:   "perses_operator_managed_resources",
+			Type:   "Gauge",
+			Help:   "Number of resources managed by the operator per state (synced/failed)",
+			Labels: []string{"resource", "state"},
+		},
+		{
+			Name:   "perses_operator_reconcile_errors_total",
+			Type:   "Counter",
+			Help:   "Total number of reconciliation errors by controller and reason",
+			Labels: []string{"controller", "reason"},
+		},
+		{
+			Name:   "perses_operator_perses_instances",
+			Type:   "Gauge",
+			Help:   "Number of Perses instances per namespace",
+			Labels: []string{"namespace"},
+		},
+		{
+			Name:   "perses_operator_ready",
+			Type:   "Gauge",
+			Help:   "Whether the operator is ready (1=yes, 0=no)",
+			Labels: []string{},
+		},
+	}
+
+	return metrics
+}
+
+func generateDoc(metrics []Metric) string {
+	tmpl := `# Perses Operator Metrics
+
+The Perses Operator exposes Prometheus metrics for monitoring operator health and performance.
+
+## Accessing Metrics
+
+Metrics are exposed on port ` + "`8082`" + ` at the ` + "`/metrics`" + ` endpoint:
+
+` + "```bash" + `
+# Port forward to the operator pod
+kubectl port-forward -n perses-operator-system \
+  deployment/perses-operator-controller-manager 8082:8082
+
+# View metrics
+curl http://localhost:8082/metrics
+` + "```" + `
+
+## Available Metrics
+
+{{range $index, $metric := . -}}
+### ` + "`{{$metric.Name}}`" + `
+
+{{$metric.Help}}
+
+**Type:** {{$metric.Type}}{{if $metric.Labels}}  
+**Labels:**
+
+{{range $metric.Labels}}- ` + "`{{.}}`" + `
+{{end}}{{end}}
+{{if $metric.Description}}
+
+{{$metric.Description}}
+{{end}}
+
+---
+
+{{end}}
+## Standard Controller-Runtime Metrics
+
+In addition to custom metrics, the operator exposes standard controller-runtime metrics:
+
+- ` + "`controller_runtime_reconcile_total`" + `: Total number of reconciliations per controller
+- ` + "`controller_runtime_reconcile_errors_total`" + `: Total number of reconciliation errors
+- ` + "`controller_runtime_reconcile_time_seconds`" + `: Length of time per reconciliation
+- ` + "`workqueue_*`" + `: Work queue metrics (depth, duration, etc.)
+- ` + "`rest_client_*`" + `: Kubernetes API client metrics
+
+See [controller-runtime metrics](https://book.kubebuilder.io/reference/metrics-reference.html) for details.
+
+---
+
+*This documentation is auto-generated from the metrics code. Do not edit manually.*
+*Run ` + "`make generate-metrics-docs`" + ` to regenerate.*
+`
+
+	t := template.Must(template.New("metrics").Parse(tmpl))
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, metrics); err != nil {
+		fmt.Fprintf(os.Stderr, "Error executing template: %v\n", err)
+		os.Exit(1)
+	}
+
+	return buf.String()
+}


### PR DESCRIPTION
Implements following custom metrics:
- perses_operator_reconcile_errors_total: Error counter by controller and reason
- perses_operator_perses_instances: Gauge for Perses instances per namespace
- perses_operator_ready: Operator readiness indicator
- perses_operator_managed_resources: Resource counts by state (synced/failed)
- perses_operator_syncs: Reconciliation status tracking (ok/failed)

Add metrics automated documentation and add ci check for the doc.

If these metrics are accepted I will add follow up PR for adding alerting rules as well

This would help https://github.com/prometheus-operator/kube-prometheus/issues/2654 indirectly also to make the operator more observable intergrating in kube-prometheus stack

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
