### PR TITLE
[IGNORE] automate publish operator release to Operator Hub

### DIFF
--- a/.github/workflows/operator-hub-release.yaml
+++ b/.github/workflows/operator-hub-release.yaml
@@ -1,0 +1,91 @@
+name: Create OperatorHub pull request
+
+on:
+  workflow_call:
+    inputs:
+      org:
+        type: string
+        required: true
+      repo:
+        type: string
+        required: true
+    secrets:
+      BOT_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  BOT_USER: persesbot
+  OPERATOR_NAME: perses-operator
+
+jobs:
+  create-operator-pull-request:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version from tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          TAG=${TAG:1}
+          echo "VERSION=${TAG}" >> $GITHUB_ENV
+
+      - name: Sync fork
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          gh repo sync ${{ env.BOT_USER }}/${{ inputs.repo }} \
+              --source ${{ inputs.org }}/${{ inputs.repo }} \
+              --force
+
+      - name: Checkout community-operators fork
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BOT_USER }}/${{ inputs.repo }}
+          token: ${{ secrets.BOT_TOKEN }}
+
+      - name: Checkout perses-operator at release tag
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref_name }}
+          path: tmp/
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: tmp/go.mod
+
+      - name: Generate bundle manifests
+        working-directory: tmp/
+        run: make bundle
+
+      - name: Copy bundle to versioned directory
+        run: |
+          mkdir -p operators/${OPERATOR_NAME}/${VERSION}
+          cp -R tmp/bundle/manifests operators/${OPERATOR_NAME}/${VERSION}/
+          cp -R tmp/bundle/metadata operators/${OPERATOR_NAME}/${VERSION}/
+          cp -R tmp/bundle/tests operators/${OPERATOR_NAME}/${VERSION}/
+          rm -rf tmp/
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          git config user.name ${{ env.BOT_USER }}
+          git config user.email ${{ env.BOT_USER }}@users.noreply.github.com
+
+          message="operator ${OPERATOR_NAME} (${VERSION})"
+          branch="update-${OPERATOR_NAME}-to-${VERSION}"
+
+          git checkout -b $branch
+          git add -A
+          git commit -s -m "$message"
+          git push -f --set-upstream origin $branch
+          gh pr create --title "$message" \
+                       --body "Release ${OPERATOR_NAME} \`${VERSION}\`." \
+                       --repo ${{ inputs.org }}/${{ inputs.repo }} \
+                       --base main

--- a/.github/workflows/publish-operator-hub.yaml
+++ b/.github/workflows/publish-operator-hub.yaml
@@ -1,0 +1,22 @@
+name: Publish operator to OperatorHub
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  operatorhub-community:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/operator-hub-release.yaml
+    with:
+      org: k8s-operatorhub
+      repo: community-operators
+    secrets:
+      # NOTE: BOT_TOKEN is a PAT (repo scope) for the persesbot account
+      # Required to sync and push to persesbot's fork of community-operators
+      # and to create pull requests against the upstream repository.
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,6 +64,20 @@ It can be helpful to leave the release branch up for a little while in case we n
 
 Once the release branch is no longer needed, you should open a new PR based on `main` to merge those changes. When this PR is approved, merge it into `main` :warning: **using the "merge pull request" option, not "squash and merge"** (the latter would delete the commit needed for the release tag, which can lead to problems).
 
-## 4. Update the Helm chart
+## 4. Publish to OperatorHub (automated)
+
+When the GitHub release is published, a workflow automatically creates a pull request to submit the new operator version to [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators/pulls) (OperatorHub.io).
+
+A maintainer should monitor the PR and address any CI feedback from the community-operators repository.
+
+### One-time setup prerequisites
+
+Before the automation can run, the following must be configured once:
+
+1. **Bot account**: The `persesbot` GitHub account must have a fork of [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/community-operators).
+2. **GitHub secret**: A Personal Access Token with `repo` scope for the bot account must be added as `PERSESBOT_GITHUB_TOKEN` in the repository settings.
+3. **CLA/DCO**: The bot account should sign the CNCF CLA or Linux Foundation DCO if required.
+
+## 5. Update the Helm chart
 
 After the release is published, update the [Perses Operator Helm chart](https://github.com/perses/helm-charts/tree/main/charts/perses-operator) in the [perses/helm-charts](https://github.com/perses/helm-charts) repository. Follow the [Bumping perses-operator Version](https://github.com/perses/helm-charts/blob/main/DEVELOPER_GUIDE.md#bumping-perses-operator-version) guide.


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This commit adds workflow that automatically creates a PR to community-operators repo when a new release is published.

The workflow syncs the fork of the community-operators repo, generates the OLM bundle from the release tag and submits a new version

Closes: #350 

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
