### PR TITLE
[BUGFIX]: Sync dashboards across multiple Perses instances

### DIFF
--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -27,6 +27,7 @@ import (
 	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
 
 	logger "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,6 +78,10 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 	}
 
 	for _, persesInstance := range persesInstances.Items {
+		if !meta.IsStatusConditionTrue(persesInstance.Status.Conditions, common.TypeAvailablePerses) {
+			dlog.Infof("Skipping Perses instance %s/%s (not yet available)", persesInstance.Namespace, persesInstance.Name)
+			continue
+		}
 		if res, reason, err := r.syncPersesDashboard(ctx, persesInstance, dashboard); subreconciler.ShouldHaltOrRequeue(res, err) {
 			return r.setStatusToDegraded(ctx, req, res, reason, err)
 		}

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -75,6 +75,24 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 
 				err = k8sClient.Create(ctx, perses)
 				Expect(err).To(Not(HaveOccurred()))
+
+				// Set the Perses instance status to Available so child controllers
+				// consider it ready for syncing.
+				// Use Eventually to handle potential resource version conflicts
+				Eventually(func() error {
+					// Fetch the latest version of the resource
+					if err := k8sClient.Get(ctx, persesNamespaceName, perses); err != nil {
+						return err
+					}
+					perses.Status.Conditions = []metav1.Condition{{
+						Type:               common.TypeAvailablePerses,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Testing",
+						Message:            "Available for testing",
+						LastTransitionTime: metav1.Now(),
+					}}
+					return k8sClient.Status().Update(ctx, perses)
+				}, time.Second*10, time.Millisecond*250).Should(Succeed())
 			}
 
 			newSecret = &persesv1.GlobalSecret{

--- a/test/e2e/multi-instance-sync/00-assert.yaml
+++ b/test/e2e/multi-instance-sync/00-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-1
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-instance-1-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses-instance-1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-instance-1

--- a/test/e2e/multi-instance-sync/00-install.yaml
+++ b/test/e2e/multi-instance-sync/00-install.yaml
@@ -1,0 +1,14 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-1
+spec:
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/multi-instance-sync/01-assert.yaml
+++ b/test/e2e/multi-instance-sync/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-instance-1
+status:
+  readyReplicas: 1

--- a/test/e2e/multi-instance-sync/02-assert.yaml
+++ b/test/e2e/multi-instance-sync/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdashboard sync-test-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/multi-instance-sync/02-install.yaml
+++ b/test/e2e/multi-instance-sync/02-install.yaml
@@ -1,0 +1,39 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: sync-test-dashboard
+spec:
+  config:
+    display:
+      name: Sync Test Dashboard
+    duration: 5m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Test Panel
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"

--- a/test/e2e/multi-instance-sync/03-assert.yaml
+++ b/test/e2e/multi-instance-sync/03-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-instance-2
+status:
+  readyReplicas: 1

--- a/test/e2e/multi-instance-sync/03-install.yaml
+++ b/test/e2e/multi-instance-sync/03-install.yaml
@@ -1,0 +1,14 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-2
+spec:
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/multi-instance-sync/04-assert.yaml
+++ b/test/e2e/multi-instance-sync/04-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  # Verify that the dashboard created in step 02 is available on the
+  # second Perses instance created in step 03.
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-instance-2 18080:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18080/api/v1/projects/$NAMESPACE/dashboards/sync-test-dashboard) || {
+        echo "FAIL: Dashboard not synced to perses-instance-2"
+        exit 1
+      }
+      echo "Dashboard found on perses-instance-2:"
+      echo "$RESULT"

--- a/test/e2e/multi-instance-sync/05-assert.yaml
+++ b/test/e2e/multi-instance-sync/05-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-instance-1 -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete perses/perses-instance-2 -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdashboard/sync-test-dashboard -n $NAMESPACE --timeout=60s

--- a/test/e2e/multi-instance-sync/05-delete.yaml
+++ b/test/e2e/multi-instance-sync/05-delete.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDashboard
+    metadata:
+      name: sync-test-dashboard
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-instance-1
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-instance-2

--- a/test/e2e/namespace-isolation/00-assert.yaml
+++ b/test/e2e/namespace-isolation/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perses-test-ns-a
+status:
+  phase: Active
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perses-test-ns-b
+status:
+  phase: Active

--- a/test/e2e/namespace-isolation/00-install.yaml
+++ b/test/e2e/namespace-isolation/00-install.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perses-test-ns-a
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perses-test-ns-b

--- a/test/e2e/namespace-isolation/01-assert.yaml
+++ b/test/e2e/namespace-isolation/01-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-a
+  namespace: perses-test-ns-a
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-b
+  namespace: perses-test-ns-b
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled

--- a/test/e2e/namespace-isolation/01-install.yaml
+++ b/test/e2e/namespace-isolation/01-install.yaml
@@ -1,0 +1,35 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-a
+  namespace: perses-test-ns-a
+  labels:
+    env: team-a
+spec:
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi
+---
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-instance-b
+  namespace: perses-test-ns-b
+  labels:
+    env: team-b
+spec:
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/namespace-isolation/02-assert.yaml
+++ b/test/e2e/namespace-isolation/02-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdashboard dashboard-in-ns-a -n perses-test-ns-a -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled
+  - script: kubectl get persesdatasource datasource-in-ns-b -n perses-test-ns-b -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/namespace-isolation/02-install.yaml
+++ b/test/e2e/namespace-isolation/02-install.yaml
@@ -1,0 +1,61 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: dashboard-in-ns-a
+  namespace: perses-test-ns-a
+spec:
+  instanceSelector:
+    matchLabels:
+      env: team-a
+  config:
+    display:
+      name: Dashboard in Namespace A
+    duration: 5m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Test Panel A
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesDatasource
+metadata:
+  name: datasource-in-ns-b
+  namespace: perses-test-ns-b
+spec:
+  instanceSelector:
+    matchLabels:
+      env: team-b
+  config:
+    display:
+      name: Datasource in Namespace B
+    default: true
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        directUrl: http://prometheus.perses-test-ns-b.svc:9090

--- a/test/e2e/namespace-isolation/03-assert.yaml
+++ b/test/e2e/namespace-isolation/03-assert.yaml
@@ -1,0 +1,53 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  # Verify dashboard-in-ns-a exists in perses-instance-a (matching label env=team-a)
+  - script: |
+      kubectl port-forward -n perses-test-ns-a svc/perses-instance-a 18080:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18080/api/v1/projects/perses-test-ns-a/dashboards/dashboard-in-ns-a) || {
+        echo "FAIL: Dashboard dashboard-in-ns-a not found in perses-instance-a (matching label)"
+        exit 1
+      }
+      echo "✓ Dashboard dashboard-in-ns-a found in perses-instance-a (instance selector working)"
+
+  # Verify dashboard-in-ns-a does NOT exist in perses-instance-b (non-matching label env=team-b)
+  - script: |
+      kubectl port-forward -n perses-test-ns-b svc/perses-instance-b 18081:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      # This should fail (return non-zero) because the dashboard's instanceSelector doesn't match
+      if curl -sf http://localhost:18081/api/v1/projects/perses-test-ns-a/dashboards/dashboard-in-ns-a >/dev/null 2>&1; then
+        echo "FAIL: Dashboard dashboard-in-ns-a incorrectly synced to perses-instance-b (non-matching label)"
+        exit 1
+      fi
+      echo "✓ Dashboard dashboard-in-ns-a correctly NOT in perses-instance-b (instance selector working)"
+
+  # Verify datasource-in-ns-b exists in perses-instance-b (matching label env=team-b)
+  - script: |
+      kubectl port-forward -n perses-test-ns-b svc/perses-instance-b 18082:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18082/api/v1/projects/perses-test-ns-b/datasources/datasource-in-ns-b) || {
+        echo "FAIL: Datasource datasource-in-ns-b not found in perses-instance-b (matching label)"
+        exit 1
+      }
+      echo "✓ Datasource datasource-in-ns-b found in perses-instance-b (instance selector working)"
+
+  # Verify datasource-in-ns-b does NOT exist in perses-instance-a (non-matching label env=team-a)
+  - script: |
+      kubectl port-forward -n perses-test-ns-a svc/perses-instance-a 18083:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      # This should fail (return non-zero) because the datasource's instanceSelector doesn't match
+      if curl -sf http://localhost:18083/api/v1/projects/perses-test-ns-b/datasources/datasource-in-ns-b >/dev/null 2>&1; then
+        echo "FAIL: Datasource datasource-in-ns-b incorrectly synced to perses-instance-a (non-matching label)"
+        exit 1
+      fi
+      echo "✓ Datasource datasource-in-ns-b correctly NOT in perses-instance-a (instance selector working)"

--- a/test/e2e/namespace-isolation/04-assert.yaml
+++ b/test/e2e/namespace-isolation/04-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-instance-a -n perses-test-ns-a --timeout=60s
+  - command: kubectl wait --for=delete perses/perses-instance-b -n perses-test-ns-b --timeout=60s

--- a/test/e2e/namespace-isolation/04-delete.yaml
+++ b/test/e2e/namespace-isolation/04-delete.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl delete persesdashboard dashboard-in-ns-a -n perses-test-ns-a --ignore-not-found
+  - command: kubectl delete persesdatasource datasource-in-ns-b -n perses-test-ns-b --ignore-not-found
+  - command: kubectl delete perses perses-instance-a -n perses-test-ns-a --ignore-not-found
+  - command: kubectl delete perses perses-instance-b -n perses-test-ns-b --ignore-not-found
+  - command: kubectl delete namespace perses-test-ns-a --ignore-not-found
+  - command: kubectl delete namespace perses-test-ns-b --ignore-not-found


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

    Previously, existing PersesDashboard, PersesDatasource, and
    PersesGlobalDatasource CRs were not synced to newly created Perses
    instances because their controllers only reconciled on CR changes.

    Add a Perses watch with predicates to each child controller that
    triggers re-reconciliation of all CRs when a Perses instance
    transitions to Available status. This ensures its API is reachable
    before attempting to sync, avoiding connection errors and exponential
    backoff from trying to reach an instance that isn't ready yet.

    Additionally, skip unavailable Perses instances in the reconcile
    loop itself as defense in depth, so that reconciliations triggered
    by other events (e.g. CR status updates) never attempt to connect
    to instances that aren't ready.

    CRs are matched to Perses instances via instanceSelector labels
    across all namespaces. If no instanceSelector is set, the CR syncs
    to all available Perses instances.

    Add e2e tests for multi-instance sync and instance selector isolation,
    and integration tests for the instance selector behavior.

Closes: #286

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
