### PR TITLE
[FEATURE] Add kuttl e2e tests and split unit/integration test targets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ Closes: #ISSUE-NUMBER
 
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated
+- [ ] E2E tests added/updated
 - [ ] Manual testing performed
 
 ## Checklist

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,52 @@
+name: e2e
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/*
+      - snapshot/*
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
+
+jobs:
+  e2e:
+    name: "kuttl e2e tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.13.0
+        with:
+          cluster_name: kuttl-e2e
+          node_image: kindest/node:v1.34.3@sha256:08497ee19eace7b4b5348db5c6a1591d7752b164530a36f855cb0f2bdcbadd48
+          wait: 5m
+      - name: Deploy operator
+        run: make e2e-deploy
+      - name: Run e2e tests
+        run: make test-e2e
+      - name: Collect debug info on failure
+        if: failure()
+        run: |
+          echo "=== Operator logs ==="
+          kubectl logs -n perses-operator-system deployment/perses-operator-controller-manager --tail=200 || true
+          echo ""
+          echo "=== Events ==="
+          kubectl get events -A --sort-by='.lastTimestamp' | tail -50 || true
+          echo ""
+          echo "=== Perses resources ==="
+          kubectl get perses,persesdashboard,persesdatasource,persesglobaldatasource -A -o wide || true
+          echo ""
+          echo "=== Pods ==="
+          kubectl get pods -A || true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,8 +29,8 @@ jobs:
         run: make checkformat
       - name: check go.mod
         run: make checkunused
-  test:
-    name: 'tests'
+  test-unit:
+    name: 'unit tests'
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -39,8 +39,20 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
-      - name: test
-        run: make test
+      - name: unit tests
+        run: make test-unit
+  test-integration:
+    name: 'integration tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+      - name: integration tests
+        run: make test-integration
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -23,14 +23,14 @@ KUSTOMIZE = $(LOCALBIN)/kustomize
 KUSTOMIZE_VERSION = v3.8.7
 
 CONTROLLER_GEN = $(LOCALBIN)/controller-gen
-CONTROLLER_TOOLS_VERSION = v0.19.0
+CONTROLLER_TOOLS_VERSION = v0.20.0
 
 GOJSONTOYAML_BINARY = $(LOCALBIN)/gojsontoyaml
 GOJSONTOYAML_VERSION = v0.1.0
 
 ENVTEST = $(LOCALBIN)/setup-envtest
-ENVTEST_VERSION = release-0.19  # Version of setup-envtest binary
-ENVTEST_K8S_VERSION = 1.31.0    # Kubernetes version for test assets
+ENVTEST_VERSION = release-0.22  # Version of setup-envtest binary
+ENVTEST_K8S_VERSION = 1.34.0    # Kubernetes version for test assets
 
 JSONNET_BINARY = $(LOCALBIN)/jsonnet
 JSONNET_VERSION = v0.21.0
@@ -55,6 +55,9 @@ OPERATOR_SDK_VERSION = v1.42.0
 
 OPM = $(LOCALBIN)/opm
 OPM_VERSION = v1.23.0
+
+KUTTL = $(LOCALBIN)/kubectl-kuttl
+KUTTL_VERSION = 0.19.0
 
 ## Kustomize - uses custom install script
 KUSTOMIZE_INSTALL_SCRIPT = https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh
@@ -163,6 +166,17 @@ $(OPM) opm: $(LOCALBIN) ## Install opm locally if necessary.
 		chmod +x $(OPM) ;\
 	}
 
+.PHONY: kuttl
+$(KUTTL) kuttl: $(LOCALBIN) ## Install kubectl-kuttl locally if necessary.
+	@{ \
+		set -ex ;\
+		[[ -f $(KUTTL) ]] && exit 0 ;\
+		OS=$$(go env GOOS) && ARCH=$$(go env GOARCH) && \
+		[ "$${ARCH}" = "amd64" ] && ARCH="x86_64" ;\
+		curl -sSLo $(KUTTL) https://github.com/kudobuilder/kuttl/releases/download/v$(KUTTL_VERSION)/kubectl-kuttl_$(KUTTL_VERSION)_$${OS}_$${ARCH} ;\
+		chmod +x $(KUTTL) ;\
+	}
+
 .PHONY: build-tools
 build-tools: ## Install all tools.
 build-tools: $(KUSTOMIZE) \
@@ -176,7 +190,8 @@ build-tools: $(KUSTOMIZE) \
 		$(CRD_REF_DOCS) \
 		$(ENVTEST) \
 		$(OPERATOR_SDK) \
-		$(OPM)
+		$(OPM) \
+		$(KUTTL)
 
 
 .PHONY: clean-tools
@@ -198,4 +213,5 @@ validate-tools: build-tools ## Validate that all tools are installed and working
 	@echo -n "  setup-envtest: " && [ -x $(ENVTEST) ] && echo "installed" || echo "missing"
 	@echo -n "  operator-sdk: " && $(OPERATOR_SDK) version 2>&1 | head -n 1
 	@echo -n "  opm: " && $(OPM) version 2>&1 | head -n 1
+	@echo -n "  kuttl: " && $(KUTTL) version 2>&1 | head -n 1
 	@echo "✅ All tools validated successfully!"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ make undeploy
 - [API Docs](docs/api.md)
 - [Metrics Documentation](docs/metrics.md)
 - [Developer Docs](docs/dev.md)
+- [Testing](docs/testing.md)
 - Sample CRDs
   - [Kubernetes](config/samples)
   - [OpenShift](config/samples/openshift)
@@ -87,7 +88,7 @@ make undeploy
 
 ## License
 
-Copyright 2025 The Perses Authors.
+Copyright The Perses Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: perses.perses.dev
 spec:
   group: perses.dev

--- a/config/crd/bases/perses.dev_persesdashboards.yaml
+++ b/config/crd/bases/perses.dev_persesdashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdashboards.perses.dev
 spec:
   group: perses.dev

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdatasources.perses.dev
 spec:
   group: perses.dev

--- a/config/crd/bases/perses.dev_persesglobaldatasources.yaml
+++ b/config/crd/bases/perses.dev_persesglobaldatasources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesglobaldatasources.perses.dev
 spec:
   group: perses.dev

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,93 @@
+# Testing
+
+## Unit and Integration Tests
+
+| Target | Description |
+| ------ | ----------- |
+| `make test-unit` | Run unit tests only (no envtest, fast) |
+| `make test-integration` | Run controller integration tests with [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest) |
+
+Unit tests (`internal/`, `api/`, `scripts/`) use standard Go testing with [testify](https://github.com/stretchr/testify) or [Ginkgo](https://onsi.github.io/ginkgo/).
+
+Integration tests (`controllers/`) use [Ginkgo](https://onsi.github.io/ginkgo/) with envtest to spin up a lightweight API server with CRDs installed.
+
+## E2E Tests (kuttl)
+
+E2E tests use [kuttl](https://kuttl.dev/) to validate the operator in a real [kind](https://kind.sigs.k8s.io/) cluster.
+
+### Prerequisites
+
+- [Go](https://go.dev/doc/install)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/docs/installation)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+### Makefile Targets
+
+| Target | Description |
+| ------ | ----------- |
+| `make e2e-setup` | Create kind cluster and deploy operator |
+| `make e2e-create-cluster` | Create kind cluster only |
+| `make e2e-deploy` | Build image, load into kind, and deploy (requires existing cluster) |
+| `make test-e2e` | Run kuttl tests (requires operator to be deployed) |
+| `make e2e-cleanup` | Delete the kind cluster |
+
+### Quick Start
+
+```bash
+make e2e-setup    # Create cluster + deploy operator
+make test-e2e     # Run tests
+make e2e-cleanup  # Tear down
+```
+
+When iterating, run `make e2e-setup` once, then repeat `make test-e2e`. Use `make e2e-deploy` to redeploy after operator code changes without recreating the cluster.
+
+### Configuration
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `KIND_CLUSTER_NAME` | `kuttl-e2e` | Name of the kind cluster |
+| `E2E_TAG` | Git short SHA | Image tag for the operator |
+| `E2E_IMG` | `docker.io/persesdev/perses-operator:<E2E_TAG>` | Full operator image reference |
+
+### Test Structure
+
+Tests are under `test/e2e/` following the [kuttl convention](https://kuttl.dev/docs/kuttl-test-harness.html). Kuttl creates a random namespace per test case for isolation. Steps run sequentially.
+
+```text
+test/e2e/
+├── kuttl-test.yaml
+├── perses-statefulset/   # database.file → StatefulSet
+│   ├── 00-install.yaml   # Create Perses instance, assert StatefulSet + sub-resources
+│   ├── 00-assert.yaml
+│   ├── 01-assert.yaml    # Assert pod readiness
+│   ├── 02-install.yaml   # Create PersesDatasource, assert reconciled
+│   ├── 02-assert.yaml
+│   ├── 03-install.yaml   # Create PersesDashboard, assert reconciled
+│   ├── 03-assert.yaml
+│   ├── 04-delete.yaml    # Delete all, assert cleanup
+│   └── 04-assert.yaml
+└── perses-deployment/    # database.sql → Deployment
+    ├── 00-install.yaml   # Create Perses instance with SQL config, assert Deployment + sub-resources
+    ├── 00-assert.yaml
+    ├── 01-delete.yaml    # Delete all, assert cleanup
+    └── 01-assert.yaml
+```
+
+To add a new test case, create a directory under `test/e2e/`. To add steps to an existing test case, add numbered files (e.g. `05-install.yaml`, `05-assert.yaml`).
+
+### Debugging
+
+```bash
+# Operator logs
+kubectl logs -n perses-operator-system deployment/perses-operator-controller-manager -f
+
+# Events in test namespace
+kubectl get events -A --sort-by='.lastTimestamp' | tail -50
+
+# All Perses resources
+kubectl get perses,persesdashboard,persesdatasource -A
+
+# Run a single test case
+bin/kubectl-kuttl test --config test/e2e/kuttl-test.yaml --test perses-statefulset
+```

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: perses.perses.dev
 spec:
   group: perses.dev

--- a/jsonnet/examples/0persesdashboardsCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdashboardsCustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdashboards.perses.dev
 spec:
   group: perses.dev

--- a/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdatasources.perses.dev
 spec:
   group: perses.dev

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.19.0"
+      "controller-gen.kubebuilder.io/version": "v0.20.0"
     },
     "name": "perses.perses.dev"
   },

--- a/jsonnet/generated/perses.dev_persesdashboards-crd.json
+++ b/jsonnet/generated/perses.dev_persesdashboards-crd.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.19.0"
+      "controller-gen.kubebuilder.io/version": "v0.20.0"
     },
     "name": "persesdashboards.perses.dev"
   },

--- a/jsonnet/generated/perses.dev_persesdatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesdatasources-crd.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.19.0"
+      "controller-gen.kubebuilder.io/version": "v0.20.0"
     },
     "name": "persesdatasources.perses.dev"
   },

--- a/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
@@ -3,7 +3,7 @@
   "kind": "CustomResourceDefinition",
   "metadata": {
     "annotations": {
-      "controller-gen.kubebuilder.io/version": "v0.19.0"
+      "controller-gen.kubebuilder.io/version": "v0.20.0"
     },
     "name": "persesglobaldatasources.perses.dev"
   },

--- a/test/e2e/kuttl-test.yaml
+++ b/test/e2e/kuttl-test.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+testDirs:
+  - ./test/e2e
+startControlPlane: false
+timeout: 300
+parallel: 1

--- a/test/e2e/perses-deployment/00-assert.yaml
+++ b/test/e2e/perses-deployment/00-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-sql-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-sql-test-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses-sql-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perses-sql-test

--- a/test/e2e/perses-deployment/00-install.yaml
+++ b/test/e2e/perses-deployment/00-install.yaml
@@ -1,0 +1,38 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-sql-test
+spec:
+  metadata:
+    labels:
+      instance: perses-sql-test
+  config:
+    database:
+      sql:
+        user: "root"
+        password: "e2e-test-password"
+        db_name: "perses"
+        net: "tcp"
+        addr: "mysql:3306"
+        allow_all_files: false
+        allow_cleartext_passwords: false
+        allow_fallback_to_plaintext: false
+        allow_native_passwords: true
+        allow_old_passwords: false
+        case_sensitive: false
+        check_conn_liveness: true
+        client_found_rows: false
+        columns_with_alias: false
+        interpolate_params: false
+        max_allowed_packet: 67108864
+        multi_statements: false
+        parse_time: true
+        read_timeout: "30s"
+        reject_read_only: false
+        server_pub_key: ""
+        timeout: "10s"
+        write_timeout: "30s"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/perses-deployment/01-assert.yaml
+++ b/test/e2e/perses-deployment/01-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-sql-test -n $NAMESPACE --timeout=60s

--- a/test/e2e/perses-deployment/01-delete.yaml
+++ b/test/e2e/perses-deployment/01-delete.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-sql-test

--- a/test/e2e/perses-statefulset/00-assert.yaml
+++ b/test/e2e/perses-statefulset/00-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-e2e-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-e2e-test-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses-e2e-test
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-e2e-test

--- a/test/e2e/perses-statefulset/00-install.yaml
+++ b/test/e2e/perses-statefulset/00-install.yaml
@@ -1,0 +1,17 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-e2e-test
+spec:
+  metadata:
+    labels:
+      instance: perses-e2e-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/perses-statefulset/01-assert.yaml
+++ b/test/e2e/perses-statefulset/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-e2e-test
+status:
+  readyReplicas: 1

--- a/test/e2e/perses-statefulset/02-assert.yaml
+++ b/test/e2e/perses-statefulset/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdatasource e2e-datasource -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/perses-statefulset/02-install.yaml
+++ b/test/e2e/perses-statefulset/02-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDatasource
+metadata:
+  name: e2e-datasource
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-e2e-test
+  config:
+    display:
+      name: "E2E Test Datasource"
+    default: true
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        directUrl: "https://prometheus.demo.prometheus.io"

--- a/test/e2e/perses-statefulset/03-assert.yaml
+++ b/test/e2e/perses-statefulset/03-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdashboard e2e-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/perses-statefulset/03-install.yaml
+++ b/test/e2e/perses-statefulset/03-install.yaml
@@ -1,0 +1,42 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: e2e-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-e2e-test
+  config:
+    display:
+      name: E2E Test Dashboard
+    duration: 5m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Test Panel
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"

--- a/test/e2e/perses-statefulset/04-assert.yaml
+++ b/test/e2e/perses-statefulset/04-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-e2e-test -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdashboard/e2e-dashboard -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdatasource/e2e-datasource -n $NAMESPACE --timeout=60s

--- a/test/e2e/perses-statefulset/04-delete.yaml
+++ b/test/e2e/perses-statefulset/04-delete.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDashboard
+    metadata:
+      name: e2e-dashboard
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDatasource
+    metadata:
+      name: e2e-datasource
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-e2e-test


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Add kuttl e2e tests for StatefulSet (file DB) and Deployment (SQL DB) paths
- Add Makefile targets: e2e-setup, e2e-deploy, test-e2e, e2e-cleanup
- Add GitHub Actions e2e workflow with Kind cluster (k8s 1.34)
- Split `make test` into `make test-unit` and `make test-integration`
- Align ENVTEST_VERSION (release-0.22) with controller-runtime v0.22.3
- Add docs/testing.md and link from README

Closes #276

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
