### PR TITLE
[IGNORE] install kustomize via go to avoid GH API rate limits

### DIFF
--- a/Makefile.tools
+++ b/Makefile.tools
@@ -76,17 +76,15 @@ SHFMT_VERSION = v3.13.0
 SHELLCHECK = $(LOCALBIN)/shellcheck
 SHELLCHECK_VERSION = v0.11.0
 
-## Kustomize - uses custom install script
-KUSTOMIZE_INSTALL_SCRIPT = https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh
+## Go-based tools - use go install
 .PHONY: kustomize
 $(KUSTOMIZE) kustomize: $(LOCALBIN) ## Install kustomize locally if necessary.
 	@{ \
 		set -ex ;\
 		[[ -f $(KUSTOMIZE) ]] && exit 0 ;\
-		curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN) ;\
+		GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION) ;\
 	}
 
-## Go-based tools - use go install
 .PHONY: controller-gen
 $(CONTROLLER_GEN) controller-gen: $(LOCALBIN) ## Install controller-gen locally if necessary.
 	@{ \


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

The kustomize install script (install_kustomize.sh) makes unauthenticated GitHub API calls that frequently hit rate limits on shared CI runners.

Replace with `go install` which uses the Go module proxy instead, consistent with how all other Go-based tools in Makefile.tools are installed.

Ref: https://github.com/perses/perses-operator/actions/runs/23037432245/workflow

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
