### PR TITLE
[ENHANCEMENT] Publish container images to quay.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           registry: 'docker.io'
+      - name: Login to Quay.io
+        uses: redhat-actions/podman-login@v1
+        if: ${{ github.event_name == 'push' && (startsWith(github.ref_name, 'v') || github.ref_name == 'main') }}
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+          registry: 'quay.io'
       - name: install goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -60,6 +67,7 @@ jobs:
         run: |
           make cross-build
           BUNDLE_IMG=docker.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-build
+          BUNDLE_IMG=quay.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-build
       - name: Push main branch images
         ## This step will run when main branch is pushed.
         ## It will push docker images with 'main' tag and git SHA tag
@@ -67,6 +75,7 @@ jobs:
         run: |
           make push-main-docker-image
           BUNDLE_IMG=docker.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-push
+          BUNDLE_IMG=quay.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-push
       - name: Publish Release and binaries
         ## This step will only run when a new tag is pushed.
         ## It will build the Go binaries and the docker images and then publish:
@@ -75,9 +84,9 @@ jobs:
         if: ${{ github.event_name == 'push' && startsWith(github.ref_name, 'v') }}
         run: |
           make cross-release
-          make bundle-build
-          make bundle-push
-          make catalog-build
-          make catalog-push
+          BUNDLE_IMG=docker.io/persesdev/perses-operator-bundle:v$(cat VERSION) make bundle-build bundle-push
+          BUNDLE_IMG=quay.io/persesdev/perses-operator-bundle:v$(cat VERSION) make bundle-build bundle-push
+          CATALOG_IMG=docker.io/persesdev/perses-operator-catalog:v$(cat VERSION) make catalog-build catalog-push
+          CATALOG_IMG=quay.io/persesdev/perses-operator-catalog:v$(cat VERSION) make catalog-build catalog-push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/generate-goreleaser/dockerconfig/dockerconfig.go
+++ b/scripts/generate-goreleaser/dockerconfig/dockerconfig.go
@@ -28,6 +28,7 @@ func PersesOperatorDockerConfig(cfg TestConfig) *goreleaser.DockerConfig {
 		ImageName:  "perses-operator",
 		DebugImage: true,
 		BinaryIDs:  []string{"operator"},
+		Registry:   []string{"docker.io/persesdev", "quay.io/persesdev"},
 		ExtraFiles: []string{"LICENSE"},
 		Branch:     cfg.Branch,
 		Commit:     cfg.Commit,


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Add quay.io/persesdev as a second container registry for all operator images (operator, bundle, catalog). 

Requires QUAY_USERNAME and QUAY_TOKEN secrets to be configured in the GitHub repo settings before merging

Fixes #159

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
