### PR TITLE
[BUGFIX] add missing pods RBAC permission to role.yaml

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -95,6 +95,8 @@ jobs:
         run: make bundle-check
       - name: check installer manifest is up-to-date
         run: make installer-check
+      - name: check generated manifests are up-to-date
+        run: git diff --exit-code config/
       - name: golangci-lint
         run: make lint
   checklicense:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -10467,6 +10467,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   - configmaps
   - secrets

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,6 +28,14 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
       - services
       - configmaps
       - secrets

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -73,7 +73,6 @@ type PersesReconciler struct {
 var log = logger.WithField("module", "perses_controller")
 
 // +kubebuilder:rbac:groups=perses.dev,resources=perses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=perses.dev,resources=perses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch

--- a/jsonnet/examples/role.yaml
+++ b/jsonnet/examples/role.yaml
@@ -33,6 +33,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   - configmaps
   - secrets

--- a/jsonnet/generated/role.json
+++ b/jsonnet/generated/role.json
@@ -41,6 +41,19 @@
         ""
       ],
       "resources": [
+        "pods"
+      ],
+      "verbs": [
+        "get",
+        "list",
+        "watch"
+      ]
+    },
+    {
+      "apiGroups": [
+        ""
+      ],
+      "resources": [
         "services",
         "configmaps",
         "secrets"


### PR DESCRIPTION
config/rbac/role.yaml was missing the pods get;list;watch rule despite the +kubebuilder:rbac marker being present. bundle.yaml was correct as it is generated independently.

Also removes a duplicate perses resource marker.

add config/ drift check to catch stale generated manifests

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: NA

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
