### PR TITLE
[IGNORE] use docker instead of podman for CI image builds and pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
     env:
       # This env is required for the docker manifest command to work
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+      # This env is required for the bundle-build command to work
+      CONTAINER_RUNTIME: "docker"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,12 +47,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to Quay.io
-        uses: redhat-actions/podman-login@v1
+        uses: docker/login-action@v3
         if: ${{ github.event_name == 'push' && (startsWith(github.ref_name, 'v') || github.ref_name == 'main') }}
         with:
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          registry: "quay.io"
       - name: install goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
From ci run https://github.com/perses/perses-operator/actions/runs/22794835111/job/66127700184, pushing image is broken


```
41s
Run make push-main-docker-image
  make push-main-docker-image
  BUNDLE_IMG=docker.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-push
  BUNDLE_IMG=quay.io/persesdev/perses-operator-bundle:$(make -s print-image-tag) make bundle-push
  shell: /usr/bin/bash -e {0}
  env:
    DOCKER_CLI_EXPERIMENTAL: enabled
    GOTOOLCHAIN: local
    REGISTRY_AUTH_FILE: /run/user/1001/containers/auth.json
go run ./scripts/push-main-docker-image/push-main-docker-image.go
make image-push IMG=docker.io/persesdev/perses-operator-bundle:main-2026-03-07-8455a15
make[1]: Entering directory '/home/runner/work/perses-operator/perses-operator'
podman push docker.io/persesdev/perses-operator-bundle:main-2026-03-07-8455a15
Getting image source signatures
Copying blob sha256:e30aca8c5056f64588e187e9dc6cb5eb1e334d2c61ed7522f53b4db4e515c4dd
Copying blob sha256:f5fde7b887d31656a4f527ce7c67a5e385a198e0cbc214c7096f1cc84c7ead5b
Copying blob sha256:f4bc6853f2dc9bcbd77ccbb127b2878952ef4c36510c5bf4b442d47e68323550
Error: writing blob: initiating layer upload to /v2/persesdev/perses-operator-bundle/blobs/uploads/ in registry-1.docker.io: requested access to the resource is denied
make[1]: *** [Makefile:364: image-push] Error 125
make[1]: Leaving directory '/home/runner/work/perses-operator/perses-operator'
make: *** [Makefile:465: bundle-push] Error 2
Error: Process completed with exit code 2.
```

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
