### PR TITLE
[FEATURE] Add writable emptyDir volume for plugin storage

### DIFF
--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -37,6 +37,7 @@ const (
 	// Volume names
 	configVolumeName  = "config"
 	StorageVolumeName = "storage"
+	pluginsVolumeName = "plugins"
 
 	// TLS volume names
 	caVolumeName     = "ca"
@@ -48,6 +49,7 @@ const (
 	storageMountPath  = "/perses"
 	secretsMountPath  = "/etc/perses/provisioning/secrets"
 	configMountPath   = "/etc/perses/config"
+	pluginsMountPath  = "/etc/perses/plugins"
 	defaultConfigPath = configMountPath + "/config.yaml"
 
 	defaultFileMode = 420

--- a/internal/perses/common/volumes.go
+++ b/internal/perses/common/volumes.go
@@ -30,6 +30,12 @@ func GetVolumes(perses *v1alpha2.Perses) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: pluginsVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 
 	// Add storage volume only for file-based database
@@ -136,6 +142,11 @@ func GetVolumeMounts(perses *v1alpha2.Perses) []corev1.VolumeMount {
 			Name:      configVolumeName,
 			ReadOnly:  true,
 			MountPath: configMountPath,
+		},
+		{
+			Name:      pluginsVolumeName,
+			ReadOnly:  false,
+			MountPath: pluginsMountPath,
 		},
 	}
 

--- a/test/e2e/perses-emptydir/01-assert.yaml
+++ b/test/e2e/perses-emptydir/01-assert.yaml
@@ -16,11 +16,27 @@ commands:
         exit 1
       fi
       echo "Deployment is ready with 1 replica"
-  # Verify the emptyDir volume is mounted
+  # Verify the storage emptyDir volume is present
   - script: |
       VOLUMES=$(kubectl get deployment perses-emptydir-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.volumes[*].name}')
       echo "$VOLUMES" | grep -q "storage" || {
         echo "FAIL: emptyDir volume 'storage' not found in deployment volumes: $VOLUMES"
         exit 1
       }
-      echo "Verified: emptyDir volume is present in deployment"
+      echo "Verified: emptyDir storage volume is present in deployment"
+  # Verify the plugins emptyDir volume is present
+  - script: |
+      VOLUMES=$(kubectl get deployment perses-emptydir-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.volumes[*].name}')
+      echo "$VOLUMES" | grep -q "plugins" || {
+        echo "FAIL: emptyDir volume 'plugins' not found in deployment volumes: $VOLUMES"
+        exit 1
+      }
+      echo "Verified: emptyDir plugins volume is present in deployment"
+  # Verify the plugins volume is mounted at /etc/perses/plugins
+  - script: |
+      MOUNTS=$(kubectl get deployment perses-emptydir-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[*].mountPath}')
+      echo "$MOUNTS" | grep -q "/etc/perses/plugins" || {
+        echo "FAIL: plugins volume mount '/etc/perses/plugins' not found in container mounts: $MOUNTS"
+        exit 1
+      }
+      echo "Verified: plugins volume is mounted at /etc/perses/plugins"

--- a/test/e2e/perses-statefulset/01-assert.yaml
+++ b/test/e2e/perses-statefulset/01-assert.yaml
@@ -1,6 +1,23 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 120
+commands:
+  # Verify the plugins emptyDir volume is present
+  - script: |
+      VOLUMES=$(kubectl get statefulset perses-e2e-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.volumes[*].name}')
+      echo "$VOLUMES" | grep -q "plugins" || {
+        echo "FAIL: emptyDir volume 'plugins' not found in statefulset volumes: $VOLUMES"
+        exit 1
+      }
+      echo "Verified: emptyDir plugins volume is present in statefulset"
+  # Verify the plugins volume is mounted at /etc/perses/plugins
+  - script: |
+      MOUNTS=$(kubectl get statefulset perses-e2e-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[*].mountPath}')
+      echo "$MOUNTS" | grep -q "/etc/perses/plugins" || {
+        echo "FAIL: plugins volume mount '/etc/perses/plugins' not found in container mounts: $MOUNTS"
+        exit 1
+      }
+      echo "Verified: plugins volume is mounted at /etc/perses/plugins"
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Perses requires a writable volume at /etc/perses/plugins to install core plugins on startup. An emptyDir volume is always mounted at that path for both Deployment and StatefulSet workloads.

Fixes #208

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
