### PR TITLE
[ENHANCEMENT] Define default Perses operand image version in a singleplace

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -102,7 +102,7 @@ Each instance of the CRD deploys the following resources:
 1. Install Instances of Custom Resources and run the controller:
 
 ```shell
-PERSES_IMAGE=docker.io/persesdev/perses:v0.50.3 make install-crds run
+PERSES_IMAGE=docker.io/persesdev/perses:v0.53.0 make install-crds run
 ```
 
 2. Install a CRD instance:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -46,7 +46,7 @@ spec:
         privateKeyPath: tls.key
 
   # Optional container image to use as the Perses server operand
-  image: docker.io/perses/perses:v0.50.3
+  image: docker.io/persesdev/perses:v0.53.0
 
   # Optional service configuration
   service:
@@ -328,7 +328,7 @@ metadata:
   name: perses
   namespace: monitoring
 spec:
-  image: docker.io/perses/perses:v0.50.3
+  image: docker.io/persesdev/perses:v0.53.0
   config:
     database:
       file:

--- a/internal/operator/defaults.go
+++ b/internal/operator/defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright The Perses Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+const (
+	// DefaultPersesVersion is the default image tag for Perses.
+	DefaultPersesVersion = "v0.53.0"
+	// DefaultPersesBaseImage is the base container registry address for Perses.
+	DefaultPersesBaseImage = "docker.io/persesdev/perses"
+	// DefaultPersesImage is the default image used for Perses Deployment or StatefulSet operands.
+	DefaultPersesImage = DefaultPersesBaseImage + ":" + DefaultPersesVersion
+)

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	globaldatasourcecontroller "github.com/perses/perses-operator/controllers/globaldatasources"
 	persescontroller "github.com/perses/perses-operator/controllers/perses"
 	operatormetrics "github.com/perses/perses-operator/internal/metrics"
+	"github.com/perses/perses-operator/internal/operator"
 	"github.com/perses/perses-operator/internal/perses/common"
 	//+kubebuilder:scaffold:imports
 )
@@ -77,7 +78,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&persesImage, "perses-default-base-image", "docker.io/persesdev/perses:v0.51.0", "The default image used for the Perses Deployment or StatefulSet operands")
+	flag.StringVar(&persesImage, "perses-default-base-image", operator.DefaultPersesImage, "The default image used for the Perses Deployment or StatefulSet operands")
 	flag.StringVar(&persesServerURL, common.PersesServerURLFlag, "", "The Perses backend server URL")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the metrics and webhook servers.")
 	opts := zap.Options{


### PR DESCRIPTION

Replace the hardcoded image string in main.go with operator.DefaultPersesImage so the default Perses operand version is controlled from one location and stays in sync with the go.mod dependency

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
