### PR TITLE
[IGNORE] remove redundant podman login to docker.io in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   build:
-    name: 'go and github release'
+    name: "go and github release"
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       # This env is required for the docker manifest command to work
-      DOCKER_CLI_EXPERIMENTAL: 'enabled'
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,20 +44,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login with podman
-        uses: redhat-actions/podman-login@v1
-        if: ${{ github.event_name == 'push' && (startsWith(github.ref_name, 'v') || github.ref_name == 'main') }}
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          registry: 'docker.io'
       - name: Login to Quay.io
         uses: redhat-actions/podman-login@v1
         if: ${{ github.event_name == 'push' && (startsWith(github.ref_name, 'v') || github.ref_name == 'main') }}
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          registry: 'quay.io'
+          registry: "quay.io"
       - name: install goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
https://github.com/perses/perses-operator/pull/340 didn't full fix

IIUC it needs robo account to use in CI https://docs.quay.io/glossary/robot-accounts.html and needs to QUAY_USERNAME and QUAY_PASSOWORD set accordingly

cc: @jgbernalp 

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
