### PR TITLE
[ENHANCEMENT] Improve manager caching when watching secrets

### DIFF
--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -176,6 +176,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -295,6 +296,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -401,6 +403,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -585,6 +588,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -661,6 +665,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -815,6 +820,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -86,7 +86,7 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 }
 
 func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboard *persesv1alpha2.PersesDashboard) (*ctrl.Result, common.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
@@ -190,7 +190,7 @@ func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Co
 }
 
 func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboardNamespace string, dashboardName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -55,6 +55,7 @@ func dashboardFromContext(ctx context.Context) (*persesv1alpha2.PersesDashboard,
 // PersesDashboardReconciler reconciles a PersesDashboard object
 type PersesDashboardReconciler struct {
 	client.Client
+	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -24,12 +24,14 @@ import (
 	persesconfig "github.com/perses/perses/pkg/model/api/config"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persescommon "github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
@@ -37,6 +39,24 @@ import (
 	internal "github.com/perses/perses-operator/internal/perses"
 	"github.com/perses/perses-operator/internal/perses/common"
 )
+
+// secretStrippingClient wraps a client.Client and strips Data/StringData from
+// Secret objects on Get, simulating the cache Transform.
+// This lets tests verify that secret data is read through APIReader, not Client.
+type secretStrippingClient struct {
+	client.Client
+}
+
+func (c *secretStrippingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	if s, ok := obj.(*corev1.Secret); ok {
+		s.Data = nil
+		s.StringData = nil
+	}
+	return nil
+}
 
 var _ = Describe("Datasource controller", Ordered, func() {
 	Context("Datasource controller test", func() {
@@ -180,6 +200,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -303,6 +324,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -410,6 +432,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -578,6 +601,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -701,6 +725,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -777,6 +802,192 @@ var _ = Describe("Datasource controller", Ordered, func() {
 				}
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+
+	Context("Datasource controller test with BasicAuth secret", func() {
+		const PersesName = "perses-for-ds-basicauth"
+		const DatasourceName = "ds-with-basicauth"
+		const PersesSecretName = DatasourceName + "-secret"
+		const K8sSecretName = "basicauth-creds"
+
+		ctx := context.Background()
+
+		var namespace *corev1.Namespace
+		var PersesNamespace string
+		var persesNamespaceName types.NamespacedName
+		var datasourceNamespaceName types.NamespacedName
+
+		BeforeAll(func() {
+			By("Creating the Namespace")
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "perses-ds-basicauth-test-",
+				},
+			}
+			err := k8sClient.Create(ctx, namespace)
+			Expect(err).To(Not(HaveOccurred()))
+			PersesNamespace = namespace.Name
+			persesNamespaceName = types.NamespacedName{Name: PersesName, Namespace: PersesNamespace}
+			datasourceNamespaceName = types.NamespacedName{Name: DatasourceName, Namespace: PersesNamespace}
+
+			By("Creating the Perses instance")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PersesName,
+					Namespace: PersesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					ContainerPort: ptr.To(int32(8080)),
+				},
+			}
+			err = k8sClient.Create(ctx, perses)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, persesNamespaceName, perses); err != nil {
+					return err
+				}
+				perses.Status.Conditions = []metav1.Condition{{
+					Type:               common.TypeAvailablePerses,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Testing",
+					Message:            "Available for testing",
+					LastTransitionTime: metav1.Now(),
+				}}
+				return k8sClient.Status().Update(ctx, perses)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed())
+
+			By("Creating the K8s Secret with BasicAuth credentials")
+			k8sSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      K8sSecretName,
+					Namespace: PersesNamespace,
+				},
+				StringData: map[string]string{
+					"password": "s3cret-password",
+				},
+			}
+			err = k8sClient.Create(ctx, k8sSecret)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, namespace)
+		})
+
+		It("should read secret data via APIReader and pass it to the Perses Secret API", func() {
+			By("Creating a PersesDatasource with BasicAuth referencing the K8s secret")
+			datasource := &persesv1alpha2.PersesDatasource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      DatasourceName,
+					Namespace: PersesNamespace,
+				},
+				Spec: persesv1alpha2.DatasourceSpec{
+					Config: persesv1alpha2.Datasource{
+						DatasourceSpec: persesv1.DatasourceSpec{
+							Display: &persescommon.Display{
+								Name: DatasourceName,
+							},
+							Default: true,
+							Plugin: persescommon.Plugin{
+								Kind: "Prometheus",
+								Spec: map[string]any{},
+							},
+						},
+					},
+					Client: &persesv1alpha2.Client{
+						BasicAuth: &persesv1alpha2.BasicAuth{
+							SecretSource: persesv1alpha2.SecretSource{
+								Type:      persesv1alpha2.SecretSourceTypeSecret,
+								Name:      ptr.To(K8sSecretName),
+								Namespace: ptr.To(PersesNamespace),
+							},
+							Username:     "admin",
+							PasswordPath: "password",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, datasource)
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Setting up mock Perses API expectations")
+			mockPersesClient := new(internal.MockClient)
+			mockDatasource := new(internal.MockDatasource)
+			mockSecret := new(internal.MockSecret)
+
+			mockPersesClient.On("Datasource", PersesNamespace).Return(mockDatasource)
+			mockPersesClient.On("Secret", PersesNamespace).Return(mockSecret)
+
+			// The datasource does not exist yet in Perses
+			mockDatasource.On("Get", DatasourceName).Return(&persesv1.Datasource{}, perseshttp.RequestNotFoundError)
+			mockDatasource.On("Create", mock.AnythingOfType("*v1.Datasource")).Return(&persesv1.Datasource{}, nil)
+
+			// The Perses secret does not exist yet
+			mockSecret.On("Get", PersesSecretName).Return(&persesv1.Secret{}, perseshttp.RequestNotFoundError)
+			// Use MatchedBy to verify the secret contains the correct BasicAuth password
+			mockSecret.On("Create", mock.MatchedBy(func(s *persesv1.Secret) bool {
+				return s.Spec.BasicAuth != nil &&
+					s.Spec.BasicAuth.Username == "admin" &&
+					s.Spec.BasicAuth.Password == "s3cret-password"
+			})).Return(&persesv1.Secret{}, nil)
+
+			// Use a secretStrippingClient as Client to simulate the cache Transform
+			// that strips Data/StringData. This proves the reconciler reads secrets
+			// through APIReader (k8sClient) and not through Client.
+			strippingClient := &secretStrippingClient{Client: k8sClient}
+
+			By("Reconciling the datasource")
+			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
+				Client:        strippingClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			_, err = datasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: datasourceNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying the Perses Secret was created with correct BasicAuth data")
+			mockSecret.AssertCalled(GinkgoT(), "Create", mock.MatchedBy(func(s *persesv1.Secret) bool {
+				return s.Spec.BasicAuth != nil &&
+					s.Spec.BasicAuth.Username == "admin" &&
+					s.Spec.BasicAuth.Password == "s3cret-password"
+			}))
+
+			By("Verifying the datasource status is Available")
+			Eventually(func() error {
+				dsWithStatus := &persesv1alpha2.PersesDatasource{}
+				if err := k8sClient.Get(ctx, datasourceNamespaceName, dsWithStatus); err != nil {
+					return err
+				}
+				if len(dsWithStatus.Status.Conditions) == 0 {
+					return fmt.Errorf("no status conditions found")
+				}
+				availableCond := apimeta.FindStatusCondition(dsWithStatus.Status.Conditions, common.TypeAvailablePerses)
+				if availableCond == nil || availableCond.Status != metav1.ConditionTrue {
+					return fmt.Errorf("datasource is not Available: %v", availableCond)
+				}
+				return nil
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			mockDatasource.On("Delete", DatasourceName).Return(nil)
+			mockSecret.On("Delete", PersesSecretName).Return(nil)
+
+			dsToDelete := &persesv1alpha2.PersesDatasource{}
+			err = k8sClient.Get(ctx, datasourceNamespaceName, dsToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, dsToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+
+			_, err = datasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: datasourceNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
 })

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -89,7 +89,7 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 }
 
 func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasource *persesv1alpha2.PersesDatasource) (*ctrl.Result, persescommon.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")
@@ -203,14 +203,14 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 
 		switch basicAuth.Type {
 		case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-			passwordData, err := persescommon.GetBasicAuthData(ctx, r.Client, namespace, datasourceName, basicAuth)
+			passwordData, err := persescommon.GetBasicAuthData(ctx, r.APIReader, namespace, datasourceName, basicAuth)
 
 			if err != nil {
 				dlog.WithFields(logger.Fields{
 					"datasource": datasourceName,
 					"namespace":  namespace,
-					"error":      err,
-				}).Error("Failed to get user basic auth password data for datasource")
+					"secretName": basicAuth.Name,
+				}).WithError(err).Error("Failed to get user basic auth password data for datasource")
 				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 			}
 
@@ -236,14 +236,14 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 		oAuthConfig.TokenURL = oauth.TokenURL
 		switch oauth.Type {
 		case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-			clientIDData, clientSecretData, err := persescommon.GetOAuthData(ctx, r.Client, namespace, datasourceName, oauth)
+			clientIDData, clientSecretData, err := persescommon.GetOAuthData(ctx, r.APIReader, namespace, datasourceName, oauth)
 
 			if err != nil {
 				dlog.WithFields(logger.Fields{
 					"datasource": datasourceName,
 					"namespace":  namespace,
-					"error":      err,
-				}).Error("Failed to get user oauth data for datasource")
+					"secretName": oauth.Name,
+				}).WithError(err).Error("Failed to get user oauth data for datasource")
 				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 			}
 
@@ -284,14 +284,14 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 		if tls.CaCert != nil {
 			switch tls.CaCert.Type {
 			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				caData, _, err := persescommon.GetTLSCertData(ctx, r.Client, namespace, datasourceName, tls.CaCert)
+				caData, _, err := persescommon.GetTLSCertData(ctx, r.APIReader, namespace, datasourceName, tls.CaCert)
 
 				if err != nil {
 					dlog.WithFields(logger.Fields{
 						"datasource": datasourceName,
 						"namespace":  namespace,
-						"error":      err,
-					}).Error("Failed to get CA data for datasource")
+						"secretName": tls.CaCert.Name,
+					}).WithError(err).Error("Failed to get CA data for datasource")
 					return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 				}
 
@@ -304,14 +304,14 @@ func (r *PersesDatasourceReconciler) syncPersesSecret(ctx context.Context, perse
 		if tls.UserCert != nil {
 			switch tls.UserCert.Type {
 			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				certData, keyData, err := persescommon.GetTLSCertData(ctx, r.Client, namespace, datasourceName, tls.UserCert)
+				certData, keyData, err := persescommon.GetTLSCertData(ctx, r.APIReader, namespace, datasourceName, tls.UserCert)
 
 				if err != nil {
 					dlog.WithFields(logger.Fields{
 						"datasource": datasourceName,
 						"namespace":  namespace,
-						"error":      err,
-					}).Error("Failed to get user certificate data for datasource")
+						"secretName": tls.UserCert.Name,
+					}).WithError(err).Error("Failed to get user certificate data for datasource")
 					return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 				}
 
@@ -386,7 +386,7 @@ func (r *PersesDatasourceReconciler) deleteDatasourceInAllInstances(ctx context.
 }
 
 func (r *PersesDatasourceReconciler) deleteDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasourceNamespace string, datasourceName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		dlog.WithError(err).Error("Failed to create perses rest client")

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -54,6 +54,7 @@ func datasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesDatasourc
 // PersesDatasourceReconciler reconciles a PersesDatasource object
 type PersesDatasourceReconciler struct {
 	client.Client
+	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -174,6 +174,7 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -297,6 +298,7 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			By("Reconciling the custom resource created")
 			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}
@@ -403,6 +405,7 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 
 			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
 				Client:        k8sClient,
+				APIReader:     k8sClient,
 				Scheme:        k8sClient.Scheme(),
 				ClientFactory: common.NewWithClient(mockPersesClient),
 			}

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -87,7 +87,7 @@ func (r *PersesGlobalDatasourceReconciler) reconcileGlobalDatasourcesInAllInstan
 }
 
 func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx context.Context, perses persesv1alpha2.Perses, globaldatasource *persesv1alpha2.PersesGlobalDatasource) (*ctrl.Result, persescommon.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		gdlog.WithError(err).Error("Failed to create perses rest client")
@@ -175,14 +175,14 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalSecret(ctx context.Co
 			if basicAuth.Namespace != nil {
 				namespace = *basicAuth.Namespace
 			}
-			passwordData, err := persescommon.GetBasicAuthData(ctx, r.Client, namespace, datasourceName, basicAuth)
+			passwordData, err := persescommon.GetBasicAuthData(ctx, r.APIReader, namespace, datasourceName, basicAuth)
 
 			if err != nil {
 				gdlog.WithFields(logger.Fields{
 					"globaldatasource": datasourceName,
 					"namespace":        basicAuth.Namespace,
-					"error":            err,
-				}).Error("Failed to get user basic auth password data for globaldatasource")
+					"secretName":       basicAuth.Name,
+				}).WithError(err).Error("Failed to get user basic auth password data for globaldatasource")
 				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 			}
 
@@ -212,13 +212,13 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalSecret(ctx context.Co
 			if oauth.Namespace != nil {
 				namespace = *oauth.Namespace
 			}
-			clientIDData, clientSecretData, err := persescommon.GetOAuthData(ctx, r.Client, namespace, datasourceName, oauth)
+			clientIDData, clientSecretData, err := persescommon.GetOAuthData(ctx, r.APIReader, namespace, datasourceName, oauth)
 			if err != nil {
 				gdlog.WithFields(logger.Fields{
 					"globaldatasource": datasourceName,
 					"namespace":        oauth.Namespace,
-					"error":            err,
-				}).Error("Failed to get user oauth data for globaldatasource")
+					"secretName":       oauth.Name,
+				}).WithError(err).Error("Failed to get user oauth data for globaldatasource")
 				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 			}
 
@@ -263,14 +263,14 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalSecret(ctx context.Co
 				if tls.CaCert.Namespace != nil {
 					caCertNamespace = *tls.CaCert.Namespace
 				}
-				caData, _, err := persescommon.GetTLSCertData(ctx, r.Client, caCertNamespace, datasourceName, tls.CaCert)
+				caData, _, err := persescommon.GetTLSCertData(ctx, r.APIReader, caCertNamespace, datasourceName, tls.CaCert)
 
 				if err != nil {
 					gdlog.WithFields(logger.Fields{
 						"globaldatasource": datasourceName,
 						"namespace":        tls.CaCert.Namespace,
-						"error":            err,
-					}).Error("Failed to get CA data for globaldatasource")
+						"secretName":       tls.CaCert.Name,
+					}).WithError(err).Error("Failed to get CA data for globaldatasource")
 					return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 				}
 
@@ -287,14 +287,14 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalSecret(ctx context.Co
 				if tls.UserCert.Namespace != nil {
 					userCertNamespace = *tls.UserCert.Namespace
 				}
-				certData, keyData, err := persescommon.GetTLSCertData(ctx, r.Client, userCertNamespace, datasourceName, tls.UserCert)
+				certData, keyData, err := persescommon.GetTLSCertData(ctx, r.APIReader, userCertNamespace, datasourceName, tls.UserCert)
 
 				if err != nil {
 					gdlog.WithFields(logger.Fields{
 						"globaldatasource": datasourceName,
 						"namespace":        tls.UserCert.Namespace,
-						"error":            err,
-					}).Error("Failed to get user certificate data for globaldatasource")
+						"secretName":       tls.UserCert.Name,
+					}).WithError(err).Error("Failed to get user certificate data for globaldatasource")
 					return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonInvalidConfiguration)
 				}
 
@@ -370,7 +370,7 @@ func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasourceInAllInstances(
 }
 
 func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasourceName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.Client, perses)
+	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
 
 	if err != nil {
 		gdlog.WithError(err).Error("Failed to create perses rest client")

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -54,6 +54,7 @@ func globalDatasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesGlo
 // PersesGlobalDatasourceReconciler reconciles a PersesDatasource object
 type PersesGlobalDatasourceReconciler struct {
 	client.Client
+	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory

--- a/controllers/perses/find_perses_for_secret_test.go
+++ b/controllers/perses/find_perses_for_secret_test.go
@@ -1,0 +1,213 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/perses/perses-operator/api/v1alpha2"
+)
+
+func TestFindPersesForSecret_WithPartialObjectMetadata(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha2.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	perses := &v1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-perses",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha2.PersesSpec{
+			Provisioning: &v1alpha2.Provisioning{
+				SecretRefs: []*v1alpha2.ProvisioningSecret{
+					{
+						SecretKeySelector: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "my-secret",
+							},
+							Key: "password",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(perses).Build()
+	reconciler := &PersesReconciler{Client: fakeClient}
+
+	tests := []struct {
+		name           string
+		secretName     string
+		secretNs       string
+		expectRequests int
+	}{
+		{
+			name:           "matching secret triggers reconciliation",
+			secretName:     "my-secret",
+			secretNs:       "test-ns",
+			expectRequests: 1,
+		},
+		{
+			name:           "non-matching secret name returns empty",
+			secretName:     "other-secret",
+			secretNs:       "test-ns",
+			expectRequests: 0,
+		},
+		{
+			name:           "matching name in different namespace returns empty",
+			secretName:     "my-secret",
+			secretNs:       "other-ns",
+			expectRequests: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// WatchesMetadata passes PartialObjectMetadata instead of *corev1.Secret
+			obj := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.secretName,
+					Namespace: tt.secretNs,
+				},
+			}
+			obj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+
+			requests := reconciler.findPersesForSecret(context.Background(), obj)
+			assert.Len(t, requests, tt.expectRequests)
+			if tt.expectRequests > 0 {
+				assert.Equal(t, "test-perses", requests[0].Name)
+				assert.Equal(t, "test-ns", requests[0].Namespace)
+			}
+		})
+	}
+}
+
+func TestFindPersesForSecret_MultiplePersesReferencingSameSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha2.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	perses1 := &v1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perses-one",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha2.PersesSpec{
+			Provisioning: &v1alpha2.Provisioning{
+				SecretRefs: []*v1alpha2.ProvisioningSecret{
+					{
+						SecretKeySelector: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "shared-secret",
+							},
+							Key: "password",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	perses2 := &v1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perses-two",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha2.PersesSpec{
+			Provisioning: &v1alpha2.Provisioning{
+				SecretRefs: []*v1alpha2.ProvisioningSecret{
+					{
+						SecretKeySelector: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "shared-secret",
+							},
+							Key: "token",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(perses1, perses2).Build()
+	reconciler := &PersesReconciler{Client: fakeClient}
+
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-secret",
+			Namespace: "test-ns",
+		},
+	}
+	obj.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+
+	requests := reconciler.findPersesForSecret(context.Background(), obj)
+	assert.Len(t, requests, 2)
+
+	names := []string{requests[0].Name, requests[1].Name}
+	assert.Contains(t, names, "perses-one")
+	assert.Contains(t, names, "perses-two")
+}
+
+func TestFindPersesForSecret_NoPersesInNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha2.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &PersesReconciler{Client: fakeClient}
+
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "any-secret",
+			Namespace: "empty-ns",
+		},
+	}
+
+	requests := reconciler.findPersesForSecret(context.Background(), obj)
+	assert.Empty(t, requests)
+}
+
+func TestFindPersesForSecret_PersesWithoutProvisioning(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = v1alpha2.AddToScheme(scheme)
+
+	perses := &v1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-perses",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha2.PersesSpec{},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(perses).Build()
+	reconciler := &PersesReconciler{Client: fakeClient}
+
+	obj := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-secret",
+			Namespace: "test-ns",
+		},
+	}
+
+	requests := reconciler.findPersesForSecret(context.Background(), obj)
+	assert.Empty(t, requests)
+}

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -16,7 +16,6 @@ package perses
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 	"time"
 
@@ -63,6 +62,7 @@ type Config struct {
 // PersesReconciler reconciles a Perses object
 type PersesReconciler struct {
 	client.Client
+	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	Config                Config
@@ -410,26 +410,34 @@ func (r *PersesReconciler) reconcileProvisioning(ctx context.Context, req ctrl.R
 		})
 	}
 
-	var newSecretVersions []v1alpha2.SecretVersion
+	// Use a map to deduplicate secrets and avoid redundant API calls
+	// (provisioning secrets may be referenced more than once for different keys)
+	secretVersionMap := make(map[string]string) // name -> resourceVersion
 	for _, secretRef := range perses.Spec.Provisioning.SecretRefs {
+		if _, seen := secretVersionMap[secretRef.Name]; seen {
+			continue
+		}
+
 		secretName := types.NamespacedName{
 			Namespace: perses.Namespace,
 			Name:      secretRef.Name,
 		}
 
 		actualSecret := &corev1.Secret{}
-		err := r.Get(ctx, secretName, actualSecret)
+		err := r.APIReader.Get(ctx, secretName, actualSecret)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get provisioning secret %s", secretName.String())
 			return subreconciler.RequeueWithError(err)
 		}
-		// provisioning secrets may be used more than once for different keys, so only add the secret once
-		if !slices.ContainsFunc(newSecretVersions, func(version v1alpha2.SecretVersion) bool { return version.Name == secretName.Name }) {
-			newSecretVersions = append(newSecretVersions, v1alpha2.SecretVersion{
-				Name:    secretRef.Name,
-				Version: actualSecret.ResourceVersion,
-			})
-		}
+		secretVersionMap[secretRef.Name] = actualSecret.ResourceVersion
+	}
+
+	newSecretVersions := make([]v1alpha2.SecretVersion, 0, len(secretVersionMap))
+	for name, version := range secretVersionMap {
+		newSecretVersions = append(newSecretVersions, v1alpha2.SecretVersion{
+			Name:    name,
+			Version: version,
+		})
 	}
 
 	sort.Slice(newSecretVersions, func(i, j int) bool {
@@ -446,40 +454,32 @@ func (r *PersesReconciler) reconcileProvisioning(ctx context.Context, req ctrl.R
 }
 
 func (r *PersesReconciler) findPersesForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
-	// only check for secrets
-	secret, ok := obj.(*corev1.Secret)
-	if !ok {
-		return nil
-	}
-
 	// List all Perses objects in the same namespace as the secret
 	persesList := &v1alpha2.PersesList{}
-	if err := r.List(ctx, persesList, client.InNamespace(secret.Namespace)); err != nil {
-		log.WithError(err).Errorf("failed to list Perses instances for secret %s/%s", secret.Namespace, secret.Name)
+	if err := r.List(ctx, persesList, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.WithError(err).Errorf("failed to list Perses instances for secret %s/%s", obj.GetNamespace(), obj.GetName())
 		return nil
 	}
 
+	var requests []reconcile.Request
 	for _, perses := range persesList.Items {
 		if perses.Spec.Provisioning == nil || len(perses.Spec.Provisioning.SecretRefs) == 0 {
 			continue
 		}
-		// Check if this Perses instance references the changed secret
 		for _, ref := range perses.Spec.Provisioning.SecretRefs {
-			if ref.Name == secret.Name {
-				// only need to reconcile on the first secret that matches the Perses instance
-				return []reconcile.Request{
-					{
-						NamespacedName: types.NamespacedName{
-							Name:      perses.Name,
-							Namespace: perses.Namespace,
-						},
+			if ref.Name == obj.GetName() {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      perses.Name,
+						Namespace: perses.Namespace,
 					},
-				}
+				})
+				break // found a match for this Perses instance, move to next
 			}
 		}
 	}
 
-	return []reconcile.Request{}
+	return requests
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -490,7 +490,9 @@ func (r *PersesReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
-		Watches(
+		// WatchesMetadata only caches metadata (not Data) to reduce memory.
+		// Actual secret data is read via APIReader in reconcileProvisioning.
+		WatchesMetadata(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findPersesForSecret),
 		).

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -111,8 +111,9 @@ var _ = Describe("Perses controller", func() {
 
 			By("Reconciling the custom resource created")
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			// Errors might arise during reconciliation, but we are checking the final state of the resources
@@ -339,8 +340,9 @@ var _ = Describe("Perses controller", func() {
 
 			By("Reconciling the custom resource created")
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			// Errors might arise during reconciliation, but we are checking the final state of the resources
@@ -491,8 +493,9 @@ var _ = Describe("Perses controller", func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			By("Reconciling the custom resource created")
@@ -601,8 +604,9 @@ var _ = Describe("Perses controller", func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			By("Reconciling to add the finalizer")
@@ -690,8 +694,9 @@ var _ = Describe("Perses controller", func() {
 			Expect(k8sClient.Create(ctx, perses)).To(Succeed())
 
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			By("Reconciling the custom resource")
@@ -954,8 +959,9 @@ var _ = Describe("Perses controller", func() {
 			Expect(k8sClient.Create(ctx, perses)).To(Succeed())
 
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			By("Reconciling until validateVolumes catches the orphan volumeMount")
@@ -1010,8 +1016,9 @@ var _ = Describe("Perses controller", func() {
 			Expect(k8sClient.Create(ctx, perses)).To(Succeed())
 
 			persesReconciler := &persescontroller.PersesReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
 			}
 
 			By("Reconciling until validateVolumes catches the missing volumes")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -96,8 +96,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&persesController.PersesReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
+		Client:    k8sManager.GetClient(),
+		APIReader: k8sManager.GetAPIReader(),
+		Scheme:    k8sManager.GetScheme(),
 		Config: persesController.Config{
 			PersesImage: operator.DefaultPersesImage,
 		},

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -32,7 +32,7 @@ import (
 const tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 type PersesClientFactory interface {
-	CreateClient(ctx context.Context, client client.Client, perses persesv1alpha2.Perses) (v1.ClientInterface, error)
+	CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error)
 }
 
 type PersesClientFactoryWithConfig struct{}
@@ -41,7 +41,7 @@ func NewWithConfig() PersesClientFactory {
 	return &PersesClientFactoryWithConfig{}
 }
 
-func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client client.Client, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
+func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	var urlStr string
 
 	var httpProtocol = "http"
@@ -148,6 +148,6 @@ func NewWithClient(client v1.ClientInterface) PersesClientFactory {
 	return &PersesClientFactoryWithClient{client: client}
 }
 
-func (f *PersesClientFactoryWithClient) CreateClient(_ context.Context, _ client.Client, _ persesv1alpha2.Perses) (v1.ClientInterface, error) {
+func (f *PersesClientFactoryWithClient) CreateClient(_ context.Context, _ client.Reader, _ persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	return f.client, nil
 }

--- a/internal/perses/common/secret.go
+++ b/internal/perses/common/secret.go
@@ -31,7 +31,7 @@ func HasSecretConfig(c *v1alpha2.Client) bool {
 }
 
 // GetBasicAuthData get basic auth from a BasicAuth resource
-func GetBasicAuthData(ctx context.Context, client client.Client, namespace string, name string, basicAuth *v1alpha2.BasicAuth) (string, error) {
+func GetBasicAuthData(ctx context.Context, client client.Reader, namespace string, name string, basicAuth *v1alpha2.BasicAuth) (string, error) {
 	var passwordData string
 
 	if basicAuth.Type == v1alpha2.SecretSourceTypeSecret || basicAuth.Type == v1alpha2.SecretSourceTypeConfigMap {
@@ -76,7 +76,7 @@ func GetBasicAuthData(ctx context.Context, client client.Client, namespace strin
 }
 
 // GetOAuthData get basic auth from a OAuth resource
-func GetOAuthData(ctx context.Context, client client.Client, namespace string, name string, oauth *v1alpha2.OAuth) (string, string, error) {
+func GetOAuthData(ctx context.Context, client client.Reader, namespace string, name string, oauth *v1alpha2.OAuth) (string, string, error) {
 	var clientIDData string
 	var clientSecretData string
 
@@ -148,7 +148,7 @@ func GetOAuthData(ctx context.Context, client client.Client, namespace string, n
 }
 
 // GetTLSCertData get tls certs from a Certificate resource
-func GetTLSCertData(ctx context.Context, client client.Client, namespace string, name string, cert *v1alpha2.Certificate) (string, string, error) {
+func GetTLSCertData(ctx context.Context, client client.Reader, namespace string, name string, cert *v1alpha2.Certificate) (string, string, error) {
 	var certData string
 	var keyData string
 

--- a/internal/perses/common/secret_test.go
+++ b/internal/perses/common/secret_test.go
@@ -1,0 +1,497 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perses/perses-operator/api/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func TestGetBasicAuthData(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads password from Secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+			Data:       map[string][]byte{"password": []byte("s3cret")},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("my-secret"),
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		password, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "s3cret", password)
+	})
+
+	t.Run("reads password from ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default"},
+			Data:       map[string]string{"password": "cm-password"},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeConfigMap,
+				Name: ptr.To("my-cm"),
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		password, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "cm-password", password)
+	})
+
+	t.Run("respects namespace override", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "other-ns"},
+			Data:       map[string][]byte{"password": []byte("cross-ns")},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type:      v1alpha2.SecretSourceTypeSecret,
+				Name:      ptr.To("my-secret"),
+				Namespace: ptr.To("other-ns"),
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		password, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "cross-ns", password)
+	})
+
+	t.Run("returns error when secret not found", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("missing-secret"),
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		_, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.Error(t, err)
+	})
+
+	t.Run("returns error when key missing in secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+			Data:       map[string][]byte{"other-key": []byte("value")},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("my-secret"),
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		_, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no password data found")
+	})
+
+	t.Run("returns empty string for non-secret/configmap type", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeFile,
+			},
+			Username:     "admin",
+			PasswordPath: "/path/to/password",
+		}
+
+		password, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.NoError(t, err)
+		assert.Equal(t, "", password)
+	})
+
+	t.Run("returns error when name is nil", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		basicAuth := &v1alpha2.BasicAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+			},
+			Username:     "admin",
+			PasswordPath: "password",
+		}
+
+		_, err := GetBasicAuthData(ctx, reader, "default", "test-ds", basicAuth)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no name found")
+	})
+}
+
+func TestGetOAuthData(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads client ID and secret from Secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "oauth-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				"client-id":     []byte("my-client-id"),
+				"client-secret": []byte("my-client-secret"),
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("oauth-secret"),
+			},
+			ClientIDPath:     ptr.To("client-id"),
+			ClientSecretPath: ptr.To("client-secret"),
+			TokenURL:         "https://auth.example.com/token",
+		}
+
+		clientID, clientSecret, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.NoError(t, err)
+		assert.Equal(t, "my-client-id", clientID)
+		assert.Equal(t, "my-client-secret", clientSecret)
+	})
+
+	t.Run("reads from ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "oauth-cm", Namespace: "default"},
+			Data: map[string]string{
+				"client-id":     "cm-client-id",
+				"client-secret": "cm-client-secret",
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeConfigMap,
+				Name: ptr.To("oauth-cm"),
+			},
+			ClientIDPath:     ptr.To("client-id"),
+			ClientSecretPath: ptr.To("client-secret"),
+			TokenURL:         "https://auth.example.com/token",
+		}
+
+		clientID, clientSecret, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.NoError(t, err)
+		assert.Equal(t, "cm-client-id", clientID)
+		assert.Equal(t, "cm-client-secret", clientSecret)
+	})
+
+	t.Run("returns error when secret not found", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("missing"),
+			},
+			ClientIDPath:     ptr.To("client-id"),
+			ClientSecretPath: ptr.To("client-secret"),
+		}
+
+		_, _, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.Error(t, err)
+	})
+
+	t.Run("returns error when client ID key missing", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "oauth-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				"client-secret": []byte("my-client-secret"),
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("oauth-secret"),
+			},
+			ClientIDPath:     ptr.To("client-id"),
+			ClientSecretPath: ptr.To("client-secret"),
+		}
+
+		_, _, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no client id data found")
+	})
+
+	t.Run("returns error when client secret key missing", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "oauth-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				"client-id": []byte("my-client-id"),
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("oauth-secret"),
+			},
+			ClientIDPath:     ptr.To("client-id"),
+			ClientSecretPath: ptr.To("client-secret"),
+		}
+
+		_, _, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no client secret data found")
+	})
+
+	t.Run("returns empty strings for file type", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeFile,
+			},
+			TokenURL: "https://auth.example.com/token",
+		}
+
+		clientID, clientSecret, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.NoError(t, err)
+		assert.Equal(t, "", clientID)
+		assert.Equal(t, "", clientSecret)
+	})
+
+	t.Run("returns error when name is nil", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		oauth := &v1alpha2.OAuth{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+			},
+			ClientIDPath: ptr.To("client-id"),
+		}
+
+		_, _, err := GetOAuthData(ctx, reader, "default", "test-ds", oauth)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no name found")
+	})
+}
+
+func TestGetTLSCertData(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("reads cert and key from Secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				"tls.crt": []byte("cert-data"),
+				"tls.key": []byte("key-data"),
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("tls-secret"),
+			},
+			CertPath:       "tls.crt",
+			PrivateKeyPath: ptr.To("tls.key"),
+		}
+
+		certData, keyData, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.NoError(t, err)
+		assert.Equal(t, "cert-data", certData)
+		assert.Equal(t, "key-data", keyData)
+	})
+
+	t.Run("reads cert without key from Secret (CA cert)", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "ca-secret", Namespace: "default"},
+			Data: map[string][]byte{
+				"ca.crt": []byte("ca-cert-data"),
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("ca-secret"),
+			},
+			CertPath: "ca.crt",
+		}
+
+		certData, keyData, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.NoError(t, err)
+		assert.Equal(t, "ca-cert-data", certData)
+		assert.Equal(t, "", keyData)
+	})
+
+	t.Run("reads from ConfigMap", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls-cm", Namespace: "default"},
+			Data: map[string]string{
+				"tls.crt": "cm-cert-data",
+				"tls.key": "cm-key-data",
+			},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeConfigMap,
+				Name: ptr.To("tls-cm"),
+			},
+			CertPath:       "tls.crt",
+			PrivateKeyPath: ptr.To("tls.key"),
+		}
+
+		certData, keyData, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.NoError(t, err)
+		assert.Equal(t, "cm-cert-data", certData)
+		assert.Equal(t, "cm-key-data", keyData)
+	})
+
+	t.Run("returns error when secret not found", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("missing"),
+			},
+			CertPath: "tls.crt",
+		}
+
+		_, _, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.Error(t, err)
+	})
+
+	t.Run("returns error when cert key missing in secret", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls-secret", Namespace: "default"},
+			Data:       map[string][]byte{"other-key": []byte("value")},
+		}
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+				Name: ptr.To("tls-secret"),
+			},
+			CertPath: "tls.crt",
+		}
+
+		_, _, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no data found for certificate")
+	})
+
+	t.Run("returns empty strings for file type", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeFile,
+			},
+			CertPath: "/path/to/cert",
+		}
+
+		certData, keyData, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.NoError(t, err)
+		assert.Equal(t, "", certData)
+		assert.Equal(t, "", keyData)
+	})
+
+	t.Run("returns error when name is nil", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		cert := &v1alpha2.Certificate{
+			SecretSource: v1alpha2.SecretSource{
+				Type: v1alpha2.SecretSourceTypeSecret,
+			},
+			CertPath: "tls.crt",
+		}
+
+		_, _, err := GetTLSCertData(ctx, reader, "default", "test-ds", cert)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no name found")
+	})
+}
+
+func TestHasSecretConfig(t *testing.T) {
+	t.Run("returns false for nil client", func(t *testing.T) {
+		assert.False(t, HasSecretConfig(nil))
+	})
+
+	t.Run("returns false for empty client", func(t *testing.T) {
+		assert.False(t, HasSecretConfig(&v1alpha2.Client{}))
+	})
+
+	t.Run("returns true for BasicAuth", func(t *testing.T) {
+		assert.True(t, HasSecretConfig(&v1alpha2.Client{
+			BasicAuth: &v1alpha2.BasicAuth{},
+		}))
+	})
+
+	t.Run("returns true for OAuth", func(t *testing.T) {
+		assert.True(t, HasSecretConfig(&v1alpha2.Client{
+			OAuth: &v1alpha2.OAuth{},
+		}))
+	})
+
+	t.Run("returns true for TLS enabled", func(t *testing.T) {
+		assert.True(t, HasSecretConfig(&v1alpha2.Client{
+			TLS: &v1alpha2.TLS{Enable: ptr.To(true)},
+		}))
+	})
+
+	t.Run("returns false for TLS disabled", func(t *testing.T) {
+		assert.False(t, HasSecretConfig(&v1alpha2.Client{
+			TLS: &v1alpha2.TLS{Enable: ptr.To(false)},
+		}))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -22,10 +22,13 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -119,6 +122,22 @@ func main() {
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 		PprofBindAddress: "127.0.0.1:8083",
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					// Strip secret data from the cache to reduce memory usage.
+					// All controllers watch or read secrets but only need metadata for change detection.
+					// Controllers that need actual secret data use the APIReader instead.
+					Transform: func(obj interface{}) (interface{}, error) {
+						if secret, ok := obj.(*corev1.Secret); ok {
+							secret.Data = nil
+							secret.StringData = nil
+						}
+						return obj, nil
+					},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -132,6 +151,7 @@ func main() {
 
 	if err = (&persescontroller.PersesReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
@@ -145,6 +165,7 @@ func main() {
 
 	if err = (&dashboardcontroller.PersesDashboardReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
@@ -156,6 +177,7 @@ func main() {
 
 	if err = (&datasourcecontroller.PersesDatasourceReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
@@ -167,6 +189,7 @@ func main() {
 
 	if err = (&globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
 		Client:                mgr.GetClient(),
+		APIReader:             mgr.GetAPIReader(),
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,

--- a/test/e2e/perses-provisioning-secrets/00-assert.yaml
+++ b/test/e2e/perses-provisioning-secrets/00-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-provisioning-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-provisioning-test

--- a/test/e2e/perses-provisioning-secrets/00-install.yaml
+++ b/test/e2e/perses-provisioning-secrets/00-install.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provisioning-secret
+stringData:
+  encryption-key: "initial-secret-value"
+---
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-provisioning-test
+  labels:
+    app.kubernetes.io/instance: perses-provisioning-test
+spec:
+  metadata:
+    labels:
+      instance: perses-provisioning-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+    security:
+      encryptionKeyFile: "/etc/perses/provisioning/secrets/provisioning-secret-encryption-key"
+      cookie:
+        secure: false
+      enable_auth: false
+      readonly: false
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi
+  provisioning:
+    secretRefs:
+      - name: provisioning-secret
+        key: encryption-key

--- a/test/e2e/perses-provisioning-secrets/01-assert.yaml
+++ b/test/e2e/perses-provisioning-secrets/01-assert.yaml
@@ -1,0 +1,52 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  # Verify provisioning-version annotation is set on StatefulSet pod template
+  - script: |
+      ANNOTATION=$(kubectl get statefulset perses-provisioning-test -n $NAMESPACE -o jsonpath='{.spec.template.metadata.annotations.perses\.dev/provisioning-version}')
+      if [ -z "$ANNOTATION" ]; then
+        echo "FAIL: provisioning-version annotation not found on StatefulSet pod template"
+        exit 1
+      fi
+      echo "Verified: provisioning-version annotation is set: $ANNOTATION"
+  # Verify provisioning secret is mounted as a volume
+  - script: |
+      VOLUMES=$(kubectl get statefulset perses-provisioning-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.volumes[*].name}')
+      echo "$VOLUMES" | grep -q "provisioning-" || {
+        echo "FAIL: provisioning secret volume not found in StatefulSet volumes: $VOLUMES"
+        exit 1
+      }
+      echo "Verified: provisioning secret volume is present"
+  # Verify the volume mount path exists
+  - script: |
+      MOUNTS=$(kubectl get statefulset perses-provisioning-test -n $NAMESPACE -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[*].mountPath}')
+      echo "$MOUNTS" | grep -q "/etc/perses/provisioning/secrets" || {
+        echo "FAIL: provisioning secret mount path not found: $MOUNTS"
+        exit 1
+      }
+      echo "Verified: provisioning secret volume mount is present"
+  # Verify status.provisioning has the secret entry
+  - script: |
+      SECRET_NAME=$(kubectl get perses perses-provisioning-test -n $NAMESPACE -o jsonpath='{.status.provisioning[0].name}')
+      if [ "$SECRET_NAME" != "provisioning-secret" ]; then
+        echo "FAIL: expected status.provisioning[0].name='provisioning-secret', got '$SECRET_NAME'"
+        exit 1
+      fi
+      VERSION=$(kubectl get perses perses-provisioning-test -n $NAMESPACE -o jsonpath='{.status.provisioning[0].version}')
+      if [ -z "$VERSION" ]; then
+        echo "FAIL: status.provisioning[0].version is empty"
+        exit 1
+      fi
+      echo "Verified: status.provisioning[0] = {name: $SECRET_NAME, version: $VERSION}"
+  # Save the initial provisioning-version annotation for later comparison
+  - script: |
+      kubectl get statefulset perses-provisioning-test -n $NAMESPACE -o jsonpath='{.spec.template.metadata.annotations.perses\.dev/provisioning-version}' > /tmp/initial-provisioning-version
+      echo "Saved initial provisioning-version: $(cat /tmp/initial-provisioning-version)"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-provisioning-test
+status:
+  readyReplicas: 1

--- a/test/e2e/perses-provisioning-secrets/02-assert.yaml
+++ b/test/e2e/perses-provisioning-secrets/02-assert.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  # Verify the provisioning-version annotation changed after secret update
+  - script: |
+      INITIAL=$(cat /tmp/initial-provisioning-version)
+      CURRENT=$(kubectl get statefulset perses-provisioning-test -n $NAMESPACE -o jsonpath='{.spec.template.metadata.annotations.perses\.dev/provisioning-version}')
+      if [ -z "$CURRENT" ]; then
+        echo "FAIL: provisioning-version annotation not found after secret update"
+        exit 1
+      fi
+      if [ "$INITIAL" = "$CURRENT" ]; then
+        echo "FAIL: provisioning-version annotation did not change after secret update (still: $CURRENT)"
+        exit 1
+      fi
+      echo "Verified: provisioning-version changed from '$INITIAL' to '$CURRENT'"
+  # Verify status.provisioning version was updated
+  - script: |
+      VERSION=$(kubectl get perses perses-provisioning-test -n $NAMESPACE -o jsonpath='{.status.provisioning[0].version}')
+      if [ -z "$VERSION" ]; then
+        echo "FAIL: status.provisioning[0].version is empty after secret update"
+        exit 1
+      fi
+      echo "Verified: status.provisioning[0].version = $VERSION (updated)"

--- a/test/e2e/perses-provisioning-secrets/02-install.yaml
+++ b/test/e2e/perses-provisioning-secrets/02-install.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provisioning-secret
+stringData:
+  encryption-key: "updated-secret-value"

--- a/test/e2e/perses-provisioning-secrets/03-assert.yaml
+++ b/test/e2e/perses-provisioning-secrets/03-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete perses/perses-provisioning-test -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete secret/provisioning-secret -n $NAMESPACE --timeout=60s

--- a/test/e2e/perses-provisioning-secrets/03-delete.yaml
+++ b/test/e2e/perses-provisioning-secrets/03-delete.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-provisioning-test
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: provisioning-secret


### PR DESCRIPTION
# Description

This PR:
- Adds caching configuration for the manager when watching secrets. Uses only the secret metadata to reduce the memory footprint. To read the actual secret, only when reconciling, a new client reader is added which bypasses the cache.
- Adds tests for the secret reconciliation when using provisioning
- Improves the perses instances reconciliaton when multiple perses reference the same secret

Fixes: [COO-1741](https://redhat.atlassian.net/browse/COO-1741)

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
