### PR TITLE
[BUGFIX] fix delete errors being silently swallowed in dashboard, datasource and globaldatasource controllers

### DIFF
--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -371,6 +371,55 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())
 		})
+
+		It("should return an error when the Perses API delete call fails", func() {
+			By("Creating the custom resource for the Kind PersesDashboard")
+			dashboard := &persesv1alpha2.PersesDashboard{}
+			err := k8sClient.Get(ctx, dashboardNamespaceName, dashboard)
+			if err != nil && errors.IsNotFound(err) {
+				perses := &persesv1alpha2.PersesDashboard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DashboardName,
+						Namespace: PersesNamespace,
+					},
+					Spec: persesv1alpha2.PersesDashboardSpec{
+						Config: persesv1alpha2.Dashboard{
+							DashboardSpec: newDashboard.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, perses)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			mockPersesClient := new(internal.MockClient)
+			mockDashboard := new(internal.MockDashboard)
+
+			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
+			mockDashboard.On("Delete", DashboardName).Return(perseshttp.RequestInternalError)
+
+			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			dashboardToDelete := &persesv1alpha2.PersesDashboard{}
+			err = k8sClient.Get(ctx, dashboardNamespaceName, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Deleting the custom resource")
+			err = k8sClient.Delete(ctx, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Reconciling should return an error because the backend delete failed")
+			_, err = dashboardReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: dashboardNamespaceName,
+			})
+			Expect(err).To(HaveOccurred())
+			mockDashboard.AssertCalled(GinkgoT(), "Delete", DashboardName)
+		})
 	})
 
 	Context("Dashboard controller instance selector test", func() {

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -209,8 +209,15 @@ func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses 
 
 	err = persesClient.Dashboard(dashboardNamespace).Delete(dashboardName)
 
-	if err != nil && errors.Is(err, perseshttp.RequestNotFoundError) {
-		dlog.Infof("Dashboard not found: %s", dashboardName)
+	// Ignore NotFound — the resource may have already been deleted from Perses directly.
+	// Any other error means the delete failed and should be retried.
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			dlog.Infof("Dashboard not found: %s", dashboardName)
+			return subreconciler.ContinueReconciling()
+		}
+		dlog.WithError(err).Errorf("Failed to delete dashboard: %s", dashboardName)
+		return subreconciler.RequeueWithError(err)
 	}
 
 	dlog.Infof("Dashboard deleted: %s", dashboardName)

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -380,6 +380,55 @@ var _ = Describe("Datasource controller", Ordered, func() {
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())
 		})
+
+		It("should return an error when the Perses API delete call fails", func() {
+			By("Creating the custom resource for the Kind PersesDatasource")
+			datasource := &persesv1alpha2.PersesDatasource{}
+			err := k8sClient.Get(ctx, datasourceNamespaceName, datasource)
+			if err != nil && errors.IsNotFound(err) {
+				datasource = &persesv1alpha2.PersesDatasource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DatasourceName,
+						Namespace: PersesNamespace,
+					},
+					Spec: persesv1alpha2.DatasourceSpec{
+						Config: persesv1alpha2.Datasource{
+							DatasourceSpec: newDatasource.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, datasource)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			mockPersesClient := new(internal.MockClient)
+			mockDatasource := new(internal.MockDatasource)
+
+			mockPersesClient.On("Datasource", PersesNamespace).Return(mockDatasource)
+			mockDatasource.On("Delete", DatasourceName).Return(perseshttp.RequestInternalError)
+
+			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			datasourceToDelete := &persesv1alpha2.PersesDatasource{}
+			err = k8sClient.Get(ctx, datasourceNamespaceName, datasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Deleting the custom resource")
+			err = k8sClient.Delete(ctx, datasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Reconciling should return an error because the backend delete failed")
+			_, err = datasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: datasourceNamespaceName,
+			})
+			Expect(err).To(HaveOccurred())
+			mockDatasource.AssertCalled(GinkgoT(), "Delete", DatasourceName)
+		})
 	})
 
 	Context("Datasource controller test with api_prefix", func() {

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -402,23 +402,36 @@ func (r *PersesDatasourceReconciler) deleteDatasource(ctx context.Context, perse
 		return subreconciler.RequeueWithError(err)
 	}
 
+	// Ignore NotFound — the resource may have already been deleted from Perses directly.
+	// Any other error means the delete failed and should be retried.
+	// Secret delete is attempted regardless of whether the datasource was found or not.
 	err = persesClient.Datasource(datasourceNamespace).Delete(datasourceName)
 
-	if err != nil && errors.Is(err, perseshttp.RequestNotFoundError) {
-		dlog.Infof("Datasource not found: %s", datasourceName)
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			dlog.Infof("Datasource not found: %s", datasourceName)
+		} else {
+			dlog.WithError(err).Errorf("Failed to delete datasource: %s", datasourceName)
+			return subreconciler.RequeueWithError(err)
+		}
+	} else {
+		dlog.Infof("Datasource deleted: %s", datasourceName)
 	}
-
-	dlog.Infof("Datasource deleted: %s", datasourceName)
 
 	secretName := datasourceName + persescommon.SecretNameSuffix
 
 	err = persesClient.Secret(datasourceNamespace).Delete(secretName)
 
-	if err != nil && errors.Is(err, perseshttp.RequestNotFoundError) {
-		dlog.Infof("Secret not found: %s", secretName)
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			dlog.Infof("Secret not found: %s", secretName)
+		} else {
+			dlog.WithError(err).Errorf("Failed to delete secret: %s", secretName)
+			return subreconciler.RequeueWithError(err)
+		}
+	} else {
+		dlog.Infof("Secret deleted: %s", secretName)
 	}
-
-	dlog.Infof("Secret deleted: %s", secretName)
 
 	return subreconciler.ContinueReconciling()
 }

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -374,5 +374,53 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())
 		})
+
+		It("should return an error when the Perses API delete call fails", func() {
+			By("Creating the custom resource for the Kind PersesGlobalDatasource")
+			globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
+			err := k8sClient.Get(ctx, globaldatasourceNamespaceName, globaldatasource)
+			if err != nil && errors.IsNotFound(err) {
+				globaldatasource = &persesv1alpha2.PersesGlobalDatasource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: GlobalDatasourceName,
+					},
+					Spec: persesv1alpha2.DatasourceSpec{
+						Config: persesv1alpha2.Datasource{
+							DatasourceSpec: newGlobalDatasource.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, globaldatasource)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			mockPersesClient := new(internal.MockClient)
+			mockGlobalDatasource := new(internal.MockGlobalDatasource)
+
+			mockPersesClient.On("GlobalDatasource").Return(mockGlobalDatasource)
+			mockGlobalDatasource.On("Delete", GlobalDatasourceName).Return(perseshttp.RequestInternalError)
+
+			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			globaldatasourceToDelete := &persesv1alpha2.PersesGlobalDatasource{}
+			err = k8sClient.Get(ctx, globaldatasourceNamespaceName, globaldatasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Deleting the custom resource")
+			err = k8sClient.Delete(ctx, globaldatasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Reconciling should return an error because the backend delete failed")
+			_, err = globaldatasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: globaldatasourceNamespaceName,
+			})
+			Expect(err).To(HaveOccurred())
+			mockGlobalDatasource.AssertCalled(GinkgoT(), "Delete", GlobalDatasourceName)
+		})
 	})
 })

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -378,23 +378,36 @@ func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasource(ctx context.Co
 		return subreconciler.RequeueWithError(err)
 	}
 
+	// Ignore NotFound — the resource may have already been deleted from Perses directly.
+	// Any other error means the delete failed and should be retried.
+	// Secret delete is attempted regardless of whether the datasource was found or not.
 	err = persesClient.GlobalDatasource().Delete(datasourceName)
 
-	if err != nil && errors.Is(err, perseshttp.RequestNotFoundError) {
-		gdlog.Infof("GlobalDatasource not found: %s", datasourceName)
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			gdlog.Infof("GlobalDatasource not found: %s", datasourceName)
+		} else {
+			gdlog.WithError(err).Errorf("Failed to delete global datasource: %s", datasourceName)
+			return subreconciler.RequeueWithError(err)
+		}
+	} else {
+		gdlog.Infof("GlobalDatasource deleted: %s", datasourceName)
 	}
-
-	gdlog.Infof("GlobalDatasource deleted: %s", datasourceName)
 
 	secretName := datasourceName + persescommon.SecretNameSuffix
 
 	err = persesClient.GlobalSecret().Delete(secretName)
 
-	if err != nil && errors.Is(err, perseshttp.RequestNotFoundError) {
-		gdlog.Infof("GlobalSecret not found: %s", secretName)
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			gdlog.Infof("GlobalSecret not found: %s", secretName)
+		} else {
+			gdlog.WithError(err).Errorf("Failed to delete global secret: %s", secretName)
+			return subreconciler.RequeueWithError(err)
+		}
+	} else {
+		gdlog.Infof("GlobalSecret deleted: %s", secretName)
 	}
-
-	gdlog.Infof("GlobalSecret deleted: %s", secretName)
 
 	return subreconciler.ContinueReconciling()
 }


### PR DESCRIPTION
The error check after Delete() only entered the block when the error was NotFound, silently ignoring all other errors and logging a false success. 

Fix the condition to propagate non-NotFound errors by requeuing, and add integration tests covering the delete failure path.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->


## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
