### PR TITLE
[ENHANCEMENT] Add script and Makefile support for OperatorHub bundle submission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ IMAGE_TAG_BASE ?= docker.io/persesdev/perses-operator
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
+# REPLACES_VERSION defines the previous operator version for OLM upgrade path (replaces-mode).
+# Set this when generating the bundle for OperatorHub submission.
+# (e.g make bundle REPLACES_VERSION=0.1.1)
+REPLACES_VERSION ?=
+
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
@@ -446,10 +451,13 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 ##@ Build Dependencies
 
 .PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+ifneq ($(REPLACES_VERSION),)
+	$(YQ) -i '.spec.replaces = "perses-operator.v$(REPLACES_VERSION)"' bundle/manifests/perses-operator.clusterserviceversion.yaml
+endif
 	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-check

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,3 +67,49 @@ Once the release branch is no longer needed, you should open a new PR based on `
 ## 4. Update the Helm chart
 
 After the release is published, update the [Perses Operator Helm chart](https://github.com/perses/helm-charts/tree/main/charts/perses-operator) in the [perses/helm-charts](https://github.com/perses/helm-charts) repository. Follow the [Bumping perses-operator Version](https://github.com/perses/helm-charts/blob/main/DEVELOPER_GUIDE.md#bumping-perses-operator-version) guide.
+
+## 5. Publish to OperatorHub
+
+After the release is published, submit the updated operator bundle to [OperatorHub](https://operatorhub.io) via the [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators) repository.
+
+- Ensure you are on the release branch:
+
+  ```bash
+  git checkout release/v<major>.<minor>
+  ```
+
+- Regenerate the bundle with the `replaces` field pointing to the previous OperatorHub version:
+
+  ```bash
+  make bundle REPLACES_VERSION=<previous-operatorhub-version>
+  ```
+
+  For example, if the last version published to OperatorHub was `0.1.1`:
+
+  ```bash
+  make bundle REPLACES_VERSION=0.1.1
+  ```
+
+- Verify the `replaces` field was injected into `bundle/manifests/perses-operator.clusterserviceversion.yaml` (this file is gitignored, so changes won't appear in `git status`):
+
+  ```bash
+  grep replaces bundle/manifests/perses-operator.clusterserviceversion.yaml
+  ```
+
+- Use the publish script to prepare the community-operators PR (run `./scripts/publish-to-operatorhub/publish-to-operatorhub.sh -h` for all options):
+
+  ```bash
+  ./scripts/publish-to-operatorhub/publish-to-operatorhub.sh --fork <your-github-user>/community-operators
+  ```
+
+  If you already have a local clone of community-operators:
+
+  ```bash
+  ./scripts/publish-to-operatorhub/publish-to-operatorhub.sh --fork <your-github-user>/community-operators --workdir /path/to/community-operators
+  ```
+
+  The script copies the bundle and commits it on a new branch. Follow the printed instructions to review, push, and create the PR.
+
+  > You need a fork of [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators).
+
+> **Note:** The community-operators `ci.yaml` currently uses `replaces-mode`, which requires the `replaces` field in the CSV. Switching to `semver-mode` would eliminate this requirement (OLM resolves upgrade order by semver), but this change is irreversible.

--- a/scripts/publish-to-operatorhub/publish-to-operatorhub.sh
+++ b/scripts/publish-to-operatorhub/publish-to-operatorhub.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# Copyright The Perses Authors
+# Licensed under the Apache License, Version 2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+COMMUNITY_OPERATORS_REPO="k8s-operatorhub/community-operators"
+OPERATOR_NAME="perses-operator"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Prepare a commit for the community-operators repository to publish a new
+version of perses-operator to OperatorHub.
+
+Must be run from the release branch (e.g. release/v0.3) after generating
+the bundle with: make bundle REPLACES_VERSION=<previous-version>
+
+Options:
+  --fork OWNER/REPO        Your fork of community-operators (e.g. myuser/community-operators)
+  --remote REMOTE_NAME     Git remote name in community-operators repo to push to (default: origin)
+  --workdir DIR            Path to an existing local clone of community-operators,
+                           or directory to clone into (default: /tmp/community-operators)
+  -h, --help               Show this help message
+
+Examples:
+  # Basic usage
+  ./scripts/publish-to-operatorhub/publish-to-operatorhub.sh --fork myuser/community-operators
+
+  # Use a different git remote name for pushing
+  ./scripts/publish-to-operatorhub/publish-to-operatorhub.sh --fork myuser/community-operators --remote fork-remotename
+
+  # Use an existing local clone of community-operators
+  ./scripts/publish-to-operatorhub/publish-to-operatorhub.sh --fork myuser/community-operators --workdir ~/github/community-operators
+EOF
+  exit 0
+}
+
+FORK=""
+REMOTE="origin"
+WORKDIR="/tmp/community-operators"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fork)
+      FORK="$2"
+      shift 2
+      ;;
+    --remote)
+      REMOTE="$2"
+      shift 2
+      ;;
+    --workdir)
+      WORKDIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "${FORK}" ]]; then
+  echo "Error: --fork is required (e.g. --fork myuser/community-operators)"
+  exit 1
+fi
+
+BUNDLE_DIR="${REPO_ROOT}/bundle"
+
+cd "${REPO_ROOT}"
+
+# Fetch tags from upstream and determine the latest release version
+OPERATOR_UPSTREAM="${GIT_REMOTE_UPSTREAM:-upstream}"
+echo "==> Fetching tags from ${OPERATOR_UPSTREAM}..."
+git fetch "${OPERATOR_UPSTREAM}" --tags
+
+VERSION=$(git tag --list "v*" --sort=-v:refname | head -1 | sed 's/^v//')
+if [[ -z "${VERSION}" ]]; then
+  echo "Error: no release tags found. Has a release been created?"
+  exit 1
+fi
+
+echo "==> Latest release version: ${VERSION}"
+
+MAJOR_MINOR=$(echo "${VERSION}" | sed 's/\.[0-9]*$//')
+EXPECTED_BRANCH="release/v${MAJOR_MINOR}"
+
+# Verify the script is run from the correct release branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${CURRENT_BRANCH}" != "${EXPECTED_BRANCH}" ]]; then
+  echo "Error: latest release is v${VERSION}, expected to be on branch '${EXPECTED_BRANCH}', but currently on '${CURRENT_BRANCH}'."
+  echo "  Switch to the release branch first: git checkout ${EXPECTED_BRANCH}"
+  exit 1
+fi
+
+# Check if the release branch is in sync with upstream
+echo "==> Checking if ${CURRENT_BRANCH} is in sync with ${OPERATOR_UPSTREAM}/${EXPECTED_BRANCH}..."
+git fetch "${OPERATOR_UPSTREAM}" "${EXPECTED_BRANCH}"
+LOCAL_HEAD=$(git rev-parse HEAD)
+UPSTREAM_HEAD=$(git rev-parse "${OPERATOR_UPSTREAM}/${EXPECTED_BRANCH}")
+if [[ "${LOCAL_HEAD}" != "${UPSTREAM_HEAD}" ]]; then
+  echo "WARNING: local '${CURRENT_BRANCH}' is not in sync with '${OPERATOR_UPSTREAM}/${EXPECTED_BRANCH}'."
+  echo "  Local:    ${LOCAL_HEAD}"
+  echo "  Upstream: ${UPSTREAM_HEAD}"
+  echo "  To sync: git pull ${OPERATOR_UPSTREAM} ${EXPECTED_BRANCH}"
+  echo ""
+  read -r -p "Continue anyway? [y/N] " response
+  if [[ ! "${response}" =~ ^[Yy]$ ]]; then
+    echo "Aborting."
+    exit 1
+  fi
+fi
+
+TARGET_DIR="${WORKDIR}/operators/${OPERATOR_NAME}/${VERSION}"
+BRANCH_NAME="update-${OPERATOR_NAME}-${VERSION}"
+
+# Verify the bundle has been generated
+if [[ ! -d "${BUNDLE_DIR}/manifests" ]] || [[ ! -d "${BUNDLE_DIR}/metadata" ]]; then
+  echo "Error: bundle/manifests or bundle/metadata not found."
+  echo "  Generate the bundle first: make bundle REPLACES_VERSION=<previous-version>"
+  exit 1
+fi
+
+echo "==> Preparing ${OPERATOR_NAME} v${VERSION} bundle for OperatorHub submission"
+echo "    Source: local bundle from branch ${CURRENT_BRANCH}"
+echo "    Fork: ${FORK}"
+echo "    Working directory: ${WORKDIR}"
+
+# Clone or update the fork
+if [[ -d "${WORKDIR}/.git" ]]; then
+  cd "${WORKDIR}"
+  REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+  if [[ "${REMOTE_URL}" != *"community-operators"* ]]; then
+    echo "Error: ${WORKDIR} exists but does not appear to be a community-operators clone."
+    echo "  origin URL: ${REMOTE_URL}"
+    exit 1
+  fi
+  echo "==> Updating existing clone..."
+  git fetch origin main
+  git checkout main
+  git reset --hard origin/main
+else
+  echo "==> Cloning fork..."
+  git clone "git@github.com:${FORK}.git" "${WORKDIR}"
+  cd "${WORKDIR}"
+  git remote add upstream "git@github.com:${COMMUNITY_OPERATORS_REPO}.git" 2>/dev/null || true
+  git fetch upstream main
+  git reset --hard upstream/main
+fi
+
+# Create a branch
+echo "==> Creating branch ${BRANCH_NAME}..."
+git checkout -B "${BRANCH_NAME}"
+
+# Copy bundle from local working directory
+echo "==> Copying bundle to ${TARGET_DIR}..."
+mkdir -p "${TARGET_DIR}"
+cp -r "${BUNDLE_DIR}/manifests" "${TARGET_DIR}/manifests"
+cp -r "${BUNDLE_DIR}/metadata" "${TARGET_DIR}/metadata"
+
+# Verify the replaces field is present
+if ! grep -q "replaces:" "${TARGET_DIR}/manifests/${OPERATOR_NAME}.clusterserviceversion.yaml"; then
+  echo ""
+  echo "WARNING: CSV does not contain a 'replaces' field."
+  echo "  The community-operators ci.yaml uses replaces-mode."
+  echo "  Re-generate the bundle with: make bundle REPLACES_VERSION=<previous-version>"
+  echo ""
+fi
+
+echo "==> Committing changes..."
+git add "operators/${OPERATOR_NAME}/${VERSION}/"
+git commit -s -S -m "operator ${OPERATOR_NAME} (${VERSION})"
+
+echo ""
+echo "==> Bundle prepared at: ${TARGET_DIR}"
+echo ""
+echo "Next steps:"
+echo "  1. Review the changes:"
+echo "       cd ${WORKDIR}"
+echo "       git diff HEAD~1"
+echo ""
+echo "  2. Push the branch to your fork:"
+echo "       git push -u ${REMOTE} ${BRANCH_NAME}"
+echo ""
+echo "  3. Create a PR at:"
+echo "       https://github.com/${COMMUNITY_OPERATORS_REPO}/compare/main...${FORK%%/*}:${BRANCH_NAME}"


### PR DESCRIPTION

- Add REPLACES_VERSION variable to Makefile to inject the OLM replaces field into the CSV during bundle generation using yq
- Add publish-to-operatorhub.sh script that automates preparing a community-operators PR: fetches latest release tag, validates release branch, copies bundle manifests, and creates a signed commit
- Add OperatorHub publication steps to RELEASE.md

Related-to #349

Created bundle using script and created PR manually https://github.com/k8s-operatorhub/community-operators/pull/7725

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
