### PR TITLE
[ENHANCEMENT] Remove PERSES_IMAGE env var and use DefaultPersesImage

### DIFF
--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,8 +37,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 		var dashboardNamespaceName types.NamespacedName
 		var PersesNamespace string
 
-		persesImage := "perses-dev.io/perses:test"
-
 		var newDashboard *persesv1.Dashboard
 
 		BeforeAll(func() {
@@ -54,10 +51,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			PersesNamespace = namespace.Name
 			persesNamespaceName = types.NamespacedName{Name: PersesName, Namespace: PersesNamespace}
 			dashboardNamespaceName = types.NamespacedName{Name: DashboardName, Namespace: PersesNamespace}
-
-			By("Setting the Image ENV VAR which stores the Operand image")
-			err = os.Setenv("PERSES_IMAGE", persesImage)
-			Expect(err).To(Not(HaveOccurred()))
 
 			By("Creating the custom resource for the Kind Perses")
 			perses := &persesv1alpha2.Perses{}
@@ -129,9 +122,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 		AfterAll(func() {
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("PERSES_IMAGE")
 		})
 
 		It("should successfully reconcile a custom resource dashboard for Perses", func() {
@@ -380,8 +370,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 		var SelectorNamespace string
 		var selectorDashboardNamespaceName types.NamespacedName
 
-		persesImage := "perses-dev.io/perses:test"
-
 		var selectorDashboard *persesv1.Dashboard
 
 		BeforeAll(func() {
@@ -395,10 +383,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			Expect(err).To(Not(HaveOccurred()))
 			SelectorNamespace = namespace.Name
 			selectorDashboardNamespaceName = types.NamespacedName{Name: SelectorDashboardName, Namespace: SelectorNamespace}
-
-			By("Setting the Image ENV VAR which stores the Operand image")
-			err = os.Setenv("PERSES_IMAGE", persesImage)
-			Expect(err).To(Not(HaveOccurred()))
 
 			By("Creating a Perses instance with matching labels")
 			matchingPerses := &persesv1alpha2.Perses{
@@ -498,9 +482,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 		AfterAll(func() {
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("PERSES_IMAGE")
 		})
 
 		It("should only sync the dashboard with Perses instances matching the instance selector", func() {

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,8 +37,6 @@ var _ = Describe("Datasource controller", Ordered, func() {
 		var persesNamespaceName types.NamespacedName
 		var datasourceNamespaceName types.NamespacedName
 
-		persesImage := "perses-dev.io/perses:test"
-
 		var newSecret *persesv1.Secret
 		var newDatasource *persesv1.Datasource
 
@@ -55,10 +52,6 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			PersesNamespace = namespace.Name
 			persesNamespaceName = types.NamespacedName{Name: PersesName, Namespace: PersesNamespace}
 			datasourceNamespaceName = types.NamespacedName{Name: DatasourceName, Namespace: PersesNamespace}
-
-			By("Setting the Image ENV VAR which stores the Operand image")
-			err = os.Setenv("PERSES_IMAGE", persesImage)
-			Expect(err).To(Not(HaveOccurred()))
 
 			By("Creating the custom resource for the Kind Perses")
 			perses := &persesv1alpha2.Perses{}
@@ -129,9 +122,6 @@ var _ = Describe("Datasource controller", Ordered, func() {
 		AfterAll(func() {
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("PERSES_IMAGE")
 		})
 
 		It("should successfully reconcile a custom resource datasource for Perses", func() {

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,8 +37,6 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 		var persesNamespaceName types.NamespacedName
 		globaldatasourceNamespaceName := types.NamespacedName{Name: GlobalDatasourceName}
 
-		persesImage := "perses-dev.io/perses:test"
-
 		var newSecret *persesv1.GlobalSecret
 		var newGlobalDatasource *persesv1.GlobalDatasource
 
@@ -54,10 +51,6 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			Expect(err).To(Not(HaveOccurred()))
 			PersesNamespace = namespace.Name
 			persesNamespaceName = types.NamespacedName{Name: PersesName, Namespace: PersesNamespace}
-
-			By("Setting the Image ENV VAR which stores the Operand image")
-			err = os.Setenv("PERSES_IMAGE", persesImage)
-			Expect(err).To(Not(HaveOccurred()))
 
 			By("Creating the custom resource for the Kind Perses")
 			perses := &persesv1alpha2.Perses{}
@@ -125,9 +118,6 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 		AfterAll(func() {
 			By("Deleting the Namespace to perform the tests")
 			_ = k8sClient.Delete(ctx, namespace)
-
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("PERSES_IMAGE")
 		})
 
 		It("should successfully reconcile a custom resource globaldatasource for Perses", func() {

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -24,6 +23,7 @@ import (
 
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	persescontroller "github.com/perses/perses-operator/controllers/perses"
+	"github.com/perses/perses-operator/internal/operator"
 	"github.com/perses/perses-operator/internal/perses/common"
 )
 
@@ -33,19 +33,8 @@ var _ = Describe("Perses controller", func() {
 
 		ctx := context.Background()
 
-		persesImage := "perses-dev.io/perses:test"
+		persesImage := operator.DefaultPersesImage
 		persesServiceName := "perses-custom-service-name"
-
-		BeforeEach(func() {
-			By("Setting the Image ENV VAR which stores the Operand image")
-			err := os.Setenv("PERSES_IMAGE", persesImage)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		AfterEach(func() {
-			By("Removing the Image ENV VAR which stores the Operand image")
-			_ = os.Unsetenv("PERSES_IMAGE")
-		})
 
 		It("should successfully reconcile a custom resource for Perses", func() {
 			typeNamespaceName := types.NamespacedName{Name: PersesName, Namespace: persesNamespace}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/perses/perses-operator/api/v1alpha2"
 	persesController "github.com/perses/perses-operator/controllers/perses"
+	"github.com/perses/perses-operator/internal/operator"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -100,6 +101,9 @@ var _ = BeforeSuite(func() {
 	err = (&persesController.PersesReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
+		Config: persesController.Config{
+			PersesImage: operator.DefaultPersesImage,
+		},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Remove PERSES_IMAGE env var and use DefaultPersesImage as we added defaults in https://github.com/perses/perses-operator/pull/303 `PERSES_IMAGE` is a dead code.

Improve ImageForPerses with clearer priority and error messages

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
