### PR TITLE
[IGNORE] Skip code workflows when only markdown files change

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -1,0 +1,28 @@
+name: changed-files
+
+on:
+  workflow_call:
+    outputs:
+      non-markdown-files:
+        description: "Non-empty if non-markdown files changed"
+        value: ${{ jobs.changed-files.outputs.non-markdown-files }}
+
+jobs:
+  changed-files:
+    outputs:
+      non-markdown-files: ${{ steps.changed-files.outputs.non-markdown-files }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: get changed files
+        id: changed-files
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "non-markdown-files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -iv '\.md$' | xargs)" >> "$GITHUB_OUTPUT"
+          else
+            # Always run on push and merge_group events
+            echo "non-markdown-files=true" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
 
 jobs:
+  changed-files:
+    uses: ./.github/workflows/changed-files.yaml
   e2e:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: "kuttl e2e tests"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
 
 jobs:
+  changed-files:
+    uses: ./.github/workflows/changed-files.yaml
   gofmt:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: "check code format"
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +34,8 @@ jobs:
       - name: verify go modules
         run: make tidy
   test-unit:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: "unit tests"
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +48,8 @@ jobs:
       - name: unit tests
         run: make test-unit
   test-integration:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: "integration tests"
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +62,8 @@ jobs:
       - name: integration tests
         run: make test-integration
   lint-api:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: "kube-api-linter"
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +76,8 @@ jobs:
       - name: lint API types
         run: make lint-api
   lint:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.non-markdown-files }}
     name: lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Skip code workflows when only markdown files change

I have followed prometheus-operator pattern see an example run where [only .md file is updated]( https://github.com/prometheus-operator/prometheus-operator/pull/8390/checks)

Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-jobs-with-conditions

Closes: #310 

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
