### PR TITLE
[ENHANCEMENT] Migrate kustomize vars to replacements and add installer-check to CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -93,5 +93,7 @@ jobs:
         run: make generate
       - name: check bundle changes
         run: make bundle-check
+      - name: check installer manifest is up-to-date
+        run: make installer-check
       - name: golangci-lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,10 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > bundle.yaml
 
+.PHONY: installer-check
+installer-check: build-installer ## Verify bundle.yaml is up-to-date.
+	git diff --exit-code bundle.yaml
+
 ifndef ignore-not-found
   ignore-not-found = false
 endif

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -15,7 +15,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: perses.perses.dev
 spec:
   conversion:
@@ -38,7 +38,9 @@ spec:
     singular: perses
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Perses is the Schema for the perses API
@@ -67,7 +69,8 @@ spec:
                 description: Affinity is a group of affinity scheduling rules.
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the pod.
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -86,17 +89,20 @@ spec:
                             (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the corresponding weight.
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -121,14 +127,16 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -155,7 +163,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -173,7 +182,8 @@ spec:
                           may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms. The terms are ORed.
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
                               description: |-
                                 A null or empty node selector term matches no objects. The requirements of
@@ -181,14 +191,16 @@ spec:
                                 The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -213,14 +225,16 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -254,7 +268,8 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -268,10 +283,12 @@ spec:
                           "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
                                   description: |-
@@ -279,14 +296,17 @@ spec:
                                     If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -356,14 +376,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -453,14 +476,16 @@ spec:
                                 If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -530,14 +555,16 @@ spec:
                                 An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -595,7 +622,9 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -609,10 +638,12 @@ spec:
                           "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
                                   description: |-
@@ -620,14 +651,17 @@ spec:
                                     If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -697,14 +731,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -794,14 +831,16 @@ spec:
                                 If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -871,14 +910,16 @@ spec:
                                 An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -948,13 +989,16 @@ spec:
                     description: BasicAuth basic auth config for perses client
                     properties:
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -965,6 +1009,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -1000,13 +1045,16 @@ spec:
                           items:
                             type: string
                           type: array
-                        description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                        description: EndpointParams specifies additional parameters
+                          for requests to the token endpoint.
                         type: object
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -1017,6 +1065,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -1037,12 +1086,15 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -1069,12 +1121,15 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -1097,10 +1152,16 @@ spec:
               config:
                 properties:
                   api_prefix:
-                    description: Use it in case you want to prefix the API path.
+                    description: |-
+                      Use it in case you want to prefix the API path.
+                      This can be useful if you are running Perses behind a reverse proxy.
+                      By default, the API is served with the path /api.
+                      With this config, it will be served with the path <api_prefix>/api
+                      Example: "/perses"
                     type: string
                   dashboard:
-                    description: Dashboard contains the configuration for the dashboard feature.
+                    description: Dashboard contains the configuration for the dashboard
+                      feature.
                     properties:
                       custom_lint_rules:
                         items:
@@ -1134,7 +1195,8 @@ spec:
                         type: array
                     type: object
                   database:
-                    description: Database contains the different configuration depending on the database you want to use
+                    description: Database contains the different configuration depending
+                      on the database you want to use
                     properties:
                       file:
                         properties:
@@ -1152,17 +1214,24 @@ spec:
                           addr:
                             description: Network address (requires Net)
                             type: string
+                          addr_file:
+                            description: AddrFile is a path to a file that contains
+                              the network address
+                            type: string
                           allow_all_files:
-                            description: Allow all files to be used with LOAD DATA LOCAL INFILE
+                            description: Allow all files to be used with LOAD DATA
+                              LOCAL INFILE
                             type: boolean
                           allow_cleartext_passwords:
                             description: Allows the cleartext client side plugin
                             type: boolean
                           allow_fallback_to_plaintext:
-                            description: Allows fallback to unencrypted connection if server does not support TLS
+                            description: Allows fallback to unencrypted connection
+                              if server does not support TLS
                             type: boolean
                           allow_native_passwords:
-                            description: Allows the native password authentication method
+                            description: Allows the native password authentication
+                              method
                             type: boolean
                           allow_old_passwords:
                             description: Allows the old insecure password method
@@ -1170,10 +1239,12 @@ spec:
                           case_sensitive:
                             type: boolean
                           check_conn_liveness:
-                            description: Check connections for liveness before using them
+                            description: Check connections for liveness before using
+                              them
                             type: boolean
                           client_found_rows:
-                            description: Return number of matching rows instead of rows changed
+                            description: Return number of matching rows instead of
+                              rows changed
                             type: boolean
                           collation:
                             description: Connection collation
@@ -1206,7 +1277,8 @@ spec:
                             description: Password (requires User)
                             type: string
                           password_file:
-                            description: PasswordFile is a path to a file that contains a password
+                            description: PasswordFile is a path to a file that contains
+                              a password
                             type: string
                           read_timeout:
                             description: I/O read timeout
@@ -1228,55 +1300,35 @@ spec:
                             description: TLS configuration
                             properties:
                               ca:
-                                description: Text of the CA cert to use for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              ca_file:
-                                description: The CA cert to use for the targets.
-                                type: string
-                              ca_ref:
-                                description: |-
-                                  CARef is the name of the secret within the secret manager to use as the CA cert for the
-                                  targets.
+                              caFile:
                                 type: string
                               cert:
-                                description: Text of the client cert file for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              cert_file:
-                                description: The client cert file for the targets.
+                              certFile:
                                 type: string
-                              cert_ref:
-                                description: |-
-                                  CertRef is the name of the secret within the secret manager to use as the client cert for
-                                  the targets.
-                                type: string
-                              insecure_skip_verify:
-                                description: Disable target certificate validation.
+                              insecureSkipVerify:
                                 type: boolean
                               key:
-                                description: Text of the client key file for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              key_file:
-                                description: The client key file for the targets.
+                              keyFile:
                                 type: string
-                              key_ref:
-                                description: |-
-                                  KeyRef is the name of the secret within the secret manager to use as the client key for
-                                  the targets.
+                              maxVersion:
                                 type: string
-                              max_version:
-                                description: Maximum TLS version.
-                                type: integer
-                              min_version:
-                                description: Minimum TLS version.
-                                type: integer
-                              server_name:
-                                description: Used to verify the hostname for the targets.
+                              minVersion:
                                 type: string
-                            required:
-                            - insecure_skip_verify
+                              serverName:
+                                type: string
                             type: object
                           user:
                             description: Username
+                            type: string
+                          user_file:
+                            description: UserFile is a path to a file that contains
+                              a username
                             type: string
                           write_timeout:
                             description: I/O write timeout
@@ -1336,7 +1388,8 @@ spec:
                                     The HTTP header Content-Type must be application/json, and the body must be valid array of JSON.
                                   properties:
                                     authorization:
-                                      description: The HTTP authorization credentials for the targets.
+                                      description: The HTTP authorization credentials
+                                        for the targets.
                                       properties:
                                         credentials:
                                           type: string
@@ -1350,7 +1403,8 @@ spec:
                                         password:
                                           type: string
                                         passwordFile:
-                                          description: PasswordFile is a path to a file that contains a password
+                                          description: PasswordFile is a path to a
+                                            file that contains a password
                                           type: string
                                         username:
                                           type: string
@@ -1360,6 +1414,11 @@ spec:
                                     headers:
                                       additionalProperties:
                                         type: string
+                                      type: object
+                                    k8s_auth:
+                                      properties:
+                                        kubeconfig:
+                                          type: string
                                       type: object
                                     native_auth:
                                       properties:
@@ -1380,10 +1439,12 @@ spec:
                                             auto-detect.
                                           type: integer
                                         clientID:
-                                          description: ClientID is the application's ID.
+                                          description: ClientID is the application's
+                                            ID.
                                           type: string
                                         clientSecret:
-                                          description: ClientSecret is the application's secret.
+                                          description: ClientSecret is the application's
+                                            secret.
                                           type: string
                                         clientSecretFile:
                                           type: string
@@ -1392,10 +1453,12 @@ spec:
                                             items:
                                               type: string
                                             type: array
-                                          description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                                          description: EndpointParams specifies additional
+                                            parameters for requests to the token endpoint.
                                           type: object
                                         scopes:
-                                          description: Scope specifies optional requested permissions.
+                                          description: Scope specifies optional requested
+                                            permissions.
                                           items:
                                             type: string
                                           type: array
@@ -1414,28 +1477,36 @@ spec:
                                       - tokenURL
                                       type: object
                                     tls_config:
-                                      description: TLSConfig to use to connect to the targets.
+                                      description: TLSConfig to use to connect to
+                                        the targets.
                                       properties:
                                         ca:
-                                          description: Text of the CA cert to use for the targets.
+                                          description: Text of the CA cert to use
+                                            for the targets.
                                           type: string
                                         caFile:
-                                          description: The CA cert to use for the targets.
+                                          description: The CA cert to use for the
+                                            targets.
                                           type: string
                                         cert:
-                                          description: Text of the client cert file for the targets.
+                                          description: Text of the client cert file
+                                            for the targets.
                                           type: string
                                         certFile:
-                                          description: The client cert file for the targets.
+                                          description: The client cert file for the
+                                            targets.
                                           type: string
                                         insecureSkipVerify:
-                                          description: Disable target certificate validation.
+                                          description: Disable target certificate
+                                            validation.
                                           type: boolean
                                         key:
-                                          description: Text of the client key file for the targets.
+                                          description: Text of the client key file
+                                            for the targets.
                                           type: string
                                         keyFile:
-                                          description: The client key file for the targets.
+                                          description: The client key file for the
+                                            targets.
                                           type: string
                                         maxVersion:
                                           description: |-
@@ -1450,7 +1521,8 @@ spec:
                                             See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                           type: string
                                         serverName:
-                                          description: Used to verify the hostname for the targets.
+                                          description: Used to verify the hostname
+                                            for the targets.
                                           type: string
                                       type: object
                                     url:
@@ -1465,12 +1537,16 @@ spec:
                                     and always staying synchronized with the cluster state.
                                   properties:
                                     datasource_plugin_kind:
-                                      description: DatasourcePluginKind is the name of the datasource plugin that should be filled when creating datasources found.
+                                      description: DatasourcePluginKind is the name
+                                        of the datasource plugin that should be filled
+                                        when creating datasources found.
                                       type: string
                                     labels:
                                       additionalProperties:
                                         type: string
-                                      description: The labels used to filter the list of resource when contacting the Kubernetes API.
+                                      description: The labels used to filter the list
+                                        of resource when contacting the Kubernetes
+                                        API.
                                       type: object
                                     namespace:
                                       description: |-
@@ -1478,10 +1554,12 @@ spec:
                                         Leave empty if you are looking for datasource cross-namespace.
                                       type: string
                                     pod_configuration:
-                                      description: Configuration when you want to discover the pods in Kubernetes
+                                      description: Configuration when you want to
+                                        discover the pods in Kubernetes
                                       properties:
                                         container_name:
-                                          description: Name of the container the target address points to.
+                                          description: Name of the container the target
+                                            address points to.
                                           type: string
                                         container_port_name:
                                           description: Name of the container port.
@@ -1491,20 +1569,25 @@ spec:
                                           format: int32
                                           type: integer
                                         enable:
-                                          description: If set to true, Perses server will discovery the pod
+                                          description: If set to true, Perses server
+                                            will discovery the pod
                                           type: boolean
                                       type: object
                                     service_configuration:
-                                      description: Configuration when you want to discover the services in Kubernetes
+                                      description: Configuration when you want to
+                                        discover the services in Kubernetes
                                       properties:
                                         enable:
-                                          description: If set to true, Perses server will discovery the service
+                                          description: If set to true, Perses server
+                                            will discovery the service
                                           type: boolean
                                         port_name:
-                                          description: Name of the service port for the target.
+                                          description: Name of the service port for
+                                            the target.
                                           type: string
                                         port_number:
-                                          description: Number of the service port for the target.
+                                          description: Number of the service port
+                                            for the target.
                                           format: int32
                                           type: integer
                                         service_type:
@@ -1516,7 +1599,8 @@ spec:
                                   - namespace
                                   type: object
                                 name:
-                                  description: The name of the discovery config. It is used for logging purposes only
+                                  description: The name of the discovery config. It
+                                    is used for logging purposes only
                                   type: string
                                 refresh_interval:
                                   description: Refresh interval to re-query the endpoint.
@@ -1546,15 +1630,18 @@ spec:
                     - project
                     type: object
                   ephemeral_dashboard:
-                    description: EphemeralDashboard contains the config about the ephemeral dashboard feature
+                    description: EphemeralDashboard contains the config about the
+                      ephemeral dashboard feature
                     properties:
                       cleanup_interval:
-                        description: The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
+                        description: The interval at which to trigger the cleanup
+                          of ephemeral dashboards, based on their TTLs.
                         format: duration
                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                         type: string
                       enable:
-                        description: When true user will be able to use the ephemeral dashboard at project level.
+                        description: When true user will be able to use the ephemeral
+                          dashboard at project level.
                         type: boolean
                     required:
                     - cleanup_interval
@@ -1569,10 +1656,25 @@ spec:
                     pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                     type: string
                   frontend:
-                    description: Frontend contains any config that will be used by the frontend itself.
+                    description: Frontend contains any config that will be used by
+                      the frontend itself.
                     properties:
+                      banner:
+                        description: BannerInfo contains the content to be display
+                          in a banner at the top of each page along with the severity
+                          of the information
+                        properties:
+                          message:
+                            type: string
+                          severity:
+                            type: string
+                        required:
+                        - message
+                        - severity
+                        type: object
                       disable:
-                        description: When it is true, Perses won't serve the frontend anymore, and any other config set here will be ignored
+                        description: When it is true, Perses won't serve the frontend
+                          anymore, and any other config set here will be ignored
                         type: boolean
                       explorer:
                         description: |-
@@ -1585,11 +1687,13 @@ spec:
                         - enable
                         type: object
                       important_dashboards:
-                        description: ImportantDashboards contains important dashboard selectors
+                        description: ImportantDashboards contains important dashboard
+                          selectors
                         items:
                           properties:
                             dashboard:
-                              description: Dashboard is the name of the dashboard (dashboard.metadata.name)
+                              description: Dashboard is the name of the dashboard
+                                (dashboard.metadata.name)
                               type: string
                             project:
                               description: Project is the name of the project (dashboard.metadata.project)
@@ -1600,10 +1704,12 @@ spec:
                           type: object
                         type: array
                       information:
-                        description: Information contains markdown content to be display on the home page
+                        description: Information contains markdown content to be display
+                          on the home page
                         type: string
                       time_range:
-                        description: TimeRange contains the time range configuration for the dropdown
+                        description: TimeRange contains the time range configuration
+                          for the dropdown
                         properties:
                           disable_custom:
                             type: boolean
@@ -1611,13 +1717,20 @@ spec:
                             type: boolean
                           options:
                             items:
+                              description: |-
+                                DurationString is a string that represents a duration, such as "1h", "30m", "15s", etc.
+                                It is used to unmarshal a duration string from JSON or YAML, and validate that it is a valid duration string.
+
+                                Not converting the duration string into a time.Duration type allows us to avoid the issue of changing the initial input with an alias.
+                                This is something that happens when we use Duration type, because when the duration is unmarshalled then marshaled again, the input can be changed with an equivalent duration.
+                                For example "14d" will be changed to "2w".
+
+                                So, use DurationString instead of Duration when you want to preserve the original input string.
+                                If, for any reason, you need to convert the DurationString to a time.Duration, you can use the ParseDuration function.
                               format: duration
                               pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                               type: string
                             type: array
-                        required:
-                        - disable_custom
-                        - disable_zoom
                         type: object
                     required:
                     - disable
@@ -1630,18 +1743,29 @@ spec:
                         description: |-
                           ArchivePath is the path to the directory containing the archived plugins
                           When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
+                          DEPRECATED: This attribute is deprecated and will be removed in a future version. It is still supported for backward compatibility, but it is recommended to use the `archive_paths` attribute instead.
                         type: string
+                      archive_paths:
+                        description: |-
+                          ArchivePaths is the list of paths to the directories containing the archived plugins. It allows to specify multiple directories for the archived plugins.
+                          When Perses is starting, it will extract any archive found in the folders specified in this attribute in the folder specified in the `path` attribute.
+                        items:
+                          type: string
+                        type: array
                       enable_dev:
-                        description: DevEnvironment is the configuration to use when developing a plugin
+                        description: DevEnvironment is the configuration to use when
+                          developing a plugin
                         type: boolean
                       path:
-                        description: Path is the path to the directory containing the runtime plugins
+                        description: Path is the path to the directory containing
+                          the runtime plugins
                         type: string
                     required:
                     - enable_dev
                     type: object
                   provisioning:
-                    description: Provisioning contains the provisioning config that can be used if you want to provide default resources.
+                    description: Provisioning contains the provisioning config that
+                      can be used if you want to provide default resources.
                     properties:
                       folders:
                         items:
@@ -1673,13 +1797,17 @@ spec:
                         type: string
                     type: object
                   security:
-                    description: Security contains any configuration that changes the API behavior like the endpoints exposed or if the permissions are activated.
+                    description: Security contains any configuration that changes
+                      the API behavior like the endpoints exposed or if the permissions
+                      are activated.
                     properties:
                       authentication:
-                        description: Authentication contains configuration regarding management of access/refresh token
+                        description: Authentication contains configuration regarding
+                          management of access/refresh token
                         properties:
                           access_token_ttl:
-                            description: AccessTokenTTL is the time to live of the access token. By default, it is 15 minutes.
+                            description: AccessTokenTTL is the time to live of the
+                              access token. By default, it is 15 minutes.
                             format: duration
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                             type: string
@@ -1689,10 +1817,18 @@ spec:
                               It also disables the endpoint that gives the possibility to create a user.
                             type: boolean
                           providers:
-                            description: Providers configure the different authentication providers
+                            description: Providers configure the different authentication
+                              providers
                             properties:
                               enable_native:
                                 type: boolean
+                              kubernetes:
+                                properties:
+                                  enable:
+                                    type: boolean
+                                required:
+                                - enable
+                                type: object
                               oauth:
                                 items:
                                   properties:
@@ -1702,10 +1838,14 @@ spec:
                                     client_credentials:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -1713,14 +1853,17 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     client_id:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
                                       type: string
                                     client_secret:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
                                       type: string
                                     custom_login_property:
                                       type: string
@@ -1730,10 +1873,14 @@ spec:
                                     device_code:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -1741,7 +1888,6 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     http:
@@ -1753,25 +1899,32 @@ spec:
                                         tls_config:
                                           properties:
                                             ca:
-                                              description: Text of the CA cert to use for the targets.
+                                              description: Text of the CA cert to
+                                                use for the targets.
                                               type: string
                                             caFile:
-                                              description: The CA cert to use for the targets.
+                                              description: The CA cert to use for
+                                                the targets.
                                               type: string
                                             cert:
-                                              description: Text of the client cert file for the targets.
+                                              description: Text of the client cert
+                                                file for the targets.
                                               type: string
                                             certFile:
-                                              description: The client cert file for the targets.
+                                              description: The client cert file for
+                                                the targets.
                                               type: string
                                             insecureSkipVerify:
-                                              description: Disable target certificate validation.
+                                              description: Disable target certificate
+                                                validation.
                                               type: boolean
                                             key:
-                                              description: Text of the client key file for the targets.
+                                              description: Text of the client key
+                                                file for the targets.
                                               type: string
                                             keyFile:
-                                              description: The client key file for the targets.
+                                              description: The client key file for
+                                                the targets.
                                               type: string
                                             maxVersion:
                                               description: |-
@@ -1786,7 +1939,8 @@ spec:
                                                 See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                               type: string
                                             serverName:
-                                              description: Used to verify the hostname for the targets.
+                                              description: Used to verify the hostname
+                                                for the targets.
                                               type: string
                                           type: object
                                       required:
@@ -1827,10 +1981,14 @@ spec:
                                     client_credentials:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -1838,22 +1996,29 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     client_id:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
                                       type: string
                                     client_secret:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
                                       type: string
                                     device_code:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -1861,7 +2026,6 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     disable_pkce:
@@ -1878,25 +2042,32 @@ spec:
                                         tls_config:
                                           properties:
                                             ca:
-                                              description: Text of the CA cert to use for the targets.
+                                              description: Text of the CA cert to
+                                                use for the targets.
                                               type: string
                                             caFile:
-                                              description: The CA cert to use for the targets.
+                                              description: The CA cert to use for
+                                                the targets.
                                               type: string
                                             cert:
-                                              description: Text of the client cert file for the targets.
+                                              description: Text of the client cert
+                                                file for the targets.
                                               type: string
                                             certFile:
-                                              description: The client cert file for the targets.
+                                              description: The client cert file for
+                                                the targets.
                                               type: string
                                             insecureSkipVerify:
-                                              description: Disable target certificate validation.
+                                              description: Disable target certificate
+                                                validation.
                                               type: boolean
                                             key:
-                                              description: Text of the client key file for the targets.
+                                              description: Text of the client key
+                                                file for the targets.
                                               type: string
                                             keyFile:
-                                              description: The client key file for the targets.
+                                              description: The client key file for
+                                                the targets.
                                               type: string
                                             maxVersion:
                                               description: |-
@@ -1911,7 +2082,8 @@ spec:
                                                 See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                               type: string
                                             serverName:
-                                              description: Used to verify the hostname for the targets.
+                                              description: Used to verify the hostname
+                                                for the targets.
                                               type: string
                                           type: object
                                       required:
@@ -1921,6 +2093,15 @@ spec:
                                     issuer:
                                       format: uri
                                       type: string
+                                    logout:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        logout_redirect_param_name:
+                                          type: string
+                                      required:
+                                      - enabled
+                                      type: object
                                     name:
                                       type: string
                                     redirect_uri:
@@ -1941,6 +2122,7 @@ spec:
                                   - disable_pkce
                                   - http
                                   - issuer
+                                  - logout
                                   - name
                                   - slug_id
                                   type: object
@@ -1961,19 +2143,23 @@ spec:
                         - providers
                         type: object
                       authorization:
-                        description: Authorization contains all configs around rbac (permissions and roles)
+                        description: Authorization contains all configs around rbac
+                          (permissions and roles)
                         properties:
                           check_latest_update_interval:
-                            description: CheckLatestUpdateInterval that checks if the RBAC cache needs to be refreshed with db content. Only for SQL database setup.
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.CheckLatestUpdateInterval
+                              instead.'
                             format: duration
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                             type: string
                           guest_permissions:
-                            description: Default permissions for guest users (logged-in users)
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.GuestPermissions
+                              instead.'
                             items:
                               properties:
                                 actions:
-                                  description: Actions of the permission (read, create, update, delete, ...)
+                                  description: Actions of the permission (read, create,
+                                    update, delete, ...)
                                   items:
                                     type: string
                                   type: array
@@ -1989,6 +2175,81 @@ spec:
                               - scopes
                               type: object
                             type: array
+                          provider:
+                            properties:
+                              kubernetes:
+                                properties:
+                                  authenticator_ttl:
+                                    description: 'time an authenticator response will
+                                      be cached for. Default: 2m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_allow_ttl:
+                                    description: 'time an authorizer allow response
+                                      will be cached for. Default: 5m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_deny_ttl:
+                                    description: 'time an authorizer denied will be
+                                      cached for. Default: 30s'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  burst:
+                                    description: 'burst QPS the k8s client will use
+                                      with the apiserver. Default: 1000 qps'
+                                    type: integer
+                                  enable:
+                                    type: boolean
+                                  kubeconfig:
+                                    description: |-
+                                      The active user in the kubeconfig should have "create" permissions for the `TokenReview` and
+                                      `SubjectAccessReview` resources. If the kubeconfig parameter isn't available the pods service
+                                      account token will be used
+                                    type: string
+                                  qps:
+                                    description: 'query per second (QPS) the k8s client
+                                      will use with the apiserver. Default: 500 qps'
+                                    type: integer
+                                type: object
+                              native:
+                                properties:
+                                  check_latest_update_interval:
+                                    description: CheckLatestUpdateInterval that checks
+                                      if the RBAC cache needs to be refreshed with
+                                      db content. Only for SQL database setup.
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  enable:
+                                    type: boolean
+                                  guest_permissions:
+                                    description: Default permissions for guest users
+                                      (logged-in users)
+                                    items:
+                                      properties:
+                                        actions:
+                                          description: Actions of the permission (read,
+                                            create, update, delete, ...)
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopes:
+                                          description: |-
+                                            The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                            With Role, you can't target global kinds
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - actions
+                                      - scopes
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
                         type: object
                       cookie:
                         description: Cookie configuration
@@ -2000,7 +2261,8 @@ spec:
                               This setting also provides some protection against cross-site request forgery attacks (CSRF)
                             type: integer
                           secure:
-                            description: Set to true if you host Perses behind HTTPS. Default is false
+                            description: Set to true if you host Perses behind HTTPS.
+                              Default is false
                             type: boolean
                         required:
                         - secure
@@ -2047,10 +2309,12 @@ spec:
                           Also note the key size must be exactly 32 bytes long as we are using AES-256 to encrypt the data.
                         type: string
                       encryption_key_file:
-                        description: EncryptionKeyFile is the path to file containing the secret key
+                        description: EncryptionKeyFile is the path to file containing
+                          the secret key
                         type: string
                       readonly:
-                        description: Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
+                        description: Readonly will deactivate any HTTP POST, PUT,
+                          DELETE endpoint
                         type: boolean
                     required:
                     - cookie
@@ -2061,7 +2325,8 @@ spec:
                     description: Variable contains the configuration for the variable.
                     properties:
                       disable_local:
-                        description: DisableLocal when used is preventing the possibility to add a variable directly in the dashboard spec.
+                        description: DisableLocal when used is preventing the possibility
+                          to add a variable directly in the dashboard spec.
                         type: boolean
                       global:
                         properties:
@@ -2091,10 +2356,14 @@ spec:
                     type: object
                 type: object
               containerPort:
+                default: 8080
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
-                description: Image specifies the container image that should be used for the Perses deployment.
+                description: Image specifies the container image that should be used
+                  for the Perses deployment.
                 type: string
               livenessProbe:
                 description: |-
@@ -2126,7 +2395,8 @@ spec:
                     description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
-                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
@@ -2149,9 +2419,11 @@ spec:
                           "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
-                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
                               description: |-
@@ -2209,7 +2481,8 @@ spec:
                     description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
-                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
@@ -2291,7 +2564,8 @@ spec:
                     description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
-                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
@@ -2314,9 +2588,11 @@ spec:
                           "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
-                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
                               description: |-
@@ -2374,7 +2650,8 @@ spec:
                     description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
-                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
@@ -2414,7 +2691,8 @@ spec:
                 format: int32
                 type: integer
               service:
-                description: service specifies the service configuration for the perses instance
+                description: service specifies the service configuration for the perses
+                  instance
                 properties:
                   annotations:
                     additionalProperties:
@@ -2424,7 +2702,8 @@ spec:
                     type: string
                 type: object
               serviceAccountName:
-                description: ServiceAccountName is the name of the service account to use for the perses deployment or statefulset.
+                description: ServiceAccountName is the name of the service account
+                  to use for the perses deployment or statefulset.
                 type: string
               storage:
                 default:
@@ -2454,12 +2733,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -2486,12 +2768,15 @@ spec:
                     properties:
                       certPath:
                         description: Path to Certificate
+                        minLength: 1
                         type: string
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       privateKeyPath:
                         description: Path to Private key certificate
@@ -2529,9 +2814,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -2554,7 +2840,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -2636,13 +2923,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: PersesSpec defines the desired state of Perses
+            description: spec is the desired state of the Perses resource
             properties:
               affinity:
-                description: Affinity is a group of affinity scheduling rules.
+                description: affinity specifies the pod's scheduling constraints
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the pod.
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -2661,17 +2949,20 @@ spec:
                             (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the corresponding weight.
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -2696,14 +2987,16 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -2730,7 +3023,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -2748,7 +3042,8 @@ spec:
                           may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms. The terms are ORed.
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
                               description: |-
                                 A null or empty node selector term matches no objects. The requirements of
@@ -2756,14 +3051,16 @@ spec:
                                 The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements by node's labels.
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -2788,14 +3085,16 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
-                                  description: A list of node selector requirements by node's fields.
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
                                     description: |-
                                       A node selector requirement is a selector that contains values, a key, and an operator
                                       that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector applies to.
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -2829,7 +3128,8 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -2843,10 +3143,12 @@ spec:
                           "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
                                   description: |-
@@ -2854,14 +3156,17 @@ spec:
                                     If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -2931,14 +3236,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -3028,14 +3336,16 @@ spec:
                                 If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -3105,14 +3415,16 @@ spec:
                                 An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -3170,7 +3482,9 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
                         description: |-
@@ -3184,10 +3498,12 @@ spec:
                           "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
                                   description: |-
@@ -3195,14 +3511,17 @@ spec:
                                     If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -3272,14 +3591,17 @@ spec:
                                     An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
                                         description: |-
                                           A label selector requirement is a selector that contains values, a key, and an operator that
                                           relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that the selector applies to.
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
                                             description: |-
@@ -3369,14 +3691,16 @@ spec:
                                 If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -3446,14 +3770,16 @@ spec:
                                 An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
                                       relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
                                         description: |-
@@ -3512,89 +3838,125 @@ spec:
                     type: object
                 type: object
               args:
-                description: Args extra arguments to pass to perses
+                description: args are extra command-line arguments to pass to the
+                  Perses server
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               client:
-                description: Perses client configuration
+                description: client specifies the Perses client configuration
                 properties:
                   basicAuth:
-                    description: BasicAuth basic auth config for perses client
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
                     properties:
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
-                      password_path:
-                        description: Path to password
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
                         - file
                         type: string
                       username:
-                        description: Username for basic auth
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
-                    description: KubernetesAuth configuration for perses client
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
                     properties:
                       enable:
-                        description: Enable kubernetes auth for perses client
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
                         type: boolean
-                    required:
-                    - enable
                     type: object
                   oauth:
-                    description: OAuth configuration for perses client
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
                     properties:
                       authStyle:
                         description: |-
-                          AuthStyle optionally specifies how the endpoint wants the
-                          client ID & client secret sent. The zero value means to
-                          auto-detect.
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
                         type: integer
                       clientIDPath:
-                        description: Path to client id
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
                         type: string
                       clientSecretPath:
-                        description: Path to client secret
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
                         type: string
                       endpointParams:
                         additionalProperties:
                           items:
                             type: string
                           type: array
-                        description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
                         type: object
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
-                        description: Scope specifies optional requested permissions.
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       tokenURL:
                         description: |-
-                          TokenURL is the resource server's token endpoint
-                          URL. This is a constant specific to each server.
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
@@ -3604,26 +3966,46 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
-                    description: TLS the equivalent to the tls_config for perses client
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
                     properties:
                       caCert:
-                        description: CaCert to verify the perses certificate
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -3633,29 +4015,53 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
-                        description: Enable TLS connection to perses
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
                         type: boolean
                       insecureSkipVerify:
-                        description: InsecureSkipVerify skip verify of perses certificate
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
                         type: boolean
                       userCert:
-                        description: UserCert client cert/key for mTLS
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -3665,17 +4071,29 @@ spec:
                         - certPath
                         - type
                         type: object
-                    required:
-                    - enable
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:
+                description: config specifies the Perses server configuration
                 properties:
                   api_prefix:
-                    description: Use it in case you want to prefix the API path.
+                    description: |-
+                      Use it in case you want to prefix the API path.
+                      This can be useful if you are running Perses behind a reverse proxy.
+                      By default, the API is served with the path /api.
+                      With this config, it will be served with the path <api_prefix>/api
+                      Example: "/perses"
                     type: string
                   dashboard:
-                    description: Dashboard contains the configuration for the dashboard feature.
+                    description: Dashboard contains the configuration for the dashboard
+                      feature.
                     properties:
                       custom_lint_rules:
                         items:
@@ -3709,7 +4127,8 @@ spec:
                         type: array
                     type: object
                   database:
-                    description: Database contains the different configuration depending on the database you want to use
+                    description: Database contains the different configuration depending
+                      on the database you want to use
                     properties:
                       file:
                         properties:
@@ -3727,17 +4146,24 @@ spec:
                           addr:
                             description: Network address (requires Net)
                             type: string
+                          addr_file:
+                            description: AddrFile is a path to a file that contains
+                              the network address
+                            type: string
                           allow_all_files:
-                            description: Allow all files to be used with LOAD DATA LOCAL INFILE
+                            description: Allow all files to be used with LOAD DATA
+                              LOCAL INFILE
                             type: boolean
                           allow_cleartext_passwords:
                             description: Allows the cleartext client side plugin
                             type: boolean
                           allow_fallback_to_plaintext:
-                            description: Allows fallback to unencrypted connection if server does not support TLS
+                            description: Allows fallback to unencrypted connection
+                              if server does not support TLS
                             type: boolean
                           allow_native_passwords:
-                            description: Allows the native password authentication method
+                            description: Allows the native password authentication
+                              method
                             type: boolean
                           allow_old_passwords:
                             description: Allows the old insecure password method
@@ -3745,10 +4171,12 @@ spec:
                           case_sensitive:
                             type: boolean
                           check_conn_liveness:
-                            description: Check connections for liveness before using them
+                            description: Check connections for liveness before using
+                              them
                             type: boolean
                           client_found_rows:
-                            description: Return number of matching rows instead of rows changed
+                            description: Return number of matching rows instead of
+                              rows changed
                             type: boolean
                           collation:
                             description: Connection collation
@@ -3781,7 +4209,8 @@ spec:
                             description: Password (requires User)
                             type: string
                           password_file:
-                            description: PasswordFile is a path to a file that contains a password
+                            description: PasswordFile is a path to a file that contains
+                              a password
                             type: string
                           read_timeout:
                             description: I/O read timeout
@@ -3803,55 +4232,35 @@ spec:
                             description: TLS configuration
                             properties:
                               ca:
-                                description: Text of the CA cert to use for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              ca_file:
-                                description: The CA cert to use for the targets.
-                                type: string
-                              ca_ref:
-                                description: |-
-                                  CARef is the name of the secret within the secret manager to use as the CA cert for the
-                                  targets.
+                              caFile:
                                 type: string
                               cert:
-                                description: Text of the client cert file for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              cert_file:
-                                description: The client cert file for the targets.
+                              certFile:
                                 type: string
-                              cert_ref:
-                                description: |-
-                                  CertRef is the name of the secret within the secret manager to use as the client cert for
-                                  the targets.
-                                type: string
-                              insecure_skip_verify:
-                                description: Disable target certificate validation.
+                              insecureSkipVerify:
                                 type: boolean
                               key:
-                                description: Text of the client key file for the targets.
+                                description: Hidden special type for storing secrets.
                                 type: string
-                              key_file:
-                                description: The client key file for the targets.
+                              keyFile:
                                 type: string
-                              key_ref:
-                                description: |-
-                                  KeyRef is the name of the secret within the secret manager to use as the client key for
-                                  the targets.
+                              maxVersion:
                                 type: string
-                              max_version:
-                                description: Maximum TLS version.
-                                type: integer
-                              min_version:
-                                description: Minimum TLS version.
-                                type: integer
-                              server_name:
-                                description: Used to verify the hostname for the targets.
+                              minVersion:
                                 type: string
-                            required:
-                            - insecure_skip_verify
+                              serverName:
+                                type: string
                             type: object
                           user:
                             description: Username
+                            type: string
+                          user_file:
+                            description: UserFile is a path to a file that contains
+                              a username
                             type: string
                           write_timeout:
                             description: I/O write timeout
@@ -3911,7 +4320,8 @@ spec:
                                     The HTTP header Content-Type must be application/json, and the body must be valid array of JSON.
                                   properties:
                                     authorization:
-                                      description: The HTTP authorization credentials for the targets.
+                                      description: The HTTP authorization credentials
+                                        for the targets.
                                       properties:
                                         credentials:
                                           type: string
@@ -3925,7 +4335,8 @@ spec:
                                         password:
                                           type: string
                                         passwordFile:
-                                          description: PasswordFile is a path to a file that contains a password
+                                          description: PasswordFile is a path to a
+                                            file that contains a password
                                           type: string
                                         username:
                                           type: string
@@ -3935,6 +4346,11 @@ spec:
                                     headers:
                                       additionalProperties:
                                         type: string
+                                      type: object
+                                    k8s_auth:
+                                      properties:
+                                        kubeconfig:
+                                          type: string
                                       type: object
                                     native_auth:
                                       properties:
@@ -3955,10 +4371,12 @@ spec:
                                             auto-detect.
                                           type: integer
                                         clientID:
-                                          description: ClientID is the application's ID.
+                                          description: ClientID is the application's
+                                            ID.
                                           type: string
                                         clientSecret:
-                                          description: ClientSecret is the application's secret.
+                                          description: ClientSecret is the application's
+                                            secret.
                                           type: string
                                         clientSecretFile:
                                           type: string
@@ -3967,10 +4385,12 @@ spec:
                                             items:
                                               type: string
                                             type: array
-                                          description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                                          description: EndpointParams specifies additional
+                                            parameters for requests to the token endpoint.
                                           type: object
                                         scopes:
-                                          description: Scope specifies optional requested permissions.
+                                          description: Scope specifies optional requested
+                                            permissions.
                                           items:
                                             type: string
                                           type: array
@@ -3989,28 +4409,36 @@ spec:
                                       - tokenURL
                                       type: object
                                     tls_config:
-                                      description: TLSConfig to use to connect to the targets.
+                                      description: TLSConfig to use to connect to
+                                        the targets.
                                       properties:
                                         ca:
-                                          description: Text of the CA cert to use for the targets.
+                                          description: Text of the CA cert to use
+                                            for the targets.
                                           type: string
                                         caFile:
-                                          description: The CA cert to use for the targets.
+                                          description: The CA cert to use for the
+                                            targets.
                                           type: string
                                         cert:
-                                          description: Text of the client cert file for the targets.
+                                          description: Text of the client cert file
+                                            for the targets.
                                           type: string
                                         certFile:
-                                          description: The client cert file for the targets.
+                                          description: The client cert file for the
+                                            targets.
                                           type: string
                                         insecureSkipVerify:
-                                          description: Disable target certificate validation.
+                                          description: Disable target certificate
+                                            validation.
                                           type: boolean
                                         key:
-                                          description: Text of the client key file for the targets.
+                                          description: Text of the client key file
+                                            for the targets.
                                           type: string
                                         keyFile:
-                                          description: The client key file for the targets.
+                                          description: The client key file for the
+                                            targets.
                                           type: string
                                         maxVersion:
                                           description: |-
@@ -4025,7 +4453,8 @@ spec:
                                             See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                           type: string
                                         serverName:
-                                          description: Used to verify the hostname for the targets.
+                                          description: Used to verify the hostname
+                                            for the targets.
                                           type: string
                                       type: object
                                     url:
@@ -4040,12 +4469,16 @@ spec:
                                     and always staying synchronized with the cluster state.
                                   properties:
                                     datasource_plugin_kind:
-                                      description: DatasourcePluginKind is the name of the datasource plugin that should be filled when creating datasources found.
+                                      description: DatasourcePluginKind is the name
+                                        of the datasource plugin that should be filled
+                                        when creating datasources found.
                                       type: string
                                     labels:
                                       additionalProperties:
                                         type: string
-                                      description: The labels used to filter the list of resource when contacting the Kubernetes API.
+                                      description: The labels used to filter the list
+                                        of resource when contacting the Kubernetes
+                                        API.
                                       type: object
                                     namespace:
                                       description: |-
@@ -4053,10 +4486,12 @@ spec:
                                         Leave empty if you are looking for datasource cross-namespace.
                                       type: string
                                     pod_configuration:
-                                      description: Configuration when you want to discover the pods in Kubernetes
+                                      description: Configuration when you want to
+                                        discover the pods in Kubernetes
                                       properties:
                                         container_name:
-                                          description: Name of the container the target address points to.
+                                          description: Name of the container the target
+                                            address points to.
                                           type: string
                                         container_port_name:
                                           description: Name of the container port.
@@ -4066,20 +4501,25 @@ spec:
                                           format: int32
                                           type: integer
                                         enable:
-                                          description: If set to true, Perses server will discovery the pod
+                                          description: If set to true, Perses server
+                                            will discovery the pod
                                           type: boolean
                                       type: object
                                     service_configuration:
-                                      description: Configuration when you want to discover the services in Kubernetes
+                                      description: Configuration when you want to
+                                        discover the services in Kubernetes
                                       properties:
                                         enable:
-                                          description: If set to true, Perses server will discovery the service
+                                          description: If set to true, Perses server
+                                            will discovery the service
                                           type: boolean
                                         port_name:
-                                          description: Name of the service port for the target.
+                                          description: Name of the service port for
+                                            the target.
                                           type: string
                                         port_number:
-                                          description: Number of the service port for the target.
+                                          description: Number of the service port
+                                            for the target.
                                           format: int32
                                           type: integer
                                         service_type:
@@ -4091,7 +4531,8 @@ spec:
                                   - namespace
                                   type: object
                                 name:
-                                  description: The name of the discovery config. It is used for logging purposes only
+                                  description: The name of the discovery config. It
+                                    is used for logging purposes only
                                   type: string
                                 refresh_interval:
                                   description: Refresh interval to re-query the endpoint.
@@ -4121,15 +4562,18 @@ spec:
                     - project
                     type: object
                   ephemeral_dashboard:
-                    description: EphemeralDashboard contains the config about the ephemeral dashboard feature
+                    description: EphemeralDashboard contains the config about the
+                      ephemeral dashboard feature
                     properties:
                       cleanup_interval:
-                        description: The interval at which to trigger the cleanup of ephemeral dashboards, based on their TTLs.
+                        description: The interval at which to trigger the cleanup
+                          of ephemeral dashboards, based on their TTLs.
                         format: duration
                         pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                         type: string
                       enable:
-                        description: When true user will be able to use the ephemeral dashboard at project level.
+                        description: When true user will be able to use the ephemeral
+                          dashboard at project level.
                         type: boolean
                     required:
                     - cleanup_interval
@@ -4144,10 +4588,25 @@ spec:
                     pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                     type: string
                   frontend:
-                    description: Frontend contains any config that will be used by the frontend itself.
+                    description: Frontend contains any config that will be used by
+                      the frontend itself.
                     properties:
+                      banner:
+                        description: BannerInfo contains the content to be display
+                          in a banner at the top of each page along with the severity
+                          of the information
+                        properties:
+                          message:
+                            type: string
+                          severity:
+                            type: string
+                        required:
+                        - message
+                        - severity
+                        type: object
                       disable:
-                        description: When it is true, Perses won't serve the frontend anymore, and any other config set here will be ignored
+                        description: When it is true, Perses won't serve the frontend
+                          anymore, and any other config set here will be ignored
                         type: boolean
                       explorer:
                         description: |-
@@ -4160,11 +4619,13 @@ spec:
                         - enable
                         type: object
                       important_dashboards:
-                        description: ImportantDashboards contains important dashboard selectors
+                        description: ImportantDashboards contains important dashboard
+                          selectors
                         items:
                           properties:
                             dashboard:
-                              description: Dashboard is the name of the dashboard (dashboard.metadata.name)
+                              description: Dashboard is the name of the dashboard
+                                (dashboard.metadata.name)
                               type: string
                             project:
                               description: Project is the name of the project (dashboard.metadata.project)
@@ -4175,10 +4636,12 @@ spec:
                           type: object
                         type: array
                       information:
-                        description: Information contains markdown content to be display on the home page
+                        description: Information contains markdown content to be display
+                          on the home page
                         type: string
                       time_range:
-                        description: TimeRange contains the time range configuration for the dropdown
+                        description: TimeRange contains the time range configuration
+                          for the dropdown
                         properties:
                           disable_custom:
                             type: boolean
@@ -4186,13 +4649,20 @@ spec:
                             type: boolean
                           options:
                             items:
+                              description: |-
+                                DurationString is a string that represents a duration, such as "1h", "30m", "15s", etc.
+                                It is used to unmarshal a duration string from JSON or YAML, and validate that it is a valid duration string.
+
+                                Not converting the duration string into a time.Duration type allows us to avoid the issue of changing the initial input with an alias.
+                                This is something that happens when we use Duration type, because when the duration is unmarshalled then marshaled again, the input can be changed with an equivalent duration.
+                                For example "14d" will be changed to "2w".
+
+                                So, use DurationString instead of Duration when you want to preserve the original input string.
+                                If, for any reason, you need to convert the DurationString to a time.Duration, you can use the ParseDuration function.
                               format: duration
                               pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                               type: string
                             type: array
-                        required:
-                        - disable_custom
-                        - disable_zoom
                         type: object
                     required:
                     - disable
@@ -4205,18 +4675,29 @@ spec:
                         description: |-
                           ArchivePath is the path to the directory containing the archived plugins
                           When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
+                          DEPRECATED: This attribute is deprecated and will be removed in a future version. It is still supported for backward compatibility, but it is recommended to use the `archive_paths` attribute instead.
                         type: string
+                      archive_paths:
+                        description: |-
+                          ArchivePaths is the list of paths to the directories containing the archived plugins. It allows to specify multiple directories for the archived plugins.
+                          When Perses is starting, it will extract any archive found in the folders specified in this attribute in the folder specified in the `path` attribute.
+                        items:
+                          type: string
+                        type: array
                       enable_dev:
-                        description: DevEnvironment is the configuration to use when developing a plugin
+                        description: DevEnvironment is the configuration to use when
+                          developing a plugin
                         type: boolean
                       path:
-                        description: Path is the path to the directory containing the runtime plugins
+                        description: Path is the path to the directory containing
+                          the runtime plugins
                         type: string
                     required:
                     - enable_dev
                     type: object
                   provisioning:
-                    description: Provisioning contains the provisioning config that can be used if you want to provide default resources.
+                    description: Provisioning contains the provisioning config that
+                      can be used if you want to provide default resources.
                     properties:
                       folders:
                         items:
@@ -4248,13 +4729,17 @@ spec:
                         type: string
                     type: object
                   security:
-                    description: Security contains any configuration that changes the API behavior like the endpoints exposed or if the permissions are activated.
+                    description: Security contains any configuration that changes
+                      the API behavior like the endpoints exposed or if the permissions
+                      are activated.
                     properties:
                       authentication:
-                        description: Authentication contains configuration regarding management of access/refresh token
+                        description: Authentication contains configuration regarding
+                          management of access/refresh token
                         properties:
                           access_token_ttl:
-                            description: AccessTokenTTL is the time to live of the access token. By default, it is 15 minutes.
+                            description: AccessTokenTTL is the time to live of the
+                              access token. By default, it is 15 minutes.
                             format: duration
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                             type: string
@@ -4264,10 +4749,18 @@ spec:
                               It also disables the endpoint that gives the possibility to create a user.
                             type: boolean
                           providers:
-                            description: Providers configure the different authentication providers
+                            description: Providers configure the different authentication
+                              providers
                             properties:
                               enable_native:
                                 type: boolean
+                              kubernetes:
+                                properties:
+                                  enable:
+                                    type: boolean
+                                required:
+                                - enable
+                                type: object
                               oauth:
                                 items:
                                   properties:
@@ -4277,10 +4770,14 @@ spec:
                                     client_credentials:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -4288,14 +4785,17 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     client_id:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
                                       type: string
                                     client_secret:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
                                       type: string
                                     custom_login_property:
                                       type: string
@@ -4305,10 +4805,14 @@ spec:
                                     device_code:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -4316,7 +4820,6 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     http:
@@ -4328,25 +4831,32 @@ spec:
                                         tls_config:
                                           properties:
                                             ca:
-                                              description: Text of the CA cert to use for the targets.
+                                              description: Text of the CA cert to
+                                                use for the targets.
                                               type: string
                                             caFile:
-                                              description: The CA cert to use for the targets.
+                                              description: The CA cert to use for
+                                                the targets.
                                               type: string
                                             cert:
-                                              description: Text of the client cert file for the targets.
+                                              description: Text of the client cert
+                                                file for the targets.
                                               type: string
                                             certFile:
-                                              description: The client cert file for the targets.
+                                              description: The client cert file for
+                                                the targets.
                                               type: string
                                             insecureSkipVerify:
-                                              description: Disable target certificate validation.
+                                              description: Disable target certificate
+                                                validation.
                                               type: boolean
                                             key:
-                                              description: Text of the client key file for the targets.
+                                              description: Text of the client key
+                                                file for the targets.
                                               type: string
                                             keyFile:
-                                              description: The client key file for the targets.
+                                              description: The client key file for
+                                                the targets.
                                               type: string
                                             maxVersion:
                                               description: |-
@@ -4361,7 +4871,8 @@ spec:
                                                 See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                               type: string
                                             serverName:
-                                              description: Used to verify the hostname for the targets.
+                                              description: Used to verify the hostname
+                                                for the targets.
                                               type: string
                                           type: object
                                       required:
@@ -4402,10 +4913,14 @@ spec:
                                     client_credentials:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -4413,22 +4928,29 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     client_id:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
                                       type: string
                                     client_secret:
-                                      description: Hidden special type for storing secrets.
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
                                       type: string
                                     device_code:
                                       properties:
                                         client_id:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
                                           type: string
                                         client_secret:
-                                          description: Hidden special type for storing secrets.
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
                                           type: string
                                         scopes:
                                           items:
@@ -4436,7 +4958,6 @@ spec:
                                           type: array
                                       required:
                                       - client_id
-                                      - client_secret
                                       - scopes
                                       type: object
                                     disable_pkce:
@@ -4453,25 +4974,32 @@ spec:
                                         tls_config:
                                           properties:
                                             ca:
-                                              description: Text of the CA cert to use for the targets.
+                                              description: Text of the CA cert to
+                                                use for the targets.
                                               type: string
                                             caFile:
-                                              description: The CA cert to use for the targets.
+                                              description: The CA cert to use for
+                                                the targets.
                                               type: string
                                             cert:
-                                              description: Text of the client cert file for the targets.
+                                              description: Text of the client cert
+                                                file for the targets.
                                               type: string
                                             certFile:
-                                              description: The client cert file for the targets.
+                                              description: The client cert file for
+                                                the targets.
                                               type: string
                                             insecureSkipVerify:
-                                              description: Disable target certificate validation.
+                                              description: Disable target certificate
+                                                validation.
                                               type: boolean
                                             key:
-                                              description: Text of the client key file for the targets.
+                                              description: Text of the client key
+                                                file for the targets.
                                               type: string
                                             keyFile:
-                                              description: The client key file for the targets.
+                                              description: The client key file for
+                                                the targets.
                                               type: string
                                             maxVersion:
                                               description: |-
@@ -4486,7 +5014,8 @@ spec:
                                                 See MinVersion in https://pkg.go.dev/crypto/tls#Config.
                                               type: string
                                             serverName:
-                                              description: Used to verify the hostname for the targets.
+                                              description: Used to verify the hostname
+                                                for the targets.
                                               type: string
                                           type: object
                                       required:
@@ -4496,6 +5025,15 @@ spec:
                                     issuer:
                                       format: uri
                                       type: string
+                                    logout:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        logout_redirect_param_name:
+                                          type: string
+                                      required:
+                                      - enabled
+                                      type: object
                                     name:
                                       type: string
                                     redirect_uri:
@@ -4516,6 +5054,7 @@ spec:
                                   - disable_pkce
                                   - http
                                   - issuer
+                                  - logout
                                   - name
                                   - slug_id
                                   type: object
@@ -4536,19 +5075,23 @@ spec:
                         - providers
                         type: object
                       authorization:
-                        description: Authorization contains all configs around rbac (permissions and roles)
+                        description: Authorization contains all configs around rbac
+                          (permissions and roles)
                         properties:
                           check_latest_update_interval:
-                            description: CheckLatestUpdateInterval that checks if the RBAC cache needs to be refreshed with db content. Only for SQL database setup.
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.CheckLatestUpdateInterval
+                              instead.'
                             format: duration
                             pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                             type: string
                           guest_permissions:
-                            description: Default permissions for guest users (logged-in users)
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.GuestPermissions
+                              instead.'
                             items:
                               properties:
                                 actions:
-                                  description: Actions of the permission (read, create, update, delete, ...)
+                                  description: Actions of the permission (read, create,
+                                    update, delete, ...)
                                   items:
                                     type: string
                                   type: array
@@ -4564,6 +5107,81 @@ spec:
                               - scopes
                               type: object
                             type: array
+                          provider:
+                            properties:
+                              kubernetes:
+                                properties:
+                                  authenticator_ttl:
+                                    description: 'time an authenticator response will
+                                      be cached for. Default: 2m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_allow_ttl:
+                                    description: 'time an authorizer allow response
+                                      will be cached for. Default: 5m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_deny_ttl:
+                                    description: 'time an authorizer denied will be
+                                      cached for. Default: 30s'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  burst:
+                                    description: 'burst QPS the k8s client will use
+                                      with the apiserver. Default: 1000 qps'
+                                    type: integer
+                                  enable:
+                                    type: boolean
+                                  kubeconfig:
+                                    description: |-
+                                      The active user in the kubeconfig should have "create" permissions for the `TokenReview` and
+                                      `SubjectAccessReview` resources. If the kubeconfig parameter isn't available the pods service
+                                      account token will be used
+                                    type: string
+                                  qps:
+                                    description: 'query per second (QPS) the k8s client
+                                      will use with the apiserver. Default: 500 qps'
+                                    type: integer
+                                type: object
+                              native:
+                                properties:
+                                  check_latest_update_interval:
+                                    description: CheckLatestUpdateInterval that checks
+                                      if the RBAC cache needs to be refreshed with
+                                      db content. Only for SQL database setup.
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  enable:
+                                    type: boolean
+                                  guest_permissions:
+                                    description: Default permissions for guest users
+                                      (logged-in users)
+                                    items:
+                                      properties:
+                                        actions:
+                                          description: Actions of the permission (read,
+                                            create, update, delete, ...)
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopes:
+                                          description: |-
+                                            The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                            With Role, you can't target global kinds
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - actions
+                                      - scopes
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
                         type: object
                       cookie:
                         description: Cookie configuration
@@ -4575,7 +5193,8 @@ spec:
                               This setting also provides some protection against cross-site request forgery attacks (CSRF)
                             type: integer
                           secure:
-                            description: Set to true if you host Perses behind HTTPS. Default is false
+                            description: Set to true if you host Perses behind HTTPS.
+                              Default is false
                             type: boolean
                         required:
                         - secure
@@ -4622,10 +5241,12 @@ spec:
                           Also note the key size must be exactly 32 bytes long as we are using AES-256 to encrypt the data.
                         type: string
                       encryption_key_file:
-                        description: EncryptionKeyFile is the path to file containing the secret key
+                        description: EncryptionKeyFile is the path to file containing
+                          the secret key
                         type: string
                       readonly:
-                        description: Readonly will deactivate any HTTP POST, PUT, DELETE endpoint
+                        description: Readonly will deactivate any HTTP POST, PUT,
+                          DELETE endpoint
                         type: boolean
                     required:
                     - cookie
@@ -4636,7 +5257,8 @@ spec:
                     description: Variable contains the configuration for the variable.
                     properties:
                       disable_local:
-                        description: DisableLocal when used is preventing the possibility to add a variable directly in the dashboard spec.
+                        description: DisableLocal when used is preventing the possibility
+                          to add a variable directly in the dashboard spec.
                         type: boolean
                       global:
                         properties:
@@ -4666,15 +5288,19 @@ spec:
                     type: object
                 type: object
               containerPort:
+                description: containerPort is the port on which the Perses server
+                  listens for HTTP requests
                 format: int32
+                maximum: 65535
+                minimum: 1
                 type: integer
               image:
-                description: Image specifies the container image that should be used for the Perses deployment.
+                description: image specifies the container image that should be used
+                  for the Perses deployment
                 type: string
               livenessProbe:
-                description: |-
-                  Probe describes a health check to be performed against a container to determine whether it is
-                  alive or ready to receive traffic.
+                description: livenessProbe specifies the liveness probe configuration
+                  for the Perses container
                 properties:
                   exec:
                     description: Exec specifies a command to execute in the container.
@@ -4701,7 +5327,8 @@ spec:
                     description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
-                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
@@ -4724,9 +5351,11 @@ spec:
                           "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
-                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
                               description: |-
@@ -4784,7 +5413,8 @@ spec:
                     description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
-                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
@@ -4820,26 +5450,47 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              logLevel:
+                description: logLevel defines the log level for Perses
+                enum:
+                - panic
+                - fatal
+                - error
+                - warning
+                - info
+                - debug
+                - trace
+                type: string
+              logMethodTrace:
+                description: |-
+                  logMethodTrace when true, includes the calling method as a field in the log
+                  It can be useful to see immediately where the log comes from
+                type: boolean
               metadata:
-                description: Metadata to add to deployed pods
+                description: metadata specifies additional metadata to add to deployed
+                  pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
+                    description: annotations are key/value pairs attached to pods
+                      for non-identifying metadata
                     type: object
                   labels:
                     additionalProperties:
                       type: string
+                    description: labels are key/value pairs attached to pods
                     type: object
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: nodeSelector constrains pods to nodes with matching labels
                 type: object
               podSecurityContext:
                 description: |-
-                  PodSecurityContext holds pod-level security attributes and common container settings.
-                  If not specified, defaults to fsGroup: 65534 to ensure proper volume permissions for the nobody user.
+                  podSecurityContext holds pod-level security attributes and common container settings
+                  If not specified, defaults to fsGroup: 65534 to ensure proper volume permissions for the nobody user
                 properties:
                   appArmorProfile:
                     description: |-
@@ -4953,16 +5604,20 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       level:
-                        description: Level is SELinux level label that applies to the container.
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
-                        description: Role is a SELinux role label that applies to the container.
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
-                        description: Type is a SELinux type label that applies to the container.
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
-                        description: User is a SELinux user label that applies to the container.
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
@@ -5047,7 +5702,8 @@ spec:
                           GMSA credential spec named by the GMSACredentialSpecName field.
                         type: string
                       gmsaCredentialSpecName:
-                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
                         description: |-
@@ -5065,10 +5721,40 @@ spec:
                         type: string
                     type: object
                 type: object
+              provisioning:
+                description: provisioning configuration for provisioning secrets
+                properties:
+                  secretRefs:
+                    description: secretRefs is a list of references to Kubernetes
+                      secrets used for provisioning sensitive data.
+                    items:
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
               readinessProbe:
-                description: |-
-                  Probe describes a health check to be performed against a container to determine whether it is
-                  alive or ready to receive traffic.
+                description: readinessProbe specifies the readiness probe configuration
+                  for the Perses container
                 properties:
                   exec:
                     description: Exec specifies a command to execute in the container.
@@ -5095,7 +5781,8 @@ spec:
                     description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
-                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
@@ -5118,9 +5805,11 @@ spec:
                           "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
-                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
-                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
                               description: |-
@@ -5178,7 +5867,8 @@ spec:
                     description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
-                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
@@ -5215,61 +5905,355 @@ spec:
                     type: integer
                 type: object
               replicas:
+                description: replicas is the number of desired pod replicas for the
+                  Perses deployment
                 format: int32
                 type: integer
+              resources:
+                description: resources defines the compute resources configured for
+                  the container
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
               service:
-                description: service specifies the service configuration for the perses instance
+                description: service specifies the service configuration for the Perses
+                  instance
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
+                    description: annotations are key/value pairs attached to the Service
+                      for non-identifying metadata
                     type: object
                   name:
+                    description: |-
+                      name is the name of the Kubernetes Service resource
+                      If not specified, a default name will be generated
                     type: string
                 type: object
               serviceAccountName:
-                description: ServiceAccountName is the name of the service account to use for the perses deployment or statefulset.
+                description: serviceAccountName is the name of the ServiceAccount
+                  to use for the Perses deployment or statefulset
                 type: string
               storage:
-                default:
-                  size: 1Gi
-                description: Storage configuration used by the StatefulSet
+                description: storage configuration used by the StatefulSet
                 properties:
-                  size:
-                    anyOf:
-                    - type: integer
-                    - type: string
+                  emptyDir:
                     description: |-
-                      Size of the storage.
-                      cannot be decreased.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storageClass:
+                      emptyDir to use for ephemeral storage.
+                      When set, data will be lost when the pod is deleted or restarted.
+                      Mutually exclusive with PersistentVolumeClaimTemplate.
+                    properties:
+                      medium:
+                        description: |-
+                          medium represents what type of storage medium should back this directory.
+                          The default is "" which means to use the node's default medium.
+                          Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                          The size limit is also applicable for memory medium.
+                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  pvcTemplate:
                     description: |-
-                      StorageClass to use for PVCs.
-                      If not specified, will use the default storage class
-                    type: string
+                      pvcTemplate is the template for PVCs that will be created.
+                      Mutually exclusive with EmptyDir.
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          Users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
                 type: object
+                x-kubernetes-validations:
+                - message: emptyDir and pvcTemplate are mutually exclusive
+                  rule: '!(has(self.emptyDir) && has(self.pvcTemplate))'
               tls:
-                description: tls specifies the tls configuration for the perses instance
+                description: tls specifies the TLS configuration for the Perses instance
                 properties:
                   caCert:
-                    description: CaCert to verify the perses certificate
+                    description: caCert specifies the CA certificate to verify the
+                      Perses server's certificate
                     properties:
                       certPath:
-                        description: Path to Certificate
+                        description: |-
+                          certPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the certificate is stored
+                        minLength: 1
                         type: string
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
-                        description: Path to Private key certificate
+                        description: |-
+                          privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the private key is stored
+                          Required for client certificates (UserCert), optional for CA certificates (CaCert)
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
@@ -5279,29 +6263,51 @@ spec:
                     - certPath
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   enable:
-                    description: Enable TLS connection to perses
+                    description: enable determines whether TLS is enabled for connections
+                      to Perses
                     type: boolean
                   insecureSkipVerify:
-                    description: InsecureSkipVerify skip verify of perses certificate
+                    description: |-
+                      insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                      Setting this to true is insecure and should only be used for testing
                     type: boolean
                   userCert:
-                    description: UserCert client cert/key for mTLS
+                    description: userCert specifies the client certificate and key
+                      for mutual TLS (mTLS) authentication
                     properties:
                       certPath:
-                        description: Path to Certificate
+                        description: |-
+                          certPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the certificate is stored
+                        minLength: 1
                         type: string
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       privateKeyPath:
-                        description: Path to Private key certificate
+                        description: |-
+                          privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the private key is stored
+                          Required for client certificates (UserCert), optional for CA certificates (CaCert)
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
@@ -5311,10 +6317,15 @@ spec:
                     - certPath
                     - type
                     type: object
-                required:
-                - enable
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                 type: object
               tolerations:
+                description: tolerations allow pods to schedule onto nodes with matching
+                  taints
                 items:
                   description: |-
                     The pod this Toleration is attached to tolerates any taint that matches
@@ -5333,9 +6344,10 @@ spec:
                     operator:
                       description: |-
                         Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                         Exists is equivalent to wildcard for value, so that a pod can
                         tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                       type: string
                     tolerationSeconds:
                       description: |-
@@ -5352,13 +6364,2008 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
+              volumeMounts:
+                description: |-
+                  volumeMounts allows configuration of additional VolumeMounts on the Deployment or StatefulSet definitions.
+                  VolumeMounts specified here will be appended to other operator-managed volume mounts.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
+                        When not set, MountPropagationNone is used.
+                        This field is beta in 1.10.
+                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                        (which defaults to None).
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
+                      type: boolean
+                    recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
+
+                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                        recursively read-only, if it is supported by the container runtime.  If this
+                        field is set to Enabled, the mount is made recursively read-only if it is
+                        supported by the container runtime, otherwise the pod will not be started and
+                        an error will be generated to indicate the reason.
+
+                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                        None (or be unspecified, which defaults to None).
+
+                        If this field is not specified, it is treated as an equivalent of Disabled.
+                      type: string
+                    subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: |-
+                        Expanded path within the volume from which the container's volume should be mounted.
+                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                        Defaults to "" (volume's root).
+                        SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - mountPath
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: volumeMount mountPath must not conflict with or shadow
+                    operator-reserved paths under /etc/perses/config, /etc/perses/plugins,
+                    /etc/perses/provisioning, or /etc/perses, /perses, /ca, /tls
+                  rule: self.all(m, !m.mountPath.startsWith('/etc/perses/config')
+                    && !m.mountPath.startsWith('/etc/perses/plugins') && !m.mountPath.startsWith('/etc/perses/provisioning')
+                    && !(m.mountPath in ['/etc/perses', '/perses', '/ca', '/tls']))
+              volumes:
+                description: |-
+                  volumes allows configuration of additional volumes on the Deployment or StatefulSet definitions.
+                  Volumes specified here will be appended to other operator-managed volumes.
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: boolean
+                        volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
+                      properties:
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                      properties:
+                        monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: boolean
+                        secretFile:
+                          description: |-
+                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the ConfigMap,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
+                      properties:
+                        driver:
+                          description: |-
+                            driver is the name of the CSI driver that handles this volume.
+                            Consult with your admin for the correct name as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated CSI driver
+                            which will determine the default filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete the CSI
+                            NodePublishVolume and NodeUnpublishVolume calls.
+                            This field is optional, and  may be empty if no secret is required. If the
+                            secret object contains more than one secret, all secret references are passed.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver. Consult your driver's documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            Optional: mode bits to use on created files by default. Must be a
+                            Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                      properties:
+                        medium:
+                          description: |-
+                            medium represents what type of storage medium should back this directory.
+                            The default is "" which means to use the node's default medium.
+                            Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                            The size limit is also applicable for memory medium.
+                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                            The default is nil which means that the limit is undefined.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: |-
+                        ephemeral represents a volume that is handled by a cluster storage driver.
+                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                        and deleted when the pod is removed.
+
+                        Use this if:
+                        a) the volume is only needed while the pod runs,
+                        b) features of normal volumes like restoring from snapshot or capacity
+                           tracking are needed,
+                        c) the storage driver is specified through a storage class, and
+                        d) the storage driver supports dynamic volume provisioning through
+                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                           information on the connection between this volume type
+                           and PersistentVolumeClaim).
+
+                        Use PersistentVolumeClaim or one of the vendor-specific
+                        APIs for volumes that persist for longer than the lifecycle
+                        of an individual pod.
+
+                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                        be used that way - see the documentation of the driver for
+                        more information.
+
+                        A pod can use both types of ephemeral volumes and
+                        persistent volumes at the same time.
+                      properties:
+                        volumeClaimTemplate:
+                          description: |-
+                            Will be used to create a stand-alone PVC to provision the volume.
+                            The pod in which this EphemeralVolumeSource is embedded will be the
+                            owner of the PVC, i.e. the PVC will be deleted together with the
+                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                            entry. Pod validation will reject the pod if the concatenated name
+                            is not valid for a PVC (for example, too long).
+
+                            An existing PVC with that name that is not owned by the pod
+                            will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC is
+                            meant to be used by the pod, the PVC has to updated with an
+                            owner reference to the pod once the pod exists. Normally
+                            this should not be necessary, but it may be useful when
+                            manually reconstructing a broken cluster.
+
+                            This field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created.
+
+                            Required, must not be nil.
+                          properties:
+                            metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it. No other fields are allowed and will be rejected during
+                                validation.
+                              type: object
+                            spec:
+                              description: |-
+                                The specification for the PersistentVolumeClaim. The entire content is
+                                copied unchanged into the PVC that gets created from this
+                                template. The same fields as in a PersistentVolumeClaim
+                                are also valid here.
+                              properties:
+                                accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    Users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  type: string
+                                volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin scripts. This may be
+                            empty if no secret object is specified. If the secret object
+                            contains more than one secret, all secrets are passed to the plugin
+                            scripts.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                      properties:
+                        datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                        into the Pod's container.
+                      properties:
+                        directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                            the subdirectory with the given name.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: |-
+                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                      properties:
+                        endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
+                          type: string
+                        path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container. This is generally
+                        used for system agents or other privileged things that are allowed
+                        to see the host machine. Most containers will NOT need this.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      properties:
+                        path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                        type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    image:
+                      description: |-
+                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                      properties:
+                        pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          type: string
+                        reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
+                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                      type: object
+                    iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          type: string
+                        initiatorName:
+                          description: |-
+                            initiatorName is the custom iSCSI Initiator Name.
+                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                            <target portal>:<volume name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: |-
+                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: |-
+                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                      properties:
+                        path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: boolean
+                        server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
+                      properties:
+                        fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode are the mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
+                          items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
+                            properties:
+                              clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                  combination of signer name and a label selector.
+
+                                  Kubelet performs aggressive normalization of the PEM contents written
+                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                  may change the order over time.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                      everything".
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                      allowed not to exist.  If using signerName, then the combination of
+                                      signerName and labelSelector is allowed to match zero
+                                      ClusterTrustBundles.
+                                    type: boolean
+                                  path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
+                                    type: string
+                                  signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.  The contents of all selected
+                                      ClusterTrustBundles will be unified and deduplicated.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or server.
+
+                                  Kubelet generates a private key and uses it to send a
+                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                  request and issues a certificate chain, Kubelet writes the key and
+                                  certificate chain to the pod filesystem.  The pod does not start until
+                                  certificates have been issued for each podCertificate projected volume
+                                  source in its spec.
+
+                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                  timestamp.
+
+                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                  field, or separate files, indicated by the keyPath and
+                                  certificateChainPath fields.
+
+                                  The credential bundle is a single file in PEM format.  The first PEM
+                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                  entries are the certificate chain issued by the signer (typically,
+                                  signers will return their certificate chain in leaf-to-root order).
+
+                                  Prefer using the credential bundle format, since your application code
+                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                  your application must make two separate file reads. If these coincide
+                                  with a certificate rotation, it is possible that the private key and leaf
+                                  certificate you read may not correspond to each other.  Your application
+                                  will need to check for this condition, and re-read until they are
+                                  consistent.
+
+                                  The named signer controls chooses the format of the certificate it
+                                  issues; consult the signer implementation's documentation to learn how to
+                                  use the certificates it issues.
+                                properties:
+                                  certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  credentialBundlePath:
+                                    description: |-
+                                      Write the credential bundle at this path in the projected volume.
+
+                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                      key.
+
+                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                      certificate chain from the signer (leaf and any intermediates).
+
+                                      Using credentialBundlePath lets your Pod's application code make a single
+                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                      project them to separate files, your application code will need to
+                                      additionally check that the leaf certificate was issued to the key.
+                                    type: string
+                                  keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  keyType:
+                                    description: |-
+                                      The type of keypair Kubelet will generate for the pod.
+
+                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                      "ECDSAP521", and "ED25519".
+                                    type: string
+                                  maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
+
+                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                      generates for this projection.
+
+                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                      value is 7862400 (91 days).
+
+                                      The signer implementation is then free to issue a certificate with any
+                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                      longer than 24 hours.
+                                    format: int32
+                                    type: integer
+                                  signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
+                                    type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                      metadata in any way.
+
+                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                      Entries are subject to the same validation as object metadata annotations,
+                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                      are placed on values, except an overall size limitation on the entire field.
+
+                                      Signers should document the keys and values they support. Signers should
+                                      deny requests that contain keys they do not recognize.
+                                    type: object
+                                required:
+                                - keyType
+                                - signerName
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: |-
+                                      audience is the intended audience of the token. A recipient of a token
+                                      must identify itself with an identifier specified in the audience of the
+                                      token, and otherwise should reject the token. The audience defaults to the
+                                      identifier of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token. As the token approaches expiration, the kubelet volume
+                                      plugin will proactively rotate the service account token. The kubelet will
+                                      start trying to rotate the token if the token is older than 80 percent of
+                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                      and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    quobyte:
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                      properties:
+                        group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
+                          type: boolean
+                        registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries are separated with commas)
+                            which acts as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                          type: string
+                        user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: |-
+                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          type: string
+                        image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        keyring:
+                          default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        pool:
+                          default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                      properties:
+                        fsType:
+                          default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
+                            Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information. If this is not provided, Login operation will fail.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          default: ThinProvisioned
+                          description: |-
+                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values
+                            for mode bits. Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the Secret,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          type: string
+                      type: object
+                    storageos:
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.  If not specified, default values will be attempted.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: |-
+                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                            namespace is specified then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                            Set VolumeName to any name to override the default behaviour.
+                            Set to "default" if you are not using namespaces within StorageOS.
+                            Namespaces that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: volume name must not conflict with operator-reserved names
+                    (config, plugins, storage, ca, tls) or use the 'provisioning-'
+                    prefix
+                  rule: self.all(v, !(v.name in ['config', 'plugins', 'storage', 'ca',
+                    'tls']) && !v.name.startsWith('provisioning-'))
             type: object
           status:
-            description: PersesStatus defines the observed state of Perses
+            description: status is the observed state of the Perses resource
             properties:
               conditions:
+                description: conditions represent the latest observations of the Perses
+                  resource state
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -5411,6 +8418,30 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              provisioning:
+                description: provisioning contains the versions of provisioning secrets
+                  currently in use
+                items:
+                  description: SecretVersion represents a secret version
+                  properties:
+                    name:
+                      description: name is the name of the provisioning secret
+                      minLength: 1
+                      type: string
+                    version:
+                      description: version is the resource version of the provisioning
+                        secret
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             type: object
         type: object
     served: true
@@ -5423,7 +8454,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdashboards.perses.dev
 spec:
   conversion:
@@ -5446,7 +8477,9 @@ spec:
     singular: persesdashboard
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PersesDashboard is the Schema for the persesdashboards API
@@ -5488,7 +8521,23 @@ spec:
                         The data typed is available in Cue.
                       properties:
                         kind:
+                          description: Kind is the type of the plugin (e.g., Panel,
+                            Variable, Datasource, etc.).
                           type: string
+                        metadata:
+                          description: Metadata is an optional field that contains
+                            additional information such as version and registry of
+                            the plugin.
+                          properties:
+                            registry:
+                              description: 'Registry is optional. If not provided,
+                                it means the default registry: "perses.dev".'
+                              type: string
+                            version:
+                              description: Version is optional. If not provided, it
+                                means the latest version available in the Perses instance.
+                              type: string
+                          type: object
                         spec:
                           x-kubernetes-preserve-unknown-fields: true
                       required:
@@ -5509,7 +8558,8 @@ spec:
                     type: string
                 type: object
               duration:
-                description: Duration is the default time range to use when getting data to fill the dashboard
+                description: Duration is the default time range to use when getting
+                  data to fill the dashboard
                 format: duration
                 pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                 type: string
@@ -5525,6 +8575,25 @@ spec:
                   - spec
                   type: object
                 type: array
+              links:
+                description: Links is an optional list of links to display at the
+                  dashboard level
+                items:
+                  properties:
+                    name:
+                      type: string
+                    renderVariables:
+                      type: boolean
+                    targetBlank:
+                      type: boolean
+                    tooltip:
+                      type: string
+                    url:
+                      type: string
+                  required:
+                  - url
+                  type: object
+                type: array
               panels:
                 additionalProperties:
                   properties:
@@ -5538,8 +8607,6 @@ spec:
                               type: string
                             name:
                               type: string
-                          required:
-                          - name
                           type: object
                         links:
                           items:
@@ -5561,7 +8628,24 @@ spec:
                         plugin:
                           properties:
                             kind:
+                              description: Kind is the type of the plugin (e.g., Panel,
+                                Variable, Datasource, etc.).
                               type: string
+                            metadata:
+                              description: Metadata is an optional field that contains
+                                additional information such as version and registry
+                                of the plugin.
+                              properties:
+                                registry:
+                                  description: 'Registry is optional. If not provided,
+                                    it means the default registry: "perses.dev".'
+                                  type: string
+                                version:
+                                  description: Version is optional. If not provided,
+                                    it means the latest version available in the Perses
+                                    instance.
+                                  type: string
+                              type: object
                             spec:
                               x-kubernetes-preserve-unknown-fields: true
                           required:
@@ -5578,7 +8662,25 @@ spec:
                                   plugin:
                                     properties:
                                       kind:
+                                        description: Kind is the type of the plugin
+                                          (e.g., Panel, Variable, Datasource, etc.).
                                         type: string
+                                      metadata:
+                                        description: Metadata is an optional field
+                                          that contains additional information such
+                                          as version and registry of the plugin.
+                                        properties:
+                                          registry:
+                                            description: 'Registry is optional. If
+                                              not provided, it means the default registry:
+                                              "perses.dev".'
+                                            type: string
+                                          version:
+                                            description: Version is optional. If not
+                                              provided, it means the latest version
+                                              available in the Perses instance.
+                                            type: string
+                                        type: object
                                       spec:
                                         x-kubernetes-preserve-unknown-fields: true
                                     required:
@@ -5594,7 +8696,6 @@ spec:
                             type: object
                           type: array
                       required:
-                      - display
                       - plugin
                       type: object
                   required:
@@ -5603,7 +8704,8 @@ spec:
                   type: object
                 type: object
               refreshInterval:
-                description: RefreshInterval is the default refresh interval to use when landing on the dashboard
+                description: RefreshInterval is the default refresh interval to use
+                  when landing on the dashboard
                 format: duration
                 pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                 type: string
@@ -5611,7 +8713,8 @@ spec:
                 items:
                   properties:
                     kind:
-                      description: Kind is the type of the variable. Depending on the value of Kind, it will change the content of Spec.
+                      description: Kind is the type of the variable. Depending on
+                        the value of Kind, it will change the content of Spec.
                       type: string
                     spec:
                       x-kubernetes-preserve-unknown-fields: true
@@ -5630,7 +8733,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -5712,8 +8816,10 @@ spec:
           metadata:
             type: object
           spec:
+            description: spec is the desired state of the PersesDashboard resource
             properties:
               config:
+                description: config specifies the Perses dashboard configuration
                 properties:
                   datasources:
                     additionalProperties:
@@ -5733,7 +8839,24 @@ spec:
                             The data typed is available in Cue.
                           properties:
                             kind:
+                              description: Kind is the type of the plugin (e.g., Panel,
+                                Variable, Datasource, etc.).
                               type: string
+                            metadata:
+                              description: Metadata is an optional field that contains
+                                additional information such as version and registry
+                                of the plugin.
+                              properties:
+                                registry:
+                                  description: 'Registry is optional. If not provided,
+                                    it means the default registry: "perses.dev".'
+                                  type: string
+                                version:
+                                  description: Version is optional. If not provided,
+                                    it means the latest version available in the Perses
+                                    instance.
+                                  type: string
+                              type: object
                             spec:
                               x-kubernetes-preserve-unknown-fields: true
                           required:
@@ -5754,7 +8877,8 @@ spec:
                         type: string
                     type: object
                   duration:
-                    description: Duration is the default time range to use when getting data to fill the dashboard
+                    description: Duration is the default time range to use when getting
+                      data to fill the dashboard
                     format: duration
                     pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                     type: string
@@ -5770,6 +8894,25 @@ spec:
                       - spec
                       type: object
                     type: array
+                  links:
+                    description: Links is an optional list of links to display at
+                      the dashboard level
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        renderVariables:
+                          type: boolean
+                        targetBlank:
+                          type: boolean
+                        tooltip:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    type: array
                   panels:
                     additionalProperties:
                       properties:
@@ -5783,8 +8926,6 @@ spec:
                                   type: string
                                 name:
                                   type: string
-                              required:
-                              - name
                               type: object
                             links:
                               items:
@@ -5806,7 +8947,24 @@ spec:
                             plugin:
                               properties:
                                 kind:
+                                  description: Kind is the type of the plugin (e.g.,
+                                    Panel, Variable, Datasource, etc.).
                                   type: string
+                                metadata:
+                                  description: Metadata is an optional field that
+                                    contains additional information such as version
+                                    and registry of the plugin.
+                                  properties:
+                                    registry:
+                                      description: 'Registry is optional. If not provided,
+                                        it means the default registry: "perses.dev".'
+                                      type: string
+                                    version:
+                                      description: Version is optional. If not provided,
+                                        it means the latest version available in the
+                                        Perses instance.
+                                      type: string
+                                  type: object
                                 spec:
                                   x-kubernetes-preserve-unknown-fields: true
                               required:
@@ -5823,7 +8981,28 @@ spec:
                                       plugin:
                                         properties:
                                           kind:
+                                            description: Kind is the type of the plugin
+                                              (e.g., Panel, Variable, Datasource,
+                                              etc.).
                                             type: string
+                                          metadata:
+                                            description: Metadata is an optional field
+                                              that contains additional information
+                                              such as version and registry of the
+                                              plugin.
+                                            properties:
+                                              registry:
+                                                description: 'Registry is optional.
+                                                  If not provided, it means the default
+                                                  registry: "perses.dev".'
+                                                type: string
+                                              version:
+                                                description: Version is optional.
+                                                  If not provided, it means the latest
+                                                  version available in the Perses
+                                                  instance.
+                                                type: string
+                                            type: object
                                           spec:
                                             x-kubernetes-preserve-unknown-fields: true
                                         required:
@@ -5839,7 +9018,6 @@ spec:
                                 type: object
                               type: array
                           required:
-                          - display
                           - plugin
                           type: object
                       required:
@@ -5848,7 +9026,8 @@ spec:
                       type: object
                     type: object
                   refreshInterval:
-                    description: RefreshInterval is the default refresh interval to use when landing on the dashboard
+                    description: RefreshInterval is the default refresh interval to
+                      use when landing on the dashboard
                     format: duration
                     pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                     type: string
@@ -5856,7 +9035,8 @@ spec:
                     items:
                       properties:
                         kind:
-                          description: Kind is the type of the variable. Depending on the value of Kind, it will change the content of Spec.
+                          description: Kind is the type of the variable. Depending
+                            on the value of Kind, it will change the content of Spec.
                           type: string
                         spec:
                           x-kubernetes-preserve-unknown-fields: true
@@ -5871,20 +9051,20 @@ spec:
                 - panels
                 type: object
               instanceSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
+                description: instanceSelector selects Perses instances where this
+                  dashboard will be created
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
                       description: |-
                         A label selector requirement is a selector that contains values, a key, and an operator that
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
                           description: |-
@@ -5921,11 +9101,14 @@ spec:
             - config
             type: object
           status:
-            description: PersesDashboardStatus defines the observed state of PersesDashboard
+            description: status is the observed state of the PersesDashboard resource
             properties:
               conditions:
+                description: conditions represent the latest observations of the PersesDashboard
+                  resource state
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -5978,7 +9161,12 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -5990,7 +9178,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesdatasources.perses.dev
 spec:
   group: perses.dev
@@ -6003,7 +9191,9 @@ spec:
     singular: persesdatasource
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PersesDatasource is the Schema for the PersesDatasources API
@@ -6033,13 +9223,16 @@ spec:
                     description: BasicAuth basic auth config for perses client
                     properties:
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       password_path:
                         description: Path to password
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -6050,6 +9243,7 @@ spec:
                         type: string
                       username:
                         description: Username for basic auth
+                        minLength: 1
                         type: string
                     required:
                     - password_path
@@ -6085,13 +9279,16 @@ spec:
                           items:
                             type: string
                           type: array
-                        description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                        description: EndpointParams specifies additional parameters
+                          for requests to the token endpoint.
                         type: object
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
                         type: string
                       scopes:
                         description: Scope specifies optional requested permissions.
@@ -6102,6 +9299,7 @@ spec:
                         description: |-
                           TokenURL is the resource server's token endpoint
                           URL. This is a constant specific to each server.
+                        minLength: 1
                         type: string
                       type:
                         description: Type source type of secret
@@ -6122,12 +9320,15 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -6154,12 +9355,15 @@ spec:
                         properties:
                           certPath:
                             description: Path to Certificate
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
                             type: string
                           privateKeyPath:
                             description: Path to Private key certificate
@@ -6196,7 +9400,22 @@ spec:
                       The data typed is available in Cue.
                     properties:
                       kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
                         type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
                       spec:
                         x-kubernetes-preserve-unknown-fields: true
                     required:
@@ -6207,13 +9426,16 @@ spec:
                 - default
                 - plugin
                 type: object
+            required:
+            - config
             type: object
           status:
             description: PersesDatasourceStatus defines the observed state of PersesDatasource
             properties:
               conditions:
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -6295,85 +9517,122 @@ spec:
           metadata:
             type: object
           spec:
+            description: spec is the desired state of the PersesDatasource resource
             properties:
               client:
+                description: client specifies authentication and TLS configuration
+                  for the datasource
                 properties:
                   basicAuth:
-                    description: BasicAuth basic auth config for perses client
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
                     properties:
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
-                      password_path:
-                        description: Path to password
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
                         - file
                         type: string
                       username:
-                        description: Username for basic auth
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
-                    description: KubernetesAuth configuration for perses client
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
                     properties:
                       enable:
-                        description: Enable kubernetes auth for perses client
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
                         type: boolean
-                    required:
-                    - enable
                     type: object
                   oauth:
-                    description: OAuth configuration for perses client
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
                     properties:
                       authStyle:
                         description: |-
-                          AuthStyle optionally specifies how the endpoint wants the
-                          client ID & client secret sent. The zero value means to
-                          auto-detect.
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
                         type: integer
                       clientIDPath:
-                        description: Path to client id
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
                         type: string
                       clientSecretPath:
-                        description: Path to client secret
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
                         type: string
                       endpointParams:
                         additionalProperties:
                           items:
                             type: string
                           type: array
-                        description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
                         type: object
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
-                        description: Scope specifies optional requested permissions.
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       tokenURL:
                         description: |-
-                          TokenURL is the resource server's token endpoint
-                          URL. This is a constant specific to each server.
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
@@ -6383,26 +9642,46 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
-                    description: TLS the equivalent to the tls_config for perses client
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
                     properties:
                       caCert:
-                        description: CaCert to verify the perses certificate
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -6412,29 +9691,53 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
-                        description: Enable TLS connection to perses
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
                         type: boolean
                       insecureSkipVerify:
-                        description: InsecureSkipVerify skip verify of perses certificate
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
                         type: boolean
                       userCert:
-                        description: UserCert client cert/key for mTLS
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -6444,11 +9747,17 @@ spec:
                         - certPath
                         - type
                         type: object
-                    required:
-                    - enable
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:
+                description: config specifies the Perses datasource configuration
                 properties:
                   default:
                     type: boolean
@@ -6465,7 +9774,22 @@ spec:
                       The data typed is available in Cue.
                     properties:
                       kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
                         type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
                       spec:
                         x-kubernetes-preserve-unknown-fields: true
                     required:
@@ -6477,20 +9801,20 @@ spec:
                 - plugin
                 type: object
               instanceSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
+                description: instanceSelector selects Perses instances where this
+                  datasource will be created
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
                       description: |-
                         A label selector requirement is a selector that contains values, a key, and an operator that
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
                           description: |-
@@ -6527,11 +9851,14 @@ spec:
             - config
             type: object
           status:
-            description: PersesDatasourceStatus defines the observed state of PersesDatasource
+            description: status is the observed state of the PersesDatasource resource
             properties:
               conditions:
+                description: conditions represent the latest observations of the PersesDatasource
+                  resource state
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -6584,7 +9911,12 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -6596,7 +9928,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: persesglobaldatasources.perses.dev
 spec:
   conversion:
@@ -6622,7 +9954,8 @@ spec:
   - name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: PersesGlobalDatasource is the Schema for the PersesGlobalDatasources API
+        description: PersesGlobalDatasource is the Schema for the PersesGlobalDatasources
+          API
         properties:
           apiVersion:
             description: |-
@@ -6642,85 +9975,122 @@ spec:
           metadata:
             type: object
           spec:
+            description: spec is the desired state of the PersesGlobalDatasource resource
             properties:
               client:
+                description: client specifies authentication and TLS configuration
+                  for the datasource
                 properties:
                   basicAuth:
-                    description: BasicAuth basic auth config for perses client
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
                     properties:
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
-                      password_path:
-                        description: Path to password
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
                         - file
                         type: string
                       username:
-                        description: Username for basic auth
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
                         type: string
                     required:
-                    - password_path
+                    - passwordPath
                     - type
                     - username
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   kubernetesAuth:
-                    description: KubernetesAuth configuration for perses client
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
                     properties:
                       enable:
-                        description: Enable kubernetes auth for perses client
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
                         type: boolean
-                    required:
-                    - enable
                     type: object
                   oauth:
-                    description: OAuth configuration for perses client
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
                     properties:
                       authStyle:
                         description: |-
-                          AuthStyle optionally specifies how the endpoint wants the
-                          client ID & client secret sent. The zero value means to
-                          auto-detect.
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
                         type: integer
                       clientIDPath:
-                        description: Path to client id
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
                         type: string
                       clientSecretPath:
-                        description: Path to client secret
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
                         type: string
                       endpointParams:
                         additionalProperties:
                           items:
                             type: string
                           type: array
-                        description: EndpointParams specifies additional parameters for requests to the token endpoint.
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
                         type: object
                       name:
-                        description: Name of basic auth k8s resource (when type is secret or configmap)
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       namespace:
-                        description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
                         type: string
                       scopes:
-                        description: Scope specifies optional requested permissions.
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       tokenURL:
                         description: |-
-                          TokenURL is the resource server's token endpoint
-                          URL. This is a constant specific to each server.
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
                         type: string
                       type:
-                        description: Type source type of secret
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
                         enum:
                         - secret
                         - configmap
@@ -6730,26 +10100,46 @@ spec:
                     - tokenURL
                     - type
                     type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
                   tls:
-                    description: TLS the equivalent to the tls_config for perses client
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
                     properties:
                       caCert:
-                        description: CaCert to verify the perses certificate
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -6759,29 +10149,53 @@ spec:
                         - certPath
                         - type
                         type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                       enable:
-                        description: Enable TLS connection to perses
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
                         type: boolean
                       insecureSkipVerify:
-                        description: InsecureSkipVerify skip verify of perses certificate
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
                         type: boolean
                       userCert:
-                        description: UserCert client cert/key for mTLS
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
                         properties:
                           certPath:
-                            description: Path to Certificate
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
                             type: string
                           name:
-                            description: Name of basic auth k8s resource (when type is secret or configmap)
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           namespace:
-                            description: Namsespace of certificate k8s resource (when type is secret or configmap)
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
                             type: string
                           privateKeyPath:
-                            description: Path to Private key certificate
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
                             type: string
                           type:
-                            description: Type source type of secret
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
                             enum:
                             - secret
                             - configmap
@@ -6791,11 +10205,17 @@ spec:
                         - certPath
                         - type
                         type: object
-                    required:
-                    - enable
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
                     type: object
                 type: object
               config:
+                description: config specifies the Perses datasource configuration
                 properties:
                   default:
                     type: boolean
@@ -6812,7 +10232,22 @@ spec:
                       The data typed is available in Cue.
                     properties:
                       kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
                         type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
                       spec:
                         x-kubernetes-preserve-unknown-fields: true
                     required:
@@ -6824,20 +10259,20 @@ spec:
                 - plugin
                 type: object
               instanceSelector:
-                description: |-
-                  A label selector is a label query over a set of resources. The result of matchLabels and
-                  matchExpressions are ANDed. An empty label selector matches all objects. A null
-                  label selector matches no objects.
+                description: instanceSelector selects Perses instances where this
+                  datasource will be created
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
                       description: |-
                         A label selector requirement is a selector that contains values, a key, and an operator that
                         relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
                           description: |-
@@ -6874,11 +10309,15 @@ spec:
             - config
             type: object
           status:
-            description: PersesGlobalDatasourceStatus defines the observed state of PersesGlobalDatasource
+            description: status is the observed state of the PersesGlobalDatasource
+              resource
             properties:
               conditions:
+                description: conditions represent the latest observations of the PersesGlobalDatasource
+                  resource state
                 items:
-                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -6931,7 +10370,12 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -7317,29 +10761,6 @@ spec:
                 - linux
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8082
         - --leader-elect
@@ -7378,6 +10799,29 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       serviceAccountName: perses-operator-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -25,10 +25,9 @@ metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
-  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
   dnsNames:
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-    - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc
+    - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/config/crd/kustomizeconfig.yaml
+++ b/config/crd/kustomizeconfig.yaml
@@ -15,5 +15,3 @@ namespace:
   path: spec/conversion/webhook/clientConfig/service/namespace
   create: false
 
-varReference:
-- path: metadata/annotations

--- a/config/crd/patches/cainjection_in_perses.yaml
+++ b/config/crd/patches/cainjection_in_perses.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: perses.perses.dev

--- a/config/crd/patches/cainjection_in_persesdashboards.yaml
+++ b/config/crd/patches/cainjection_in_persesdashboards.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: persesdashboards.perses.dev

--- a/config/crd/patches/cainjection_in_persesdatasource.yaml
+++ b/config/crd/patches/cainjection_in_persesdatasource.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: persesdatasources.perses.dev

--- a/config/crd/patches/cainjection_in_persesglobaldatasource.yaml
+++ b/config/crd/patches/cainjection_in_persesglobaldatasource.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
   name: persesglobaldatasources.perses.dev

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,33 +42,66 @@ patches:
 # Note: webhookcainjection_patch.yaml is not needed since this operator only has conversion webhooks, not admission webhooks
 #- webhookcainjection_patch.yaml
 
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
+replacements:
+# Inject cert-manager Certificate namespace/name into CRD CA injection annotations
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+    name: serving-cert
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 0
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-# SERVICE_NAME and SERVICE_NAMESPACE variables for cert-manager Certificate DNS names
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
+    name: serving-cert
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: /
+      index: 1
+# Inject webhook Service name/namespace into Certificate dnsNames
+- source:
     kind: Service
     version: v1
     name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 0
+- source:
     kind: Service
     version: v1
     name: webhook-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Triggered by warning when ran `kustomize build config/default`

`# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.`

Migrate kustomize vars to replacements and add installer-check to CI

Add installer-check Makefile target and CI step in the lint job to verify bundle.yaml stays in sync with kustomize output.

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
