### PR TITLE
[IGNORE] rename 'namespace' metric label to resource_namespace'

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -58,14 +58,14 @@ Total number of reconciliation errors by controller and reason
 
 ---
 
-### `perses_operator_perses_instances`
+### `perses_operator_managed_perses_instances`
 
-Number of Perses instances per namespace
+Number of Perses instances managed by the operator
 
 **Type:** Gauge  
 **Labels:**
 
-- `namespace`
+- `resource_namespace`
 
 
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -82,10 +82,10 @@ func NewMetrics() *Metrics {
 		),
 		persesInstances: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "perses_operator_perses_instances",
-				Help: "Number of Perses instances per namespace",
+				Name: "perses_operator_managed_perses_instances",
+				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"namespace"},
+			[]string{"resource_namespace"},
 		),
 		ready: prometheus.NewGauge(
 			prometheus.GaugeOpts{
@@ -114,7 +114,7 @@ func (m *Metrics) ReconcileErrors(controller, reason string) prometheus.Counter 
 
 // PersesInstances returns a gauge to track Perses instance count.
 func (m *Metrics) PersesInstances(namespace string) prometheus.Gauge {
-	return m.persesInstances.With(prometheus.Labels{"namespace": namespace})
+	return m.persesInstances.With(prometheus.Labels{"resource_namespace": namespace})
 }
 
 // Ready returns a gauge to track operator readiness.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -40,10 +40,10 @@ func TestNewMetrics(t *testing.T) {
 		),
 		persesInstances: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "perses_operator_perses_instances",
-				Help: "Number of Perses instances per namespace",
+				Name: "perses_operator_managed_perses_instances",
+				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"namespace"},
+			[]string{"resource_namespace"},
 		),
 		ready: prometheus.NewGauge(
 			prometheus.GaugeOpts{
@@ -69,7 +69,7 @@ func TestNewMetrics(t *testing.T) {
 	// Check that expected metrics exist
 	metricNames := []string{
 		"perses_operator_reconcile_errors_total",
-		"perses_operator_perses_instances",
+		"perses_operator_managed_perses_instances",
 		"perses_operator_ready",
 	}
 
@@ -118,10 +118,10 @@ func TestPersesInstancesGauge(t *testing.T) {
 	m := &Metrics{
 		persesInstances: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "perses_operator_perses_instances",
-				Help: "Number of Perses instances per namespace",
+				Name: "perses_operator_managed_perses_instances",
+				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"namespace"},
+			[]string{"resource_namespace"},
 		),
 		resources: make(map[resourceKey]map[string]int),
 	}
@@ -133,10 +133,10 @@ func TestPersesInstancesGauge(t *testing.T) {
 
 	// Verify values
 	expected := `
-		# HELP perses_operator_perses_instances Number of Perses instances per namespace
-		# TYPE perses_operator_perses_instances gauge
-		perses_operator_perses_instances{namespace="perses-dev"} 1
-		perses_operator_perses_instances{namespace="production"} 3
+		# HELP perses_operator_managed_perses_instances Number of Perses instances managed by the operator
+		# TYPE perses_operator_managed_perses_instances gauge
+		perses_operator_managed_perses_instances{resource_namespace="perses-dev"} 1
+		perses_operator_managed_perses_instances{resource_namespace="production"} 3
 	`
 	err := testutil.CollectAndCompare(m.persesInstances, strings.NewReader(expected))
 	assert.NoError(t, err)

--- a/scripts/generate-metrics-docs/main.go
+++ b/scripts/generate-metrics-docs/main.go
@@ -76,10 +76,10 @@ func parseMetrics() []Metric {
 			Labels: []string{"controller", "reason"},
 		},
 		{
-			Name:   "perses_operator_perses_instances",
+			Name:   "perses_operator_managed_perses_instances",
 			Type:   "Gauge",
-			Help:   "Number of Perses instances per namespace",
-			Labels: []string{"namespace"},
+			Help:   "Number of Perses instances managed by the operator",
+			Labels: []string{"resource_namespace"},
 		},
 		{
 			Name:   "perses_operator_ready",


### PR DESCRIPTION
The 'namespace' label conflicts with Prometheus Kubernetes servicediscovery, which automatically adds a 'namespace' label from the ServiceMonitor target. Rename to 'resource_namespace' to avoid collision and ambiguity in metric queries.

Also rename metric from `perses_operator_perses_instances` to
`perses_operator_managed_perses_instances` to highlight these
are operator-managed resources.

@jan--f helped me to identify the issue

Keeping this under IGNORE since this is not yet released

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
