### PR TITLE
[IGNORE]: cache mdox link validation results in CI

### DIFF
--- a/.github/actions/mdox-cache/action.yml
+++ b/.github/actions/mdox-cache/action.yml
@@ -1,0 +1,10 @@
+name: mdox-cache
+description: Cache mdox links for validation
+runs:
+  using: composite
+  steps:
+    - name: Cache links for mdox
+      uses: actions/cache@v4
+      with:
+        path: .mdoxcache
+        key: mdox-link-cache

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,6 +39,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Cache links for mdox
+        uses: ./.github/actions/mdox-cache
       - name: format docs
         run: make fmt-docs
       - name: check docs are up-to-date

--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,8 @@ docs/config/api-docs-config-resolved.yaml
 config/local/patches/
 config/local/certificate.yaml
 
+# mdox link validation cache
+.mdoxcache
+
 # e2e tests
 kubeconfig

--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -1,13 +1,5 @@
 version: 1
 timeout: '1m'
-
-validators:
-  # timeout
-  - regex: 'github\.com'
-    type: 'ignore'
-  # code 500
-  - regex: 'slack\.com'
-    type: 'ignore'
-  # timeout
-  - regex: 'slack\.cncf\.io'
-    type: 'ignore'
+cache:
+  type: 'sqlite'
+  jitter: '1h'

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -63,7 +63,8 @@ KUTTL = $(LOCALBIN)/kubectl-kuttl
 KUTTL_VERSION = 0.24.0
 
 MDOX = $(LOCALBIN)/mdox
-MDOX_VERSION = v0.9.0
+# NOTE:  Using main branch as mdox has no tagged releases yet and main includes SQLite cache for URL validation.
+MDOX_VERSION = main
 
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GOLANGCI_LINT_VERSION = v2.10.1


### PR DESCRIPTION
This commit switches to using the latest version of mdox which caches links when validating the documentation. We use cache in GH actions to persist the validated URL's across runs to avoid the need to re-validate the links on every run. URL's are cached for 5 days (default) and 1 hour jitter to stagger revalidation and avoid request bursts

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
