### PR TITLE
[BUGFIX] Fix kube-rbac-proxy upstream port mismatch

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10801,7 +10801,7 @@ spec:
           readOnly: true
       - args:
         - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
+        - --upstream=http://127.0.0.1:8082/
         - --logtostderr=true
         - --v=0
         image: quay.io/brancz/kube-rbac-proxy:v0.21.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -34,7 +34,7 @@ spec:
         image: quay.io/brancz/kube-rbac-proxy:v0.21.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
+        - "--upstream=http://127.0.0.1:8082/"
         - "--logtostderr=true"
         - "--v=0"
         ports:


### PR DESCRIPTION
The proxy was forwarding to port 8080 but the manager binds its metrics endpoint to port 8082, making the authenticated metrics endpoint on port 8443 silently broken.

Fixes #342

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
