### PR TITLE
[IGNORE] cache CI tools to avoid re-downloading on every job

### DIFF
--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -1,0 +1,22 @@
+name: tools-cache
+description: Caches development tools
+runs:
+  using: composite
+  steps:
+    - name: Cache tools
+      uses: actions/cache@v4
+      id: tools-cache
+      with:
+        path: ./bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('Makefile.tools') }}
+
+    - name: Install tools
+      if: steps.tools-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: make build-tools
+
+    - name: Show tools
+      shell: bash
+      run: |
+        ls -l ./bin
+        make validate-tools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,6 +25,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: check API docs are up-to-date
         run: make check-api-docs
       - name: check metrics docs are up-to-date
@@ -41,6 +43,8 @@ jobs:
           enable_go: true
       - name: Cache links for mdox
         uses: ./.github/actions/mdox-cache
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: format docs
         run: make fmt-docs
       - name: check docs are up-to-date

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: Create kind cluster
         uses: helm/kind-action@v1.14.0
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,6 +29,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: check format
         run: make checkformat || (echo "Please run 'make format' locally and commit the changes." && exit 1)
       - name: verify go modules
@@ -45,6 +47,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: unit tests
         run: make test-unit
   test-integration:
@@ -59,6 +63,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: integration tests
         run: make test-integration
   lint-api:
@@ -73,6 +79,8 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: lint API types
         run: make lint-api
   lint:
@@ -89,6 +97,8 @@ jobs:
           enable_go: true
           enable_go_cache: false
           enable_npm: false
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: generate files
         run: make generate
       - name: check bundle changes
@@ -113,5 +123,7 @@ jobs:
       - uses: ./.github/perses-ci/actions/setup_environment
         with:
           enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: check license headers
         run: make checklicense


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

Every CI job currently downloads all development tools from scratch via `make build-tools` (16 tools: 12 via go install, 4 via curl). With multiple jobs per workflow, this is redundant and slow.

This commit adds a reusable composite action that
caches ./bin, keyed on the hash of Makefile.tools. On cache hit, tools are restored in seconds and installation is skipped. On cache miss, `make build-tools` runs as usual and the result is cached.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #369 

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
