### PR TITLE
[ENHANCEMENT] Allow to reconcile a Dashboard, globaldatasource or datasource in specific perses instances

### DIFF
--- a/test/e2e/perses-statefulset/00-install.yaml
+++ b/test/e2e/perses-statefulset/00-install.yaml
@@ -2,6 +2,8 @@ apiVersion: perses.dev/v1alpha2
 kind: Perses
 metadata:
   name: perses-e2e-test
+  labels:
+    app.kubernetes.io/instance: perses-e2e-test
 spec:
   metadata:
     labels:


### PR DESCRIPTION
## Description

Re adding https://github.com/perses/perses-operator/pull/128 that was unintentionally removed before the 0.2 release

Closes: #109

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
