### PR TITLE
[FEATURE] Add e2e tests for global datasource, emptyDir storage, and resource updates

### DIFF
--- a/test/e2e/global-datasource/00-assert.yaml
+++ b/test/e2e/global-datasource/00-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-gds-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-gds-test-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses-gds-test
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-gds-test

--- a/test/e2e/global-datasource/00-install.yaml
+++ b/test/e2e/global-datasource/00-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-gds-test
+  labels:
+    app.kubernetes.io/instance: perses-gds-test
+spec:
+  metadata:
+    labels:
+      instance: perses-gds-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/global-datasource/01-assert.yaml
+++ b/test/e2e/global-datasource/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-gds-test
+status:
+  readyReplicas: 1

--- a/test/e2e/global-datasource/02-assert.yaml
+++ b/test/e2e/global-datasource/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesglobaldatasource e2e-global-datasource -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/global-datasource/02-install.yaml
+++ b/test/e2e/global-datasource/02-install.yaml
@@ -1,0 +1,16 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesGlobalDatasource
+metadata:
+  name: e2e-global-datasource
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-gds-test
+  config:
+    display:
+      name: "E2E Global Datasource"
+    default: true
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        directUrl: "https://prometheus.demo.prometheus.io"

--- a/test/e2e/global-datasource/03-assert.yaml
+++ b/test/e2e/global-datasource/03-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-gds-test 18090:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18090/api/v1/globaldatasources/e2e-global-datasource) || {
+        echo "FAIL: Global datasource e2e-global-datasource not found in Perses instance"
+        exit 1
+      }
+      echo "$RESULT" | grep -q "E2E Global Datasource" || {
+        echo "FAIL: Global datasource display name mismatch"
+        exit 1
+      }
+      echo "Global datasource e2e-global-datasource found in Perses instance"

--- a/test/e2e/global-datasource/04-assert.yaml
+++ b/test/e2e/global-datasource/04-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete persesglobaldatasource/e2e-global-datasource --timeout=60s
+  - command: kubectl wait --for=delete perses/perses-gds-test -n $NAMESPACE --timeout=60s

--- a/test/e2e/global-datasource/04-delete.yaml
+++ b/test/e2e/global-datasource/04-delete.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesGlobalDatasource
+    metadata:
+      name: e2e-global-datasource
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-gds-test

--- a/test/e2e/perses-emptydir/00-assert.yaml
+++ b/test/e2e/perses-emptydir/00-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-emptydir-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: perses-emptydir-test-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: perses-emptydir-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perses-emptydir-test

--- a/test/e2e/perses-emptydir/00-install.yaml
+++ b/test/e2e/perses-emptydir/00-install.yaml
@@ -1,0 +1,21 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-emptydir-test
+  labels:
+    app.kubernetes.io/instance: perses-emptydir-test
+spec:
+  metadata:
+    labels:
+      instance: perses-emptydir-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  storage:
+    emptyDir: {}
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/perses-emptydir/01-assert.yaml
+++ b/test/e2e/perses-emptydir/01-assert.yaml
@@ -1,0 +1,26 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  # Verify it created a Deployment (not StatefulSet) for file DB + emptyDir
+  - script: |
+      if kubectl get statefulset perses-emptydir-test -n $NAMESPACE 2>/dev/null; then
+        echo "FAIL: StatefulSet should not exist for emptyDir storage"
+        exit 1
+      fi
+      echo "Verified: No StatefulSet created for emptyDir storage"
+  - script: |
+      READY=$(kubectl get deployment perses-emptydir-test -n $NAMESPACE -o jsonpath='{.status.readyReplicas}')
+      if [ "$READY" != "1" ]; then
+        echo "FAIL: Deployment not ready, readyReplicas=$READY"
+        exit 1
+      fi
+      echo "Deployment is ready with 1 replica"
+  # Verify the emptyDir volume is mounted
+  - script: |
+      VOLUMES=$(kubectl get deployment perses-emptydir-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.volumes[*].name}')
+      echo "$VOLUMES" | grep -q "storage" || {
+        echo "FAIL: emptyDir volume 'storage' not found in deployment volumes: $VOLUMES"
+        exit 1
+      }
+      echo "Verified: emptyDir volume is present in deployment"

--- a/test/e2e/perses-emptydir/02-assert.yaml
+++ b/test/e2e/perses-emptydir/02-assert.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-emptydir-test -n $NAMESPACE --timeout=60s

--- a/test/e2e/perses-emptydir/02-delete.yaml
+++ b/test/e2e/perses-emptydir/02-delete.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-emptydir-test

--- a/test/e2e/resource-update/00-assert.yaml
+++ b/test/e2e/resource-update/00-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-update-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-update-test

--- a/test/e2e/resource-update/00-install.yaml
+++ b/test/e2e/resource-update/00-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-update-test
+  labels:
+    app.kubernetes.io/instance: perses-update-test
+spec:
+  metadata:
+    labels:
+      instance: perses-update-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/resource-update/01-assert.yaml
+++ b/test/e2e/resource-update/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-update-test
+status:
+  readyReplicas: 1

--- a/test/e2e/resource-update/02-assert.yaml
+++ b/test/e2e/resource-update/02-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdashboard update-test-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled
+  - script: kubectl get persesdatasource update-test-datasource -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/resource-update/02-install.yaml
+++ b/test/e2e/resource-update/02-install.yaml
@@ -1,0 +1,59 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: update-test-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-update-test
+  config:
+    display:
+      name: Original Dashboard Name
+    duration: 5m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Original Panel
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesDatasource
+metadata:
+  name: update-test-datasource
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-update-test
+  config:
+    display:
+      name: "Original Datasource Name"
+    default: true
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        directUrl: "https://prometheus.demo.prometheus.io"

--- a/test/e2e/resource-update/03-assert.yaml
+++ b/test/e2e/resource-update/03-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  # Verify original dashboard exists in Perses
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-update-test 18084:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18084/api/v1/projects/$NAMESPACE/dashboards/update-test-dashboard) || {
+        echo "FAIL: Dashboard not found in Perses"
+        exit 1
+      }
+      echo "$RESULT" | grep -q "Original Dashboard Name" || {
+        echo "FAIL: Dashboard display name mismatch"
+        exit 1
+      }
+      echo "Original dashboard verified in Perses"
+  # Verify original datasource exists in Perses
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-update-test 18085:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18085/api/v1/projects/$NAMESPACE/datasources/update-test-datasource) || {
+        echo "FAIL: Datasource not found in Perses"
+        exit 1
+      }
+      echo "$RESULT" | grep -q "Original Datasource Name" || {
+        echo "FAIL: Datasource display name mismatch"
+        exit 1
+      }
+      echo "Original datasource verified in Perses"

--- a/test/e2e/resource-update/04-assert.yaml
+++ b/test/e2e/resource-update/04-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: kubectl get persesdashboard update-test-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled
+  - script: kubectl get persesdatasource update-test-datasource -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}' | grep -q Reconciled

--- a/test/e2e/resource-update/04-install.yaml
+++ b/test/e2e/resource-update/04-install.yaml
@@ -1,0 +1,59 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: update-test-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-update-test
+  config:
+    display:
+      name: Updated Dashboard Name
+    duration: 10m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Updated Panel
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up{job="prometheus"}
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesDatasource
+metadata:
+  name: update-test-datasource
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-update-test
+  config:
+    display:
+      name: "Updated Datasource Name"
+    default: false
+    plugin:
+      kind: "PrometheusDatasource"
+      spec:
+        directUrl: "https://prometheus.updated.example.com"

--- a/test/e2e/resource-update/05-assert.yaml
+++ b/test/e2e/resource-update/05-assert.yaml
@@ -1,0 +1,34 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  # Verify updated dashboard in Perses
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-update-test 18086:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18086/api/v1/projects/$NAMESPACE/dashboards/update-test-dashboard) || {
+        echo "FAIL: Dashboard not found in Perses after update"
+        exit 1
+      }
+      echo "$RESULT" | grep -q "Updated Dashboard Name" || {
+        echo "FAIL: Dashboard was not updated. Response: $RESULT"
+        exit 1
+      }
+      echo "Dashboard successfully updated in Perses"
+  # Verify updated datasource in Perses
+  - script: |
+      kubectl port-forward -n $NAMESPACE svc/perses-update-test 18087:8080 &
+      PF_PID=$!
+      trap "kill $PF_PID 2>/dev/null" EXIT
+      sleep 3
+      RESULT=$(curl -sf http://localhost:18087/api/v1/projects/$NAMESPACE/datasources/update-test-datasource) || {
+        echo "FAIL: Datasource not found in Perses after update"
+        exit 1
+      }
+      echo "$RESULT" | grep -q "Updated Datasource Name" || {
+        echo "FAIL: Datasource was not updated. Response: $RESULT"
+        exit 1
+      }
+      echo "Datasource successfully updated in Perses"

--- a/test/e2e/resource-update/06-assert.yaml
+++ b/test/e2e/resource-update/06-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-update-test -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdashboard/update-test-dashboard -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdatasource/update-test-datasource -n $NAMESPACE --timeout=60s

--- a/test/e2e/resource-update/06-delete.yaml
+++ b/test/e2e/resource-update/06-delete.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDashboard
+    metadata:
+      name: update-test-dashboard
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDatasource
+    metadata:
+      name: update-test-datasource
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-update-test


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add e2e tests for global datasource, emptyDir storage, and resource updates

Closes: #298

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
