### PR TITLE
[BREAKINGCHANGE] Add CEL validation for SecretSource conditional requirements

### DIFF
--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -224,6 +224,8 @@ const (
 )
 
 // SecretSource configuration for a perses secret source
+// +kubebuilder:validation:XValidation:rule="self.type != 'secret' && self.type != 'configmap' || has(self.name)",message="name is required when type is secret or configmap"
+// +kubebuilder:validation:XValidation:rule="self.type != 'secret' && self.type != 'configmap' || has(self.namespace)",message="namespace is required when type is secret or configmap"
 type SecretSource struct {
 	// Type specifies the source type for secret data (secret, configmap, or file)
 	// +required
@@ -232,10 +234,12 @@ type SecretSource struct {
 	// Name is the name of the Kubernetes Secret or ConfigMap resource
 	// Required when Type is "secret" or "configmap", ignored when Type is "file"
 	// +optional
+	// +kubebuilder:validation:MinLength=1
 	Name *string `json:"name,omitempty"`
 	// Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
 	// Required when Type is "secret" or "configmap", ignored when Type is "file"
 	// +optional
+	// +kubebuilder:validation:MinLength=1
 	Namespace *string `json:"namespace,omitempty"`
 }
 

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -3712,11 +3712,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       passwordPath:
                         description: |-
@@ -3742,6 +3744,11 @@ spec:
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
                     description: KubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -3783,11 +3790,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
                         description: Scopes specifies optional requested permissions
@@ -3813,6 +3822,11 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
                     description: TLS provides TLS/SSL configuration for secure connections
                       to Perses
@@ -3831,11 +3845,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -3855,6 +3871,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
                         description: Enable determines whether TLS is enabled for
                           connections to Perses
@@ -3878,11 +3901,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -3902,6 +3927,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:
@@ -5941,11 +5973,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
                         description: |-
@@ -5965,6 +5999,11 @@ spec:
                     - certPath
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   enable:
                     description: Enable determines whether TLS is enabled for connections
                       to Perses
@@ -5988,11 +6027,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
                         description: |-
@@ -6012,6 +6053,11 @@ spec:
                     - certPath
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                 type: object
               tolerations:
                 description: Tolerations allow pods to schedule onto nodes with matching

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -341,11 +341,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       passwordPath:
                         description: |-
@@ -371,6 +373,11 @@ spec:
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
                     description: KubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -412,11 +419,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
                         description: Scopes specifies optional requested permissions
@@ -442,6 +451,11 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
                     description: TLS provides TLS/SSL configuration for secure connections
                       to Perses
@@ -460,11 +474,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -484,6 +500,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
                         description: Enable determines whether TLS is enabled for
                           connections to Perses
@@ -507,11 +530,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -531,6 +556,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:

--- a/config/crd/bases/perses.dev_persesglobaldatasources.yaml
+++ b/config/crd/bases/perses.dev_persesglobaldatasources.yaml
@@ -54,11 +54,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       passwordPath:
                         description: |-
@@ -84,6 +86,11 @@ spec:
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
                     description: KubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -125,11 +132,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
                         description: Scopes specifies optional requested permissions
@@ -155,6 +164,11 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
                     description: TLS provides TLS/SSL configuration for secure connections
                       to Perses
@@ -173,11 +187,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -197,6 +213,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
                         description: Enable determines whether TLS is enabled for
                           connections to Perses
@@ -220,11 +243,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -244,6 +269,13 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,8 +30,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _[SecretSourceType](#secretsourcetype)_ | Type specifies the source type for secret data (secret, configmap, or file) |  | Enum: [secret configmap file] <br />Required: \{\} <br /> |
-| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
-| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
+| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
+| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
 | `username` _string_ | Username is the username credential for basic authentication |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `passwordPath` _string_ | PasswordPath specifies the key name within the secret/configmap or filesystem path<br />(depending on SecretSource.Type) where the password is stored |  | MinLength: 1 <br />Required: \{\} <br /> |
 
@@ -50,8 +50,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _[SecretSourceType](#secretsourcetype)_ | Type specifies the source type for secret data (secret, configmap, or file) |  | Enum: [secret configmap file] <br />Required: \{\} <br /> |
-| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
-| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
+| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
+| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
 | `certPath` _string_ | CertPath specifies the key name within the secret/configmap or filesystem path<br />(depending on SecretSource.Type) where the certificate is stored |  | MinLength: 1 <br />Required: \{\} <br /> |
 | `privateKeyPath` _string_ | PrivateKeyPath specifies the key name within the secret/configmap or filesystem path<br />(depending on SecretSource.Type) where the private key is stored<br />Required for client certificates (UserCert), optional for CA certificates (CaCert) |  | Optional: \{\} <br /> |
 
@@ -184,8 +184,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _[SecretSourceType](#secretsourcetype)_ | Type specifies the source type for secret data (secret, configmap, or file) |  | Enum: [secret configmap file] <br />Required: \{\} <br /> |
-| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
-| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
+| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
+| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
 | `clientIDPath` _string_ | ClientIDPath specifies the key name within the secret/configmap or filesystem path<br />(depending on SecretSource.Type) where the OAuth client ID is stored |  | Optional: \{\} <br /> |
 | `clientSecretPath` _string_ | ClientSecretPath specifies the key name within the secret/configmap or filesystem path<br />(depending on SecretSource.Type) where the OAuth client secret is stored |  | Optional: \{\} <br /> |
 | `tokenURL` _string_ | TokenURL is the OAuth 2.0 provider's token endpoint URL<br />This is a constant specific to each OAuth provider |  | MinLength: 1 <br />Required: \{\} <br /> |
@@ -483,8 +483,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _[SecretSourceType](#secretsourcetype)_ | Type specifies the source type for secret data (secret, configmap, or file) |  | Enum: [secret configmap file] <br />Required: \{\} <br /> |
-| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
-| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | Optional: \{\} <br /> |
+| `name` _string_ | Name is the name of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
+| `namespace` _string_ | Namespace is the namespace of the Kubernetes Secret or ConfigMap resource<br />Required when Type is "secret" or "configmap", ignored when Type is "file" |  | MinLength: 1 <br />Optional: \{\} <br /> |
 
 
 #### SecretSourceType

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -3516,11 +3516,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       passwordPath:
                         description: |-
@@ -3544,6 +3546,11 @@ spec:
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
                     description: KubernetesAuth enables Kubernetes native authentication for the Perses client
                     properties:
@@ -3581,11 +3588,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
                         description: Scopes specifies optional requested permissions for the OAuth token
@@ -3609,6 +3618,11 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
                     description: TLS provides TLS/SSL configuration for secure connections to Perses
                     properties:
@@ -3625,11 +3639,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -3648,6 +3664,11 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                       enable:
                         description: Enable determines whether TLS is enabled for connections to Perses
                         type: boolean
@@ -3669,11 +3690,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -3692,6 +3715,11 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                     type: object
                 type: object
               config:
@@ -5609,11 +5637,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
                         description: |-
@@ -5632,6 +5662,11 @@ spec:
                     - certPath
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   enable:
                     description: Enable determines whether TLS is enabled for connections to Perses
                     type: boolean
@@ -5653,11 +5688,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
                         description: |-
@@ -5676,6 +5713,11 @@ spec:
                     - certPath
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                 type: object
               tolerations:
                 description: Tolerations allow pods to schedule onto nodes with matching taints

--- a/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
@@ -328,11 +328,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       passwordPath:
                         description: |-
@@ -356,6 +358,11 @@ spec:
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
                     description: KubernetesAuth enables Kubernetes native authentication for the Perses client
                     properties:
@@ -393,11 +400,13 @@ spec:
                         description: |-
                           Name is the name of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
                         description: |-
                           Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                           Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
                         description: Scopes specifies optional requested permissions for the OAuth token
@@ -421,6 +430,11 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
                     description: TLS provides TLS/SSL configuration for secure connections to Perses
                     properties:
@@ -437,11 +451,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -460,6 +476,11 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                       enable:
                         description: Enable determines whether TLS is enabled for connections to Perses
                         type: boolean
@@ -481,11 +502,13 @@ spec:
                             description: |-
                               Name is the name of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
                             description: |-
                               Namespace is the namespace of the Kubernetes Secret or ConfigMap resource
                               Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
                             description: |-
@@ -504,6 +527,11 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                     type: object
                 type: object
               config:

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -3638,10 +3638,12 @@
                         "properties": {
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "passwordPath": {
@@ -3669,7 +3671,17 @@
                           "type",
                           "username"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "kubernetesAuth": {
                         "description": "KubernetesAuth enables Kubernetes native authentication for the Perses client",
@@ -3709,10 +3721,12 @@
                           },
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "scopes": {
@@ -3741,7 +3755,17 @@
                           "tokenURL",
                           "type"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "tls": {
                         "description": "TLS provides TLS/SSL configuration for secure connections to Perses",
@@ -3756,10 +3780,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -3780,7 +3806,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           },
                           "enable": {
                             "description": "Enable determines whether TLS is enabled for connections to Perses",
@@ -3800,10 +3836,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -3824,7 +3862,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           }
                         },
                         "type": "object"
@@ -5927,10 +5975,12 @@
                           },
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "privateKeyPath": {
@@ -5951,7 +6001,17 @@
                           "certPath",
                           "type"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "enable": {
                         "description": "Enable determines whether TLS is enabled for connections to Perses",
@@ -5971,10 +6031,12 @@
                           },
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "privateKeyPath": {
@@ -5995,7 +6057,17 @@
                           "certPath",
                           "type"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       }
                     },
                     "type": "object"

--- a/jsonnet/generated/perses.dev_persesdatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesdatasources-crd.json
@@ -390,10 +390,12 @@
                         "properties": {
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "passwordPath": {
@@ -421,7 +423,17 @@
                           "type",
                           "username"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "kubernetesAuth": {
                         "description": "KubernetesAuth enables Kubernetes native authentication for the Perses client",
@@ -461,10 +473,12 @@
                           },
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "scopes": {
@@ -493,7 +507,17 @@
                           "tokenURL",
                           "type"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "tls": {
                         "description": "TLS provides TLS/SSL configuration for secure connections to Perses",
@@ -508,10 +532,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -532,7 +558,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           },
                           "enable": {
                             "description": "Enable determines whether TLS is enabled for connections to Perses",
@@ -552,10 +588,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -576,7 +614,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           }
                         },
                         "type": "object"

--- a/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
@@ -48,10 +48,12 @@
                         "properties": {
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "passwordPath": {
@@ -79,7 +81,17 @@
                           "type",
                           "username"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "kubernetesAuth": {
                         "description": "KubernetesAuth enables Kubernetes native authentication for the Perses client",
@@ -119,10 +131,12 @@
                           },
                           "name": {
                             "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "namespace": {
                             "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                            "minLength": 1,
                             "type": "string"
                           },
                           "scopes": {
@@ -151,7 +165,17 @@
                           "tokenURL",
                           "type"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "name is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                          },
+                          {
+                            "message": "namespace is required when type is secret or configmap",
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                          }
+                        ]
                       },
                       "tls": {
                         "description": "TLS provides TLS/SSL configuration for secure connections to Perses",
@@ -166,10 +190,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -190,7 +216,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           },
                           "enable": {
                             "description": "Enable determines whether TLS is enabled for connections to Perses",
@@ -210,10 +246,12 @@
                               },
                               "name": {
                                 "description": "Name is the name of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "namespace": {
                                 "description": "Namespace is the namespace of the Kubernetes Secret or ConfigMap resource\nRequired when Type is \"secret\" or \"configmap\", ignored when Type is \"file\"",
+                                "minLength": 1,
                                 "type": "string"
                               },
                               "privateKeyPath": {
@@ -234,7 +272,17 @@
                               "certPath",
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "name is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.name)"
+                              },
+                              {
+                                "message": "namespace is required when type is secret or configmap",
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                              }
+                            ]
                           }
                         },
                         "type": "object"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add CEL validation to enforce that SecretSource.Name and SecretSource.Namespace are required when Type is "secret" or "configmap", but optional when Type is "file".

Existing resources or manifests with type=secret or type=configmap that are missing name or namespace fields will now be rejected at admission time. These configurations were previously accepted but would fail at runtime.

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
