### PR TITLE
[BUGFIX] avoid panic when setting degraded status when perses instances are not found

### DIFF
--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -69,9 +69,7 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 
 	if len(persesInstances.Items) == 0 {
 		dlog.Info("No Perses instances found, retrying in 1 minute")
-		res, err := subreconciler.RequeueWithDelay(time.Minute)
-		return r.setStatusToDegraded(ctx, req, res, common.ReasonMissingPerses, err)
-
+		return r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, fmt.Errorf("no Perses instances found matching the label selector"))
 	}
 
 	for _, persesInstance := range persesInstances.Items {

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -196,13 +196,18 @@ func (r *PersesDashboardReconciler) setStatusToDegraded(
 	degradedReason common.ConditionStatusReason,
 	degradedError error,
 ) (*ctrl.Result, error) {
+	msg := "unknown error"
+	if degradedError != nil {
+		msg = degradedError.Error()
+	}
+
 	result, err := r.updateDashboardStatus(ctx, req, func(dashboard *persesv1alpha2.PersesDashboard) {
 		meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{
 			Type: common.TypeAvailablePerses, Status: metav1.ConditionFalse,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 		meta.SetStatusCondition(&dashboard.Status.Conditions, metav1.Condition{
 			Type: common.TypeDegradedPerses, Status: metav1.ConditionTrue,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 	})
 
 	if err != nil {

--- a/controllers/dashboards/persesdashboard_controller_test.go
+++ b/controllers/dashboards/persesdashboard_controller_test.go
@@ -1,0 +1,129 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboards
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	"github.com/perses/perses-operator/internal/perses/common"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDashboardController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dashboard Controller Suite")
+}
+
+func newTestDashboardReconciler(objects ...runtime.Object) *PersesDashboardReconciler {
+	scheme := runtime.NewScheme()
+	Expect(persesv1alpha2.AddToScheme(scheme)).To(Succeed())
+
+	clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range objects {
+		clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+	}
+	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesDashboard{})
+
+	return &PersesDashboardReconciler{
+		Client: clientBuilder.Build(),
+		Scheme: scheme,
+	}
+}
+
+var _ = Describe("Dashboard controller", func() {
+	Context("setStatusToDegraded", func() {
+		const DashboardName = "test-dashboard"
+		const DashboardNamespace = "default"
+
+		It("should not panic when degradedError is nil", func() {
+			dashboard := &persesv1alpha2.PersesDashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DashboardName,
+					Namespace: DashboardNamespace,
+				},
+			}
+
+			r := newTestDashboardReconciler(dashboard)
+			ctx := withDashboard(context.Background(), dashboard)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: DashboardName, Namespace: DashboardNamespace}}
+
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with 'unknown error' message")
+			fresh := &persesv1alpha2.PersesDashboard{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal("unknown error"))
+			Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal("unknown error"))
+			Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("should set degraded status conditions with the error message", func() {
+			dashboard := &persesv1alpha2.PersesDashboard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DashboardName,
+					Namespace: DashboardNamespace,
+				},
+			}
+
+			r := newTestDashboardReconciler(dashboard)
+			ctx := withDashboard(context.Background(), dashboard)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: DashboardName, Namespace: DashboardNamespace}}
+
+			degradedErr := fmt.Errorf("no Perses instances found matching the label selector")
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, degradedErr)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(degradedErr))
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with the correct error message")
+			fresh := &persesv1alpha2.PersesDashboard{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+			Expect(fresh.Status.Conditions).To(HaveLen(2))
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal(degradedErr.Error()))
+			Expect(availableCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal(degradedErr.Error()))
+			Expect(degradedCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+		})
+	})
+})

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -72,8 +72,7 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 
 	if len(persesInstances.Items) == 0 {
 		dlog.Info("No Perses instances found, requeue in 1 minute")
-		res, err := subreconciler.RequeueWithDelay(time.Minute)
-		return r.setStatusToDegraded(ctx, req, res, persescommon.ReasonMissingPerses, err)
+		return r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, persescommon.ReasonMissingPerses, fmt.Errorf("no Perses instances found matching the label selector"))
 	}
 
 	for _, persesInstance := range persesInstances.Items {

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -196,13 +196,18 @@ func (r *PersesDatasourceReconciler) setStatusToDegraded(
 	degradedReason common.ConditionStatusReason,
 	degradedError error,
 ) (*ctrl.Result, error) {
+	msg := "unknown error"
+	if degradedError != nil {
+		msg = degradedError.Error()
+	}
+
 	result, err := r.updateDatasourceStatus(ctx, req, func(datasource *persesv1alpha2.PersesDatasource) {
 		meta.SetStatusCondition(&datasource.Status.Conditions, metav1.Condition{
 			Type: common.TypeAvailablePerses, Status: metav1.ConditionFalse,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 		meta.SetStatusCondition(&datasource.Status.Conditions, metav1.Condition{
 			Type: common.TypeDegradedPerses, Status: metav1.ConditionTrue,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 	})
 
 	if err != nil {

--- a/controllers/datasources/persesdatasource_controller_test.go
+++ b/controllers/datasources/persesdatasource_controller_test.go
@@ -1,0 +1,148 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	"github.com/perses/perses-operator/internal/perses/common"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDatasourceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Datasource Controller Suite")
+}
+
+func newTestDatasourceReconciler(objects ...runtime.Object) *PersesDatasourceReconciler {
+	scheme := runtime.NewScheme()
+	Expect(persesv1alpha2.AddToScheme(scheme)).To(Succeed())
+
+	clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range objects {
+		clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+	}
+	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesDatasource{})
+
+	return &PersesDatasourceReconciler{
+		Client: clientBuilder.Build(),
+		Scheme: scheme,
+	}
+}
+
+var _ = Describe("Datasource controller", func() {
+	Context("setStatusToDegraded", func() {
+		const DatasourceName = "test-ds"
+		const DatasourceNamespace = "default"
+
+		It("should not panic when degradedError is nil", func() {
+			datasource := &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DatasourceName,
+					Namespace: DatasourceNamespace,
+				},
+			}
+
+			r := newTestDatasourceReconciler(datasource)
+			ctx := withDatasource(context.Background(), datasource)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: DatasourceName, Namespace: DatasourceNamespace}}
+
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with 'unknown error' message")
+			fresh := &persesv1alpha2.PersesDatasource{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal("unknown error"))
+			Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal("unknown error"))
+			Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("should set degraded status conditions with the error message", func() {
+			datasource := &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DatasourceName,
+					Namespace: DatasourceNamespace,
+				},
+			}
+
+			r := newTestDatasourceReconciler(datasource)
+			ctx := withDatasource(context.Background(), datasource)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: DatasourceName, Namespace: DatasourceNamespace}}
+
+			degradedErr := fmt.Errorf("no Perses instances found matching the label selector")
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, degradedErr)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(degradedErr))
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with the correct error message")
+			fresh := &persesv1alpha2.PersesDatasource{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+			Expect(fresh.Status.Conditions).To(HaveLen(2))
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal(degradedErr.Error()))
+			Expect(availableCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal(degradedErr.Error()))
+			Expect(degradedCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+		})
+
+		It("should propagate degradedError when the resource is already deleted", func() {
+			datasource := &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nonexistent",
+					Namespace: DatasourceNamespace,
+				},
+			}
+
+			r := newTestDatasourceReconciler() // no objects pre-created
+			ctx := withDatasource(context.Background(), datasource)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: DatasourceNamespace}}
+
+			degradedErr := fmt.Errorf("some error")
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{}, common.ReasonMissingPerses, degradedErr)
+
+			Expect(err).To(MatchError(degradedErr))
+			Expect(result).ToNot(BeNil())
+		})
+	})
+})

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -70,8 +70,7 @@ func (r *PersesGlobalDatasourceReconciler) reconcileGlobalDatasourcesInAllInstan
 
 	if len(persesInstances.Items) == 0 {
 		gdlog.Info("No Perses instances found, requeue in 1 minute")
-		res, err := subreconciler.RequeueWithDelay(time.Minute)
-		return r.setStatusToDegraded(ctx, req, res, persescommon.ReasonMissingPerses, err)
+		return r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, persescommon.ReasonMissingPerses, fmt.Errorf("no Perses instances found matching the label selector"))
 	}
 
 	for _, persesInstance := range persesInstances.Items {

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -196,13 +196,18 @@ func (r *PersesGlobalDatasourceReconciler) setStatusToDegraded(
 	degradedReason common.ConditionStatusReason,
 	degradedError error,
 ) (*ctrl.Result, error) {
+	msg := "unknown error"
+	if degradedError != nil {
+		msg = degradedError.Error()
+	}
+
 	result, err := r.updateGlobalDatasourceStatus(ctx, req, func(globaldatasource *persesv1alpha2.PersesGlobalDatasource) {
 		meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{
 			Type: common.TypeAvailablePerses, Status: metav1.ConditionFalse,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 		meta.SetStatusCondition(&globaldatasource.Status.Conditions, metav1.Condition{
 			Type: common.TypeDegradedPerses, Status: metav1.ConditionTrue,
-			Reason: string(degradedReason), Message: degradedError.Error()})
+			Reason: string(degradedReason), Message: msg})
 	})
 
 	if err != nil {

--- a/controllers/globaldatasources/persesglobaldatasource_controller_test.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller_test.go
@@ -1,0 +1,126 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package globaldatasources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+	"github.com/perses/perses-operator/internal/perses/common"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGlobalDatasourceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GlobalDatasource Controller Suite")
+}
+
+func newTestGlobalDatasourceReconciler(objects ...runtime.Object) *PersesGlobalDatasourceReconciler {
+	scheme := runtime.NewScheme()
+	Expect(persesv1alpha2.AddToScheme(scheme)).To(Succeed())
+
+	clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range objects {
+		clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+	}
+	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesGlobalDatasource{})
+
+	return &PersesGlobalDatasourceReconciler{
+		Client: clientBuilder.Build(),
+		Scheme: scheme,
+	}
+}
+
+var _ = Describe("GlobalDatasource controller", func() {
+	Context("setStatusToDegraded", func() {
+		const GlobalDatasourceName = "test-global-ds"
+
+		It("should not panic when degradedError is nil", func() {
+			globalDS := &persesv1alpha2.PersesGlobalDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: GlobalDatasourceName,
+				},
+			}
+
+			r := newTestGlobalDatasourceReconciler(globalDS)
+			ctx := withGlobalDatasource(context.Background(), globalDS)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: GlobalDatasourceName}}
+
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, nil)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with 'unknown error' message")
+			fresh := &persesv1alpha2.PersesGlobalDatasource{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal("unknown error"))
+			Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal("unknown error"))
+			Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("should set degraded status conditions with the error message", func() {
+			globalDS := &persesv1alpha2.PersesGlobalDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: GlobalDatasourceName,
+				},
+			}
+
+			r := newTestGlobalDatasourceReconciler(globalDS)
+			ctx := withGlobalDatasource(context.Background(), globalDS)
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: GlobalDatasourceName}}
+
+			degradedErr := fmt.Errorf("no Perses instances found")
+			result, err := r.setStatusToDegraded(ctx, req, &ctrl.Result{RequeueAfter: time.Minute}, common.ReasonMissingPerses, degradedErr)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(degradedErr))
+			Expect(result).ToNot(BeNil())
+			Expect(result.RequeueAfter).To(Equal(time.Minute))
+
+			By("Checking the status conditions were set with the correct error message")
+			fresh := &persesv1alpha2.PersesGlobalDatasource{}
+			Expect(r.Get(context.Background(), req.NamespacedName, fresh)).To(Succeed())
+			Expect(fresh.Status.Conditions).To(HaveLen(2))
+
+			availableCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeAvailablePerses)
+			Expect(availableCond).ToNot(BeNil())
+			Expect(availableCond.Message).To(Equal(degradedErr.Error()))
+			Expect(availableCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+
+			degradedCond := apimeta.FindStatusCondition(fresh.Status.Conditions, common.TypeDegradedPerses)
+			Expect(degradedCond).ToNot(BeNil())
+			Expect(degradedCond.Message).To(Equal(degradedErr.Error()))
+			Expect(degradedCond.Reason).To(Equal(string(common.ReasonMissingPerses)))
+		})
+	})
+})


### PR DESCRIPTION
# Description

Send the right error instead of null to avoid panic when setting a degraded status 

Fixes: [COO-1735](https://redhat.atlassian.net/browse/COO-1735)

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
