### PR TITLE
[IGNORE] fix generate-changelog inserting entries at wrong position

### DIFF
--- a/scripts/generate-changelog/generate-changelog.go
+++ b/scripts/generate-changelog/generate-changelog.go
@@ -38,7 +38,7 @@ func getPreviousTag() string {
 func generateChangelog(clog *changelog.Changelog, version string) string {
 	now := time.Now()
 	var buffer bytes.Buffer
-	fmt.Fprintf(&buffer, "## %s / %s\n\n", version, now.Format("2006-01-02"))
+	fmt.Fprintf(&buffer, "## %s / %s\n\n", version, now.Format("2006-01-02")) //nolint: errcheck
 	buffer.WriteString(clog.GenerateChangelog())
 	if len(clog.Unknown) > 0 {
 		buffer.WriteString("\n[//]: <UNKNOWN ENTRIES. Release shepherd, please review the following list and categorize them or remove them>\n\n")
@@ -55,16 +55,27 @@ func Write(clog *changelog.Changelog, version string) {
 	fileScanner := bufio.NewScanner(f)
 	fileScanner.Split(bufio.ScanLines)
 	var buffer bytes.Buffer
-	i := 0
+	newSection := generateChangelog(clog, version)
+	injected := false
 	for fileScanner.Scan() {
-		buffer.WriteString(fileScanner.Text())
-		buffer.WriteString("\n")
-		i++
-		if i == 1 {
-			// inject the new changelog entries after the title
+		line := fileScanner.Text()
+		// Inject the new section just before the first version heading (## ...).
+		// This works whether or not the file has a top-level "# Changelog" title.
+		if !injected && strings.HasPrefix(line, "## ") {
+			buffer.WriteString(newSection)
 			buffer.WriteString("\n")
-			buffer.WriteString(generateChangelog(clog, version))
+			injected = true
 		}
+		buffer.WriteString(line)
+		buffer.WriteString("\n")
+	}
+	if !injected {
+		// No existing version heading found; prepend the new section.
+		content := buffer.String()
+		buffer.Reset()
+		buffer.WriteString(newSection)
+		buffer.WriteString("\n")
+		buffer.WriteString(content)
 	}
 	if closeErr := f.Close(); closeErr != nil {
 		logrus.WithError(closeErr).Fatal("unable to close the file CHANGELOG.md")

--- a/scripts/generate-changelog/generate-changelog_test.go
+++ b/scripts/generate-changelog/generate-changelog_test.go
@@ -15,11 +15,14 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/perses/perses/scripts/pkg/changelog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateChangelog(t *testing.T) {
@@ -67,6 +70,53 @@ func TestGenerateChangelog(t *testing.T) {
 	for _, test := range testSuite {
 		t.Run(test.title, func(t *testing.T) {
 			assert.Equal(t, test.expected, generateChangelog(test.clog, "0.20.0"))
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	clog := &changelog.Changelog{
+		Features: []string{"add new widget (#10)"},
+		BugFixes: []string{"fix crash on startup (#9)"},
+	}
+
+	now := time.Now()
+	date := now.Format("2006-01-02")
+	newSection := fmt.Sprintf("## 1.1.0 / %s\n\n- [FEATURE] add new widget (#10)\n- [BUGFIX] fix crash on startup (#9)\n", date)
+
+	testSuite := []struct {
+		title           string
+		existingContent string
+		expected        string
+	}{
+		{
+			title:           "changelog without top-level title (operator-style)",
+			existingContent: "## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n",
+			expected:        fmt.Sprintf("%s\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n", newSection),
+		},
+		{
+			title:           "changelog with top-level title",
+			existingContent: "# Changelog\n\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n",
+			expected:        fmt.Sprintf("# Changelog\n\n%s\n## 1.0.0 / 2026-01-01\n\n- [FEATURE] initial release (#1)\n", newSection),
+		},
+	}
+
+	for _, test := range testSuite {
+		t.Run(test.title, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "CHANGELOG.md")
+			require.NoError(t, os.WriteFile(path, []byte(test.existingContent), 0600))
+
+			origDir, err := os.Getwd()
+			require.NoError(t, err)
+			require.NoError(t, os.Chdir(dir))
+			t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+			Write(clog, "1.1.0")
+
+			result, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(result))
 		})
 	}
 }


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Before (broken):

```bash
## 0.3.1 / 2026-03-04     ← line 1 written
                           ← new section injected here
## 0.3.2 / 2026-03-10
- new entries...
- old 0.3.1 entries...     ← these now incorrectly appear under 0.3.2
## 0.3.0 / ...
```


After (fixed):

```bash
## 0.3.2 / 2026-03-10     ← new section prepended at top
- new entries...
## 0.3.1 / 2026-03-04     ← previous content preserved below
- old 0.3.1 entries...
## 0.3.0 / ...
```


## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer
- [ ] Code follows project conventions and passes linting
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
