### PR TITLE
[BUGFIX] Fix probe ports ignoring spec.containerPort

### DIFF
--- a/internal/perses/common/probes.go
+++ b/internal/perses/common/probes.go
@@ -22,12 +22,17 @@ import (
 func GetProbes(perses *v1alpha2.Perses) (*v1.Probe, *v1.Probe) {
 	var livenessProbe, readinessProbe *v1.Probe
 
+	port := DefaultContainerPort
+	if perses.Spec.ContainerPort != nil {
+		port = *perses.Spec.ContainerPort
+	}
+
 	if perses.Spec.LivenessProbe != nil {
 		livenessProbe = &v1.Probe{
 			ProbeHandler: v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Path:   perses.Spec.Config.APIPrefix + "/metrics",
-					Port:   intstr.FromInt32(8080),
+					Port:   intstr.FromInt32(port),
 					Scheme: v1.URISchemeHTTP,
 				},
 			},
@@ -43,7 +48,7 @@ func GetProbes(perses *v1alpha2.Perses) (*v1.Probe, *v1.Probe) {
 			ProbeHandler: v1.ProbeHandler{
 				HTTPGet: &v1.HTTPGetAction{
 					Path:   perses.Spec.Config.APIPrefix + "/metrics",
-					Port:   intstr.FromInt32(8080),
+					Port:   intstr.FromInt32(port),
 					Scheme: v1.URISchemeHTTP,
 				},
 			},

--- a/internal/perses/common/probes_test.go
+++ b/internal/perses/common/probes_test.go
@@ -1,0 +1,82 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"github.com/perses/perses-operator/api/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetProbes", func() {
+	DescribeTable("when getting probes for a Perses instance",
+		func(perses *v1alpha2.Perses, expectedLiveness, expectedReadiness *int32) {
+			liveness, readiness := GetProbes(perses)
+			if expectedLiveness == nil {
+				Expect(liveness).To(BeNil())
+			} else {
+				Expect(liveness).NotTo(BeNil())
+				Expect(liveness.HTTPGet.Port.IntVal).To(Equal(*expectedLiveness))
+			}
+			if expectedReadiness == nil {
+				Expect(readiness).To(BeNil())
+			} else {
+				Expect(readiness).NotTo(BeNil())
+				Expect(readiness.HTTPGet.Port.IntVal).To(Equal(*expectedReadiness))
+			}
+		},
+		Entry("returns nil probes when none are configured",
+			&v1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec:       v1alpha2.PersesSpec{},
+			},
+			nil, nil,
+		),
+		Entry("uses DefaultContainerPort when containerPort is not set",
+			&v1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha2.PersesSpec{
+					LivenessProbe:  &corev1.Probe{},
+					ReadinessProbe: &corev1.Probe{},
+				},
+			},
+			ptr.To(DefaultContainerPort), ptr.To(DefaultContainerPort),
+		),
+		Entry("uses custom containerPort when set",
+			&v1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha2.PersesSpec{
+					ContainerPort:  ptr.To[int32](9000),
+					LivenessProbe:  &corev1.Probe{},
+					ReadinessProbe: &corev1.Probe{},
+				},
+			},
+			ptr.To[int32](9000), ptr.To[int32](9000),
+		),
+		Entry("only liveness probe configured uses correct port",
+			&v1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1alpha2.PersesSpec{
+					ContainerPort: ptr.To[int32](9000),
+					LivenessProbe: &corev1.Probe{},
+				},
+			},
+			ptr.To[int32](9000), nil,
+		),
+	)
+})


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Liveness and readiness probe ports were hardcoded to 8080, ignoring
the value set in spec.containerPort. Added unit tests to verify probes
use the correct port.

Closes: #346 

Needs #345 to be merged first

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
