### PR TITLE
docs: add support for markdown formatting and validation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,3 +29,17 @@ jobs:
         run: make check-api-docs
       - name: check metrics docs are up-to-date
         run: make check-metrics-docs
+  check-docs:
+    name: 'check markdown formatting and links'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - uses: perses/github-actions@v0.11.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+      - name: format docs
+        run: make fmt-docs
+      - name: check docs are up-to-date
+        run: git diff --exit-code

--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,0 +1,13 @@
+version: 1
+timeout: '1m'
+
+validators:
+  # timeout
+  - regex: 'github\.com'
+    type: 'ignore'
+  # code 500
+  - regex: 'slack\.com'
+    type: 'ignore'
+  # timeout
+  - regex: 'slack\.cncf\.io'
+    type: 'ignore'

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,8 @@
 
 For project governance, see the [Perses Governance](https://github.com/perses/perses/blob/main/GOVERNANCE.md).
 
-| Name | GitHub ID | Affiliation |
-| --- | --- | --- |
-| Gabriel Bernal | [@jgbernalp](https://github.com/jgbernalp) | Red Hat |
-| Jayapriya Pai | [@slashpai](https://github.com/slashpai) | Red Hat |
+| Name             | GitHub ID                                      | Affiliation               |
+|------------------|------------------------------------------------|---------------------------|
+| Gabriel Bernal   | [@jgbernalp](https://github.com/jgbernalp)     | Red Hat                   |
+| Jayapriya Pai    | [@slashpai](https://github.com/slashpai)       | Red Hat                   |
 | Douglass Kirkley | [@dougkirkley](https://github.com/dougkirkley) | Enlighten, an HII Company |

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,11 @@ check-metrics-docs: generate-metrics-docs ## Verify that generated metrics docs 
 		git diff docs/metrics.md --exit-code; \
 	fi
 
+.PHONY: fmt-docs
+fmt-docs: mdox ## Format docs and validate links.
+	@echo ">> formatting markdown documents"
+	$(MDOX) fmt --soft-wraps -l $$(find . -name '*.md' -not -path './bin/*' -not -path './bundle/*' -not -path './.git/*' -not -path './docs/api.md' -not -path './docs/metrics.md' -print) --links.validate.config-file=./.mdox.validate.yaml
+
 .PHONY: fmt
 fmt: jsonnet-format ## Run go fmt against code.
 	go fmt ./...

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -62,6 +62,9 @@ GINKGO_VERSION = $(shell grep 'github.com/onsi/ginkgo/v2' go.mod | awk '{print $
 KUTTL = $(LOCALBIN)/kubectl-kuttl
 KUTTL_VERSION = 0.24.0
 
+MDOX = $(LOCALBIN)/mdox
+MDOX_VERSION = v0.9.0
+
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_VERSION = v2.10.1
 
@@ -193,6 +196,14 @@ $(KUTTL) kuttl: $(LOCALBIN) ## Install kubectl-kuttl locally if necessary.
 		chmod +x $(KUTTL) ;\
 	}
 
+.PHONY: mdox
+$(MDOX) mdox: $(LOCALBIN) ## Install mdox locally if necessary.
+	@{ \
+		set -ex ;\
+		[[ -f $(MDOX) ]] && exit 0 ;\
+		GOBIN=$(LOCALBIN) go install github.com/bwplotka/mdox@$(MDOX_VERSION) ;\
+	}
+
 .PHONY: golangci-lint
 $(GOLANGCI_LINT) golangci-lint: $(LOCALBIN) ## Install golangci-lint locally if necessary.
 	@{ \
@@ -224,7 +235,8 @@ build-tools: $(KUSTOMIZE) \
 		$(GINKGO) \
 		$(OPERATOR_SDK) \
 		$(OPM) \
-		$(KUTTL)
+		$(KUTTL) \
+		$(MDOX)
 
 
 .PHONY: clean-tools
@@ -248,4 +260,5 @@ validate-tools: build-tools ## Validate that all tools are installed and working
 	@echo -n "  operator-sdk: " && $(OPERATOR_SDK) version 2>&1 | head -n 1
 	@echo -n "  opm: " && $(OPM) version 2>&1 | head -n 1
 	@echo -n "  kuttl: " && $(KUTTL) version 2>&1 | head -n 1
+	@echo -n "  mdox: " && $(MDOX) --version 2>&1 | head -n 1
 	@echo "✅ All tools validated successfully!"

--- a/config/samples/openshift/README.md
+++ b/config/samples/openshift/README.md
@@ -6,27 +6,30 @@ Openshift provides a built-in Thanos Querier as part of its Monitoring stack. Us
 
 1. Login to your openshift cluster using the `oc` CLI tool:
 2. Retrieve the Thanos Querier route URL:
+
    ```bash
    oc get route thanos-querier -n openshift-monitoring -o jsonpath='{.spec.host}'
    ```
 3. Create a Perses project or use an existing one.
 4. In your Perses project, create a secret to store your OpenShift token:
-    - **Name**: "openshift-token"
-    - select **Custom Authorization**
-    - **Type**: "Bearer"
-    - **Credentials**: Paste your OpenShift token, which you can obtain by running:
-      ```bash
-      oc whoami -t
-      ```
-    - Enable the TLS configuration and toggle the "Insecure Skip Verify" option to true if your cluster uses self-signed certificates.
-    - Save the secret.
+   - **Name**: "openshift-token"
+   - select **Custom Authorization**
+   - **Type**: "Bearer"
+   - **Credentials**: Paste your OpenShift token, which you can obtain by running:
+
+     ```bash
+     oc whoami -t
+     ```
+   - Enable the TLS configuration and toggle the "Insecure Skip Verify" option to true if your cluster uses self-signed certificates.
+   - Save the secret.
 5. In your Perses project, create a new Datasource with the following configuration:
-    - **Name**: Openshift Thanos Querier
-    - **Set as Default**: true
-    - **Plugin Options**: Source: Prometheus Datasource
-    - **HTTP Settings**: Select Proxy and set the URL to `https://<thanos-querier-route-url>` (obtained from step 2)
-    - **Secret**: Fill the name of the secret, in this case "openshift-token" (created in step 4)
-    - Save the Datasource.
+   - **Name**: Openshift Thanos Querier
+   - **Set as Default**: true
+   - **Plugin Options**: Source: Prometheus Datasource
+   - **HTTP Settings**: Select Proxy and set the URL to `https://<thanos-querier-route-url>` (obtained from step 2)
+   - **Secret**: Fill the name of the secret, in this case "openshift-token" (created in step 4)
+   - Save the Datasource.
 6. In your Perses project, create a Dashboard and its Panels. As the Datasource is the default, all the queries will use the Openshift Thanos Querier by default.
+
 > [!IMPORTANT]
 > If you face any issues connecting to the Thanos Querier, ensure that your Perses instance can reach the Openshift cluster network and that the token has the necessary permissions to access the monitoring data.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -40,7 +40,6 @@ make run
 
 > [!NOTE]
 > The Perses server image used by the operator is resolved in this order (highest priority first):
->
 > 1. `spec.image` in the Perses CR
 > 2. `--perses-default-base-image` flag passed to the operator binary
 > 3. `DefaultPersesImage` constant in `internal/operator/defaults.go` (compile-time default)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,7 +36,7 @@ KUBEBUILDER_ASSETS="$(bin/setup-envtest use -p path)" \
 
 ## E2E Tests (kuttl)
 
-E2E tests use [kuttl](https://kuttl.dev/) to validate the operator end-to-end in a real [kind](https://kind.sigs.k8s.io/) cluster, including deployment, resource synchronization, and cleanup.
+E2E tests use [kuttl](https://github.com/kudobuilder/kuttl) to validate the operator end-to-end in a real [kind](https://kind.sigs.k8s.io/) cluster, including deployment, resource synchronization, and cleanup.
 
 ### Prerequisites
 
@@ -63,15 +63,15 @@ When iterating:
 
 The following Makefile variables can be overridden to customize the e2e environment:
 
-| Variable | Default | Description |
-| -------- | ------- | ----------- |
-| `KIND_CLUSTER_NAME` | `kuttl-e2e` | Name of the kind cluster |
-| `E2E_TAG` | Git short SHA | Image tag for the operator |
-| `E2E_IMG` | `docker.io/persesdev/perses-operator:<E2E_TAG>` | Full operator image reference |
+| Variable            | Default                                         | Description                   |
+|---------------------|-------------------------------------------------|-------------------------------|
+| `KIND_CLUSTER_NAME` | `kuttl-e2e`                                     | Name of the kind cluster      |
+| `E2E_TAG`           | Git short SHA                                   | Image tag for the operator    |
+| `E2E_IMG`           | `docker.io/persesdev/perses-operator:<E2E_TAG>` | Full operator image reference |
 
 ### Test Structure
 
-Tests are under `test/e2e/` following the [kuttl convention](https://kuttl.dev/docs/kuttl-test-harness.html). Kuttl creates a random namespace per test case for isolation. Steps run sequentially.
+Tests are under `test/e2e/` following the [kuttl convention](https://github.com/kudobuilder/kuttl/blob/main/docs/kuttl-test-harness.md). Kuttl creates a random namespace per test case for isolation. Steps run sequentially.
 
 ```text
 test/e2e/
@@ -114,9 +114,9 @@ See [Developer Guide](dev.md#modifying-or-adding-alerting-rules) for the full wo
 
 ## Integration vs E2E Tests
 
-| Aspect | Integration Tests | E2E Tests |
-| --- | --- | --- |
-| Environment | Lightweight API server via envtest (no real cluster) | Real Kubernetes cluster via kind |
-| Scope | Controller reconcile logic, CRD validation, status updates | Full operator lifecycle including pod scheduling and networking |
-| Speed | Fast (seconds) | Slower (minutes, includes cluster setup) |
-| Framework | Ginkgo + envtest | kuttl |
+| Aspect      | Integration Tests                                          | E2E Tests                                                       |
+|-------------|------------------------------------------------------------|-----------------------------------------------------------------|
+| Environment | Lightweight API server via envtest (no real cluster)       | Real Kubernetes cluster via kind                                |
+| Scope       | Controller reconcile logic, CRD validation, status updates | Full operator lifecycle including pod scheduling and networking |
+| Speed       | Fast (seconds)                                             | Slower (minutes, includes cluster setup)                        |
+| Framework   | Ginkgo + envtest                                           | kuttl                                                           |

--- a/hack/README.md
+++ b/hack/README.md
@@ -11,29 +11,29 @@ For quick testing, use [`operator-sdk run bundle`](https://sdk.operatorframework
 
 1. Install OLM (skip on OpenShift)
 
-    ```bash
-    bin/operator-sdk olm install
-    ```
+   ```bash
+   bin/operator-sdk olm install
+   ```
 
 2. Build and push the operator and bundle images
 
-    ```bash
-    IMAGE_TAG_BASE=<some-registry>/perses-operator
-    make test-image-build image-push bundle-build bundle-push
-    ```
+   ```bash
+   IMAGE_TAG_BASE=<some-registry>/perses-operator
+   make test-image-build image-push bundle-build bundle-push
+   ```
 
 3. Run the bundle
 
-    ```bash
-    bin/operator-sdk run bundle <some-registry>/perses-operator-bundle:v0.2.0
-    ```
+   ```bash
+   bin/operator-sdk run bundle <some-registry>/perses-operator-bundle:v0.2.0
+   ```
 
 4. Create a Perses CR
 
-    ```bash
-    kubectl create namespace perses-dev
-    kubectl apply -f config/samples/v1alpha2/perses.yaml
-    ```
+   ```bash
+   kubectl create namespace perses-dev
+   kubectl apply -f config/samples/v1alpha2/perses.yaml
+   ```
 
 To clean up: `bin/operator-sdk cleanup perses-operator`
 
@@ -43,38 +43,38 @@ For more control (e.g., testing catalog images or subscriptions), follow these s
 
 1. Install OLM (skip on OpenShift)
 
-    ```bash
-    bin/operator-sdk olm install
-    ```
+   ```bash
+   bin/operator-sdk olm install
+   ```
 
 2. Build and push all required images
 
-    ```bash
-    IMAGE_TAG_BASE=<some-registry>/perses-operator
-    make test-image-build image-push bundle-build bundle-push catalog-build catalog-push
-    ```
+   ```bash
+   IMAGE_TAG_BASE=<some-registry>/perses-operator
+   make test-image-build image-push bundle-build bundle-push catalog-build catalog-push
+   ```
 
 3. Update the image in `hack/resources/catalog-source.yaml` to match the image pushed above, then create a CatalogSource
 
-    ```bash
-    kubectl apply -f hack/resources/catalog-source.yaml
-    ```
+   ```bash
+   kubectl apply -f hack/resources/catalog-source.yaml
+   ```
 
 4. Create a Subscription
 
-    ```bash
-    kubectl apply -f hack/resources/operator-subscription.yaml
-    ```
+   ```bash
+   kubectl apply -f hack/resources/operator-subscription.yaml
+   ```
 
 5. Check that the operator is installed
 
-    ```bash
-    kubectl get clusterserviceversion -n operators -w
-    ```
+   ```bash
+   kubectl get clusterserviceversion -n operators -w
+   ```
 
 6. Create a Perses CR
 
-    ```bash
-    kubectl create namespace perses-dev
-    kubectl apply -f config/samples/v1alpha2/perses.yaml
-    ```
+   ```bash
+   kubectl create namespace perses-dev
+   kubectl apply -f config/samples/v1alpha2/perses.yaml
+   ```


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

This commit adds support for formatting and validating markdown files in the repo using mdox. It also updates the existing docs as part of the formatting and also adds a new job in existing workflow to format and validate

Closes: #311 

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
