### PR TITLE
 docs: use Github URLS for cert-manager and minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ objects, and ensures that the desired state is reconciled.
 
 You’ll need:
 
-- a Kubernetes cluster to run against. You can use [kind](https://sigs.k8s.io/kind) or [minikube](https://minikube.sigs.k8s.io/docs/) to get a local cluster for testing, or run against a remote cluster.
+- a Kubernetes cluster to run against. You can use [kind](https://sigs.k8s.io/kind) or [minikube](https://github.com/kubernetes/minikube) to get a local cluster for testing, or run against a remote cluster.
   **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed and configured to use your cluster.
 
@@ -85,7 +85,7 @@ You’ll need:
 The Perses Operator can be installed using the [Helm chart](https://github.com/perses/helm-charts) from the Perses Helm repository.
 
 > [!NOTE]
-> The Perses Operator requires [cert-manager](https://cert-manager.io/docs/installation/) to be installed in the cluster for webhook certificate management.
+> The Perses Operator requires [cert-manager](https://github.com/cert-manager/cert-manager) to be installed in the cluster for webhook certificate management.
 
 1. Add the Perses Helm repository:
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -4,7 +4,7 @@ This guide covers the development workflow for the Perses Operator. For general 
 
 ## Prerequisites
 
-* A Kubernetes cluster — use [kind](https://sigs.k8s.io/kind) or [minikube](https://minikube.sigs.k8s.io/docs/) for local development
+* A Kubernetes cluster — use [kind](https://sigs.k8s.io/kind) or [minikube](https://github.com/kubernetes/minikube) for local development
 * [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) configured for your cluster
 * [Go](https://go.dev/doc/install)
 
@@ -84,7 +84,7 @@ For remote clusters, build, push to a registry, and deploy:
 IMG=<some-registry>/perses-operator:tag make test-image-build image-push deploy-local
 ```
 
-**Using [cert-manager](https://cert-manager.io/) (recommended for production-like environments):**
+**Using [cert-manager](https://github.com/cert-manager/cert-manager) (recommended for production-like environments):**
 
 ```shell
 make install-cert-manager

--- a/hack/README.md
+++ b/hack/README.md
@@ -3,7 +3,7 @@
 ## Pre-requisites
 
 * [operator-sdk](https://sdk.operatorframework.io/docs/installation/) CLI (install via `make operator-sdk`)
-* A Kubernetes cluster like [kind](https://sigs.k8s.io/kind), [minikube](https://minikube.sigs.k8s.io/docs/), or [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) (OLM is pre-installed on OpenShift)
+* A Kubernetes cluster like [kind](https://sigs.k8s.io/kind), [minikube](https://github.com/kubernetes/minikube), or [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift) (OLM is pre-installed on OpenShift)
 
 ## Quick Start (Testing)
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

This commit replaces the site URLs with GitHub repository URLs to reduce the mdox validation ignore list

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
