### PR TITLE
[FEATURE]: add replaces-mode support for OLM bundle generation

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -103,6 +103,8 @@ jobs:
         run: make generate
       - name: check bundle changes
         run: make bundle-check
+      - name: check jsonnet changes
+        run: make jsonnet-check
       - name: check installer manifest is up-to-date
         run: make installer-check
       - name: check generated manifests are up-to-date

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ Dockerfile.cross
 /.github/perses-ci/
 
 bundle_tmp*
-/bundle/manifests/
 
 # Auto-generated API docs config with resolved k8s version
 docs/config/api-docs-config-resolved.yaml

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
 BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 
+# VERSION_REPLACED defines the previous operator version for OLM replaces-mode upgrade chain.
+# Set this when generating bundles (e.g. make bundle VERSION_REPLACED=0.3.1)
+VERSION_REPLACED ?=
+
 # USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
 # You can enable this value if you would like to use SHA Based Digests
 # To enable set flag to true
@@ -454,15 +458,20 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 ##@ Build Dependencies
 
 .PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./bundle
+bundle: manifests kustomize operator-sdk yq ## Generate bundle manifests and metadata, then validate generated files.
+	VERSION=$(VERSION) \
+	VERSION_REPLACED=$(VERSION_REPLACED) \
+	BUNDLE_GEN_FLAGS='$(BUNDLE_GEN_FLAGS)' \
+	IMG=$(IMG) \
+		scripts/bundle.sh
 
 .PHONY: bundle-check
 bundle-check: bundle
-	git diff --exit-code bundle config jsonnet/generated jsonnet/examples
+	git diff --exit-code bundle config
+
+.PHONY: jsonnet-check
+jsonnet-check: manifests
+	git diff --exit-code jsonnet/generated jsonnet/examples
 
 .PHONY: bundle-build
 bundle-build: generate bundle ## Build the bundle image.

--- a/bundle/ci.yaml
+++ b/bundle/ci.yaml
@@ -1,0 +1,6 @@
+---
+# Use replaces-mode or semver-mode. Once you switch to semver-mode, there is no easy way back.
+updateGraph: replaces-mode
+reviewers:
+  - jgbernalp
+  - Nexucis

--- a/bundle/manifests/perses-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/perses-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: perses-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: perses-operator
+    control-plane: controller-manager
+  name: perses-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/perses-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/perses-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: perses-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: perses-operator
+  name: perses-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/perses-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/perses-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: perses-operator
+  name: perses-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/perses-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/perses-operator.clusterserviceversion.yaml
@@ -1,0 +1,1480 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "perses.dev/v1alpha2",
+          "kind": "Perses",
+          "metadata": {
+            "name": "perses-sample",
+            "namespace": "perses-dev"
+          },
+          "spec": {
+            "config": {
+              "database": {
+                "file": {
+                  "extension": "yaml",
+                  "folder": "/perses"
+                }
+              },
+              "ephemeral_dashboard": {
+                "cleanup_interval": "1s",
+                "enable": false
+              }
+            },
+            "containerPort": 8080,
+            "livenessProbe": {
+              "failureThreshold": 5,
+              "initialDelaySeconds": 10,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 5
+            },
+            "logLevel": "debug",
+            "logMethodTrace": true,
+            "metadata": {
+              "labels": {
+                "app.kubernetes.io/component": "server",
+                "app.kubernetes.io/instance": "perses-sample",
+                "app.kubernetes.io/name": "perses"
+              }
+            },
+            "readinessProbe": {
+              "failureThreshold": 5,
+              "initialDelaySeconds": 10,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 5
+            },
+            "resources": {
+              "requests": {
+                "memory": "128Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "perses.dev/v1alpha2",
+          "kind": "PersesDashboard",
+          "metadata": {
+            "name": "perses-dashboard-sample",
+            "namespace": "perses-dev"
+          },
+          "spec": {
+            "config": {
+              "datasources": {
+                "PrometheusLocal": {
+                  "default": false,
+                  "plugin": {
+                    "kind": "PrometheusDatasource",
+                    "spec": {
+                      "proxy": {
+                        "kind": "HTTPProxy",
+                        "spec": {
+                          "url": "http://localhost:9090"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "display": {
+                "description": "This is a sample dashboard",
+                "name": "Perses Dashboard Sample"
+              },
+              "duration": "5m",
+              "layouts": [
+                {
+                  "kind": "Grid",
+                  "spec": {
+                    "display": {
+                      "collapse": {
+                        "open": true
+                      },
+                      "title": "Row 1"
+                    },
+                    "items": [
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/statRAM"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 0,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/statTotalRAM"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 0,
+                        "y": 4
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/statMd"
+                        },
+                        "height": 6,
+                        "width": 4,
+                        "x": 2,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/statLg"
+                        },
+                        "height": 6,
+                        "width": 10,
+                        "x": 6,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/gaugeFormatTest"
+                        },
+                        "height": 6,
+                        "width": 4,
+                        "x": 16,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/gaugeRAM"
+                        },
+                        "height": 6,
+                        "width": 4,
+                        "x": 20,
+                        "y": 0
+                      }
+                    ]
+                  }
+                },
+                {
+                  "kind": "Grid",
+                  "spec": {
+                    "display": {
+                      "collapse": {
+                        "open": true
+                      },
+                      "title": "Row 2"
+                    },
+                    "items": [
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/legendEx"
+                        },
+                        "height": 6,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/basicEx"
+                        },
+                        "height": 6,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    ]
+                  }
+                },
+                {
+                  "kind": "Grid",
+                  "spec": {
+                    "display": {
+                      "collapse": {
+                        "open": false
+                      },
+                      "title": "Row 3"
+                    },
+                    "items": [
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/cpuGauge"
+                        },
+                        "height": 6,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/cpuLine"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 0,
+                        "y": 6
+                      },
+                      {
+                        "content": {
+                          "$ref": "#/spec/panels/defaultTimeSeriesChart"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    ]
+                  }
+                }
+              ],
+              "panels": {
+                "basicEx": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Single Query"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "legend": {
+                          "position": "right"
+                        },
+                        "yAxis": {
+                          "format": {
+                            "unit": "decimal"
+                          }
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "1 - node_filesystem_free_bytes{job='$job',instance=~'$instance',fstype!=\"rootfs\",mountpoint!~\"/(run|var).*\",mountpoint!=\"\"} / node_filesystem_size_bytes{job='$job',instance=~'$instance'}",
+                              "seriesNameFormat": "Node memory - {{device}} {{instance}}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "cpuGauge": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a gauge chart test",
+                      "name": "CPU - Gauge (Multi Series)"
+                    },
+                    "plugin": {
+                      "kind": "GaugeChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "unit": "percent-decimal"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "value": 0.2
+                            },
+                            {
+                              "value": 0.35
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "avg without (cpu)(rate(node_cpu_seconds_total{job='$job',instance=~'$instance',mode!=\"nice\",mode!=\"steal\",mode!=\"irq\"}[$interval]))",
+                              "seriesNameFormat": "{{mode}} mode - {{job}} {{instance}}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "cpuLine": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a line chart test",
+                      "name": "CPU - Line (Multi Series)"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "legend": {
+                          "position": "bottom"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "value": 0.2
+                            },
+                            {
+                              "value": 0.35
+                            }
+                          ]
+                        },
+                        "yAxis": {
+                          "format": {
+                            "decimalPlaces": 0,
+                            "unit": "percent-decimal"
+                          },
+                          "label": "CPU Label",
+                          "show": false
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "avg without (cpu)(rate(node_cpu_seconds_total{job='$job',instance=~'$instance',mode!=\"nice\",mode!=\"steal\",mode!=\"irq\"}[$interval]))",
+                              "seriesNameFormat": "{{mode}} mode - {{job}} {{instance}}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "defaultTimeSeriesChart": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Default Time Series Panel"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {}
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "up"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "gaugeAltEx": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "GaugeChart description text",
+                      "name": "Gauge Alt Ex"
+                    },
+                    "plugin": {
+                      "kind": "GaugeChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "decimalPlaces": 1,
+                          "unit": "percent-decimal"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "name": "Alert: Warning condition example",
+                              "value": 0.5
+                            },
+                            {
+                              "name": "Alert: Critical condition example",
+                              "value": 0.75
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_load15{instance=~'$instance',job='$job'}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "gaugeEx": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a gauge chart",
+                      "name": "Gauge Ex"
+                    },
+                    "plugin": {
+                      "kind": "GaugeChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "unit": "percent"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "value": 85
+                            },
+                            {
+                              "value": 95
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "(((count(count(node_cpu_seconds_total{job='$job',instance=~'$instance'}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode=\"idle\",job='$job',instance=~'$instance'}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job='$job',instance=~'$instance'}) by (cpu))"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "gaugeFormatTest": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Gauge Format Test"
+                    },
+                    "plugin": {
+                      "kind": "GaugeChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "unit": "bytes"
+                        },
+                        "max": 95000000,
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "value": 71000000
+                            },
+                            {
+                              "value": 82000000
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_time_seconds{job='$job',instance=~'$instance'} - node_boot_time_seconds{job='$job',instance=~'$instance'}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "gaugeRAM": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a stat chart",
+                      "name": "RAM Used"
+                    },
+                    "plugin": {
+                      "kind": "GaugeChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "unit": "percent"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "value": 85
+                            },
+                            {
+                              "value": 95
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "100 - ((node_memory_MemAvailable_bytes{job='$job',instance=~'$instance'} * 100) / node_memory_MemTotal_bytes{job='$job',instance=~'$instance'})"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "legendEx": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Legend Example"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "legend": {
+                          "position": "bottom"
+                        },
+                        "yAxis": {
+                          "format": {
+                            "shortValues": true,
+                            "unit": "bytes"
+                          },
+                          "show": true
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_memory_MemTotal_bytes{job='$job',instance=~'$instance'} - node_memory_MemFree_bytes{job='$job',instance=~'$instance'} - node_memory_Buffers_bytes{job='$job',instance=~'$instance'} - node_memory_Cached_bytes{job='$job',instance=~'$instance'}",
+                              "seriesNameFormat": "Node memory total"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_memory_Buffers_bytes{job='$job',instance=~'$instance'}",
+                              "seriesNameFormat": "Memory (buffers) - {{instance}}"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_memory_Cached_bytes{job='$job',instance=~'$instance'}",
+                              "seriesNameFormat": "Cached Bytes"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_memory_MemFree_bytes{job='$job',instance=~'$instance'}",
+                              "seriesNameFormat": "MemFree Bytes"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "seriesTest": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a line chart",
+                      "name": "~130 Series"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "yAxis": {
+                          "format": {
+                            "shortValues": true,
+                            "unit": "bytes"
+                          }
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "rate(caddy_http_response_duration_seconds_sum[$interval])"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "statLg": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a stat chart",
+                      "name": "Stat Lg"
+                    },
+                    "plugin": {
+                      "kind": "StatChart",
+                      "spec": {
+                        "calculation": "mean",
+                        "format": {
+                          "unit": "percent"
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "(((count(count(node_cpu_seconds_total{job='$job',instance=~'$instance'}) by (cpu))) - avg(sum by (mode)(rate(node_cpu_seconds_total{mode=\"idle\",job='$job',instance=~'$instance'}[$interval])))) * 100) / count(count(node_cpu_seconds_total{job='$job',instance=~'$instance'}) by (cpu))"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "statMd": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Stat Md"
+                    },
+                    "plugin": {
+                      "kind": "StatChart",
+                      "spec": {
+                        "calculation": "sum",
+                        "format": {
+                          "decimalPlaces": 2,
+                          "shortValues": true,
+                          "unit": "decimal"
+                        },
+                        "sparkline": {
+                          "color": "#e65013",
+                          "width": 1.5
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "avg(node_load15{job='node',instance=~'$instance'}) /  count(count(node_cpu_seconds_total{job='node',instance=~'$instance'}) by (cpu)) * 100"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "statRAM": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a stat chart",
+                      "name": "RAM Used"
+                    },
+                    "plugin": {
+                      "kind": "StatChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "unit": "percent"
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "100 - ((node_memory_MemAvailable_bytes{job='$job',instance=~'$instance'} * 100) / node_memory_MemTotal_bytes{job='$job',instance=~'$instance'})"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "statSm": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "name": "Stat Sm"
+                    },
+                    "plugin": {
+                      "kind": "StatChart",
+                      "spec": {
+                        "calculation": "mean",
+                        "format": {
+                          "decimalPlaces": 1,
+                          "shortValues": true,
+                          "unit": "decimal"
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_time_seconds{job='$job',instance=~'$instance'} - node_boot_time_seconds{job='$job',instance=~'$instance'}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "statTotalRAM": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "This is a stat chart",
+                      "name": "RAM Total"
+                    },
+                    "plugin": {
+                      "kind": "StatChart",
+                      "spec": {
+                        "calculation": "last-number",
+                        "format": {
+                          "decimalPlaces": 1,
+                          "unit": "bytes"
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_memory_MemTotal_bytes{job='$job',instance=~'$instance'}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "testNodeQuery": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "Description text",
+                      "name": "Test Query"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "legend": {
+                          "position": "right"
+                        },
+                        "yAxis": {
+                          "format": {
+                            "decimalPlaces": 2,
+                            "unit": "decimal"
+                          }
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_load15{instance=~\"(demo.do.prometheus.io:9100)\",job='$job'}",
+                              "seriesNameFormat": "Test {{job}} {{instance}}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "testQueryAlt": {
+                  "kind": "Panel",
+                  "spec": {
+                    "display": {
+                      "description": "Description text",
+                      "name": "Test Query Alt"
+                    },
+                    "plugin": {
+                      "kind": "TimeSeriesChart",
+                      "spec": {
+                        "legend": {
+                          "position": "right"
+                        },
+                        "thresholds": {
+                          "steps": [
+                            {
+                              "name": "Alert: Warning condition example",
+                              "value": 0.4
+                            },
+                            {
+                              "name": "Alert: Critical condition example",
+                              "value": 0.75
+                            }
+                          ]
+                        },
+                        "yAxis": {
+                          "format": {
+                            "decimalPlaces": 1,
+                            "unit": "percent-decimal"
+                          }
+                        }
+                      }
+                    },
+                    "queries": [
+                      {
+                        "kind": "TimeSeriesQuery",
+                        "spec": {
+                          "plugin": {
+                            "kind": "PrometheusTimeSeriesQuery",
+                            "spec": {
+                              "query": "node_load1{instance=~\"(demo.do.prometheus.io:9100)\",job='$job'}"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              "variables": [
+                {
+                  "kind": "ListVariable",
+                  "spec": {
+                    "allowAllValue": false,
+                    "allowMultiple": false,
+                    "name": "job",
+                    "plugin": {
+                      "kind": "PrometheusLabelValuesVariable",
+                      "spec": {
+                        "labelName": "job"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "ListVariable",
+                  "spec": {
+                    "allowAllValue": false,
+                    "allowMultiple": false,
+                    "name": "instance",
+                    "plugin": {
+                      "kind": "PrometheusLabelValuesVariable",
+                      "spec": {
+                        "labelName": "instance",
+                        "matchers": [
+                          "up{job=~\"$job\"}"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "ListVariable",
+                  "spec": {
+                    "name": "interval",
+                    "plugin": {
+                      "kind": "StaticListVariable",
+                      "spec": {
+                        "values": [
+                          "1m",
+                          "5m"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "TextVariable",
+                  "spec": {
+                    "constant": true,
+                    "name": "text",
+                    "value": "test"
+                  }
+                }
+              ]
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app.kubernetes.io/instance": "perses-sample"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "perses.dev/v1alpha2",
+          "kind": "PersesDatasource",
+          "metadata": {
+            "name": "perses-datasource-sample",
+            "namespace": "perses-dev"
+          },
+          "spec": {
+            "config": {
+              "default": true,
+              "display": {
+                "name": "Default Datasource"
+              },
+              "plugin": {
+                "kind": "PrometheusDatasource",
+                "spec": {
+                  "directUrl": "https://prometheus.demo.prometheus.io"
+                }
+              }
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app.kubernetes.io/instance": "perses-sample"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "perses.dev/v1alpha2",
+          "kind": "PersesGlobalDatasource",
+          "metadata": {
+            "name": "perses-globaldatasource-sample",
+            "namespace": "perses-dev"
+          },
+          "spec": {
+            "config": {
+              "default": true,
+              "display": {
+                "name": "Default Datasource"
+              },
+              "plugin": {
+                "kind": "PrometheusDatasource",
+                "spec": {
+                  "directUrl": "https://prometheus.demo.prometheus.io"
+                }
+              }
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app.kubernetes.io/instance": "perses-sample"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    containerImage: docker.io/persesdev/perses-operator:v0.1.0
+    createdAt: "2026-04-12T05:49:49Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/perses/perses-operator
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+  name: perses-operator.v0.3.2
+  namespace: operators
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Perses is the Schema for the perses API
+      displayName: Perses
+      kind: Perses
+      name: perses.perses.dev
+      specDescriptors:
+      - displayName: Affinity
+        path: affinity
+      - description: Args extra arguments to pass to perses
+        displayName: Args
+        path: args
+      - description: Perses client configuration
+        displayName: Client
+        path: client
+      - displayName: Config
+        path: config
+      - displayName: Container Port
+        path: containerPort
+      - description: Image specifies the container image that should be used for the
+          Perses deployment.
+        displayName: Image
+        path: image
+      - displayName: Liveness Probe
+        path: livenessProbe
+      - displayName: Metadata
+        path: metadata
+      - displayName: Node Selector
+        path: nodeSelector
+      - displayName: Readiness Probe
+        path: readinessProbe
+      - displayName: Replicas
+        path: replicas
+      - description: service specifies the service configuration for the perses instance
+        displayName: Service
+        path: service
+      - displayName: Annotations
+        path: service.annotations
+      - displayName: Name
+        path: service.name
+      - description: ServiceAccountName is the name of the service account to use
+          for the perses deployment or statefulset.
+        displayName: Service Account Name
+        path: serviceAccountName
+      - description: Storage configuration used by the StatefulSet
+        displayName: Storage
+        path: storage
+      - description: tls specifies the tls configuration for the perses instance
+        displayName: TLS
+        path: tls
+      - displayName: Tolerations
+        path: tolerations
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+    - kind: Perses
+      name: perses.perses.dev
+      version: v1alpha2
+    - description: A Perses Dashboard
+      displayName: Perses Dashboard
+      kind: PersesDashboard
+      name: persesdashboards.perses.dev
+      specDescriptors:
+      - displayName: Spec
+        path: spec
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+    - kind: PersesDashboard
+      name: persesdashboards.perses.dev
+      version: v1alpha2
+    - description: A Perses Datasource
+      displayName: Perses Datasource
+      kind: PersesDatasource
+      name: persesdatasources.perses.dev
+      specDescriptors:
+      - displayName: Spec
+        path: spec
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+      version: v1alpha1
+    - kind: PersesDatasource
+      name: persesdatasources.perses.dev
+      version: v1alpha2
+    - kind: PersesGlobalDatasource
+      name: persesglobaldatasources.perses.dev
+      version: v1alpha2
+  description: The Perses Operator deploys and manages Perses instances, dashboards
+    and datasources.
+  displayName: Perses Operator
+  icon:
+  - base64data: /9j/4AAQSkZJRgABAQEBLAEsAAD//gAIUGVyc2Vz/+ICsElDQ19QUk9GSUxFAAEBAAACoGxjbXMEQAAAbW50clJHQiBYWVogB+gADAACAAkAOgAsYWNzcEFQUEwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPbWAAEAAAAA0y1sY21zAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANZGVzYwAAASAAAABAY3BydAAAAWAAAAA2d3RwdAAAAZgAAAAUY2hhZAAAAawAAAAsclhZWgAAAdgAAAAUYlhZWgAAAewAAAAUZ1hZWgAAAgAAAAAUclRSQwAAAhQAAAAgZ1RSQwAAAhQAAAAgYlRSQwAAAhQAAAAgY2hybQAAAjQAAAAkZG1uZAAAAlgAAAAkZG1kZAAAAnwAAAAkbWx1YwAAAAAAAAABAAAADGVuVVMAAAAkAAAAHABHAEkATQBQACAAYgB1AGkAbAB0AC0AaQBuACAAcwBSAEcAQm1sdWMAAAAAAAAAAQAAAAxlblVTAAAAGgAAABwAUAB1AGIAbABpAGMAIABEAG8AbQBhAGkAbgAAWFlaIAAAAAAAAPbWAAEAAAAA0y1zZjMyAAAAAAABDEIAAAXe///zJQAAB5MAAP2Q///7of///aIAAAPcAADAblhZWiAAAAAAAABvoAAAOPUAAAOQWFlaIAAAAAAAACSfAAAPhAAAtsRYWVogAAAAAAAAYpcAALeHAAAY2XBhcmEAAAAAAAMAAAACZmYAAPKnAAANWQAAE9AAAApbY2hybQAAAAAAAwAAAACj1wAAVHwAAEzNAACZmgAAJmcAAA9cbWx1YwAAAAAAAAABAAAADGVuVVMAAAAIAAAAHABHAEkATQBQbWx1YwAAAAAAAAABAAAADGVuVVMAAAAIAAAAHABzAFIARwBC/9sAQwADAgIDAgIDAwMDBAMDBAUIBQUEBAUKBwcGCAwKDAwLCgsLDQ4SEA0OEQ4LCxAWEBETFBUVFQwPFxgWFBgSFBUU/9sAQwEDBAQFBAUJBQUJFA0LDRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQU/8IAEQgAUABQAwERAAIRAQMRAf/EABwAAQABBQEBAAAAAAAAAAAAAAAHAQQFBggCA//EABsBAQABBQEAAAAAAAAAAAAAAAADAQIEBgcF/9oADAMBAAIQAxAAAAGcbvfiSXdqKgC8pjz7Dze7QiF797gmbogAFyj64xuKZ154AHlXzSoAH0raBaUm4uy+8467KAAmCDR+jYuXChCcm/YyuWABINms7Bb5seybMABc0ilWzT/a0QHJ0eDsjoQAFaU7IxOF7I8sfOl2Bu9EAC5pFmWCBFF+4wtLvu9Wa90NFzIAACNrtphebfd9j1udI+egAAf/xAAjEAAABQMFAQEBAAAAAAAAAAAAAQMEBQIGFwcQExYgFREU/9oACAEBAAEFArnudO3UT1Kkv3JUmMlSYyVJjJUmGupjslWjpN6221BgnL4/nuh890Pnuh890PnughDvnKsHHnFxPk6iIclI5KRyUjkpHJT4drfzNX8g4k3HnT2XcUyexl+k/wBNaFXGMVhjFYYxWGMVhjFYW1aKNvnMzbWCbZMYjJjEZMYjJjEZMYhvqRHKq0V0qUbamNFjW8kR1HbjZVnB7KJ0q0ddix12LHXYsddix12LDeGYNVN74uZeGLtkuLTvJ6pJ+7xtaufoOxpsjtWx3LJ/7//EADQRAAAEAgcFBwMFAAAAAAAAAAABAgMEUwUREhaRodEGFBUxURAgIUFSYeETMHEiIzJCgf/aAAgBAwEBPwGiaJXSiz8aklzMFspBea1ZaC6kF61YloLqQXrViWgupBetWJaC6kF61YloHtk2DT+y4ZH71HoHmlsOKac5l27M0izDW4d46q/EhvUPMLEhvTEwsSG9MTCxIb0xMLEhvTEwsSDkfCtJtrcKr8ikIkoyKcfLkZ96qsWT6CyfQWT6CyfQWT6dxlH1XEt9TENCtQjZNMpqLvbTQTJw+9EVSiPHt5CG2rWhskvt2j61i9qJOfwL2ok5/AvaiTn8C9qJOfwL2ok5/ApWmnKTqRVZQXkIGj36Qc+myWhC6cVMTnoLpxUxOegunFTE56C6cVMTnoLpxUxOegc2WjEJNSVEfsFJNJ2Vc+3ZN5skuM/25/53jMiKsxSjrb8a641yM+1KjQdpJ+I4nHTlYmOJx05WJjicdOViY4nHTlYmOJx05WJhyOink2HHVGX5PubP0S1Hmp5/+KfL3HBaPkkKaoKGRDKfhk2TTmX2KDpdNGqUh0v0KyBbQ0ZNyVoKY2gZiGDh4Xxr5n9j/8QAIREAAgIBBAMBAQAAAAAAAAAAAAECEhMRIFFhAyEwMUD/2gAIAQIBAT8BSsY0Y0Y0Y0Y0Px8bIPT9LR5LR5LR5LR5LR5Lx5/hSS3TSXvYptGToydGToydGTocrC9lGUZRlGUZR7PH+/PVmrNWas1e2MbGOJKKS1XwjKpdEpa+vh//xAA4EAABAwECCAwFBQAAAAAAAAABAAIDBBE0EhMhMTJBkpMQIDM1QmFxkaHR0uEUMFFysSNDYoPw/9oACAEBAAY/Ao/08dPJostsHaVkgpbPtd6lyFJsO9S5Ck2HepchSbDvUuQpNh3qQ+JpYXx68Va0/kqKeI4UcjcJp4YKymjdNi24D2Nz9qu02wVdpdgq7S7BV2l2CrtLsFCOOkmc4/wKpqVxtdG3L28bKbFpDvWkO9aQ71pDvWkO/iTS2YWLYXWfWxOmqJDI8/XV2cb4Evc+ne0kNPRI4bDlCc+lqsTGf23stsV/Zu/dX9m791f2bv3V/Zu/dX9m7906XGY+pcLMOywAdSxtS45dFjc7ldajw81dajw81dajw81dajw81dajw801r4p4WnpkCwIOaQ5pFoI18NJUWEwBpZ9p/wB+OMABaTqVHDPyrWZQdXVwlr2h7TnDgubqbdBc3026C5vpt0FzfTboLm+m3QWMho4InjpNjAPEhpqQhk0gwi/PghX+VRUtZLj4pjghzs7Tq+RFLTua2piyWOzOCudv9rPNR1ldgsxWVsQNpt6/kf/EACUQAQABAQcEAwEAAAAAAAAAAAERACAhMUGBwfAQUWHxMHGR0f/aAAgBAQABPyHPQ8MBilS0PILWWLFixXyMyKayVA3bAXPWdAAMgmQGeLOlci2rg21cG2rg21cG2plRwEBqtxQeY1jJK9jxLawE+zac5znY9YVag/YmKUv83rvAZFokpcJCTJ2MvzqDBIQjU/8A8mgxnCvcqe5U9yp7lT3KjeU1fjQvoQdOCS3gtBBBBBI3GFT7IZo15kpA59QymiYSzf8Ado5ZEAxansB5zMaBDTqES4lB0riu1c92rnu1c92rnu1C8DRhrFhWB3kpYIHNZ/K94fyro9GA3uMRbtfgAiiblOU5JvSgCDMvK5Vu23ei67x8H//aAAwDAQACAAMAAAAQsSSokf8A/wBSSSRJJCTQkkiQnbbV221iTEknqTSSTSSwSSST7ySST//EACQRAQABAgUFAQEBAAAAAAAAAAERACExQVFhkRAgccHwgbHR/9oACAEDAQE/EMsfsSy4AWva+nBUIufPbq1atWl0rYbYCPN/FC1Do+TrDHOI2JiEXLKJtjnj9J7r5T3XynuvlPdfKe6bhjY8BK+AmgBiUeCxO8F9+4WArdVuq3Vbqt12SsxETpLE0GAOXdc3fujKEFLQbQ6o3HGJ6iqTGoEjkhPkhvrD+Fb7jTfcab7jTfcab7jQ4ZibpV1WDeCOaykrq2DVfRK6dyCCCCD8syKL4kDlKThAYRyTqskGg1YRbw/3uRJAVihSHXKf1v8AvUKgGCWT9r673X13uvrvdfXe6+u90+UsljhewxVQDBOJlLwEWMZxtf7H/agCKUFjMszCF5NITTvVMwNsUZxmOediNFQLCpPdgoIRsN1cLhB5t3//xAAlEQEAAgEBCAIDAAAAAAAAAAABABFhIDFBcYGR4fDxMFEQIaH/2gAIAQIBAT8QdUQo/bpAPsaBb9pidZidZidZidZidYhuRbV12SyWSyWaFouG0aqwb9AlJct7dpb27S3t2lvbtLe3aMrYFUTh+cpw/OU4fnKcPzlOH5yiJehAh36lAti2r+avbMzMzMzMzMzFXa6CTe6YP6/DosLUFNsM0Pg//8QAIxABAQABAwQDAAMAAAAAAAAAAREAICExQVFh8RBxkYGhwf/aAAgBAQABPxAKFcbYLYGBQA3XtFHO+dyg8sX8NJgwYMVkIBvBuiRTg2vc5x+iGFJUo8JwnRPm/heL4zuKEb9kqIqJJ0dO3bt2417IK8gA8qBhDnvkZNPQgeA1FiU8SM9Yz1jPWM9Yz1jBAIiPCfLlgUKpYfcmM+HSpr4gdA1P2OdLNeYFBsr8j8pAUR5HDYrNKqqM3sEp3dVatWrVlT5sBRbUWFVbNplZgEjyoyG21VApXcxr/nl6/L1+Xr8vX5fZUAfQ8fQ/WA+U0KoE5Ebfkh9nVu92SgagIGGqiwAOXCcMuqVR5+QILyEP2Vsn3iyulxQoUKf0ayuRR/Gg4JjwYCJBuRgtq0XVzTVB+QnADYEN4IkR1q9CNWDQFRU6bhlo5xEJ/kUP6YpQrbS0KAKpSqHAb6//2Q==
+    mediatype: image/jpeg
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - configmaps
+          - secrets
+          verbs:
+          - get
+          - patch
+          - update
+          - create
+          - delete
+          - list
+          - watch
+        - apiGroups:
+          - perses.dev
+          resources:
+          - perses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - perses.dev
+          resources:
+          - perses/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - perses/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdashboards/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdashboards/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdatasources
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdatasources/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesdatasources/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesglobaldatasources
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesglobaldatasources/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - perses.dev
+          resources:
+          - persesglobaldatasources/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: perses-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: perses-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: perses-operator
+          app.kubernetes.io/part-of: perses-operator
+          control-plane: controller-manager
+        name: perses-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8082
+                - --leader-elect
+                image: docker.io/persesdev/perses-operator:v0.3.2
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8082/
+                - --logtostderr=true
+                - --v=0
+                image: quay.io/brancz/kube-rbac-proxy:v0.21.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              serviceAccountName: perses-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: perses-operator-webhook-server-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: perses-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - monitoring
+  - logs
+  - traces
+  - metrics
+  - dashboards
+  links:
+  - name: Perses Operator
+    url: https://perses.dev
+  maintainers:
+  - email: gbernal@redhat.com
+    name: Gabriel Bernal
+  - email: augustin.husson@amadeus.com
+    name: Augustin Husson
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: Perses
+    url: perses.dev
+  replaces: perses-operator.v0.1.1
+  version: 0.3.2
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    conversionCRDs:
+    - perses.perses.dev
+    - persesdashboards.perses.dev
+    - persesglobaldatasources.perses.dev
+    deploymentName: perses-operator-controller-manager
+    generateName: cpersespersesdashboardspersesglobaldatasources.kb.io
+    sideEffects: None
+    targetPort: 9443
+    type: ConversionWebhook
+    webhookPath: /convert

--- a/bundle/manifests/perses.dev_perses.yaml
+++ b/bundle/manifests/perses.dev_perses.yaml
@@ -1,0 +1,8445 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.20.0
+  creationTimestamp: null
+  name: perses.perses.dev
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: perses-operator-webhook-service
+          namespace: perses-operator-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: perses.dev
+  names:
+    kind: Perses
+    listKind: PersesList
+    plural: perses
+    shortNames:
+    - per
+    singular: perses
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Perses is the Schema for the perses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PersesSpec defines the desired state of Perses
+            properties:
+              affinity:
+                description: Affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              args:
+                description: Args extra arguments to pass to perses
+                items:
+                  type: string
+                type: array
+              client:
+                description: Perses client configuration
+                properties:
+                  basicAuth:
+                    description: BasicAuth basic auth config for perses client
+                    properties:
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      password_path:
+                        description: Path to password
+                        minLength: 1
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: Username for basic auth
+                        minLength: 1
+                        type: string
+                    required:
+                    - password_path
+                    - type
+                    - username
+                    type: object
+                  kubernetesAuth:
+                    description: KubernetesAuth configuration for perses client
+                    properties:
+                      enable:
+                        description: Enable kubernetes auth for perses client
+                        type: boolean
+                    required:
+                    - enable
+                    type: object
+                  oauth:
+                    description: OAuth configuration for perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          AuthStyle optionally specifies how the endpoint wants the
+                          client ID & client secret sent. The zero value means to
+                          auto-detect.
+                        type: integer
+                      clientIDPath:
+                        description: Path to client id
+                        type: string
+                      clientSecretPath:
+                        description: Path to client secret
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: EndpointParams specifies additional parameters
+                          for requests to the token endpoint.
+                        type: object
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      scopes:
+                        description: Scope specifies optional requested permissions.
+                        items:
+                          type: string
+                        type: array
+                      tokenURL:
+                        description: |-
+                          TokenURL is the resource server's token endpoint
+                          URL. This is a constant specific to each server.
+                        minLength: 1
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                  tls:
+                    description: TLS the equivalent to the tls_config for perses client
+                    properties:
+                      caCert:
+                        description: CaCert to verify the perses certificate
+                        properties:
+                          certPath:
+                            description: Path to Certificate
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
+                            type: string
+                          namespace:
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
+                            type: string
+                          privateKeyPath:
+                            description: Path to Private key certificate
+                            type: string
+                          type:
+                            description: Type source type of secret
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                      enable:
+                        description: Enable TLS connection to perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify skip verify of perses certificate
+                        type: boolean
+                      userCert:
+                        description: UserCert client cert/key for mTLS
+                        properties:
+                          certPath:
+                            description: Path to Certificate
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
+                            type: string
+                          namespace:
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
+                            type: string
+                          privateKeyPath:
+                            description: Path to Private key certificate
+                            type: string
+                          type:
+                            description: Type source type of secret
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                    required:
+                    - enable
+                    type: object
+                type: object
+              config:
+                properties:
+                  api_prefix:
+                    description: |-
+                      Use it in case you want to prefix the API path.
+                      This can be useful if you are running Perses behind a reverse proxy.
+                      By default, the API is served with the path /api.
+                      With this config, it will be served with the path <api_prefix>/api
+                      Example: "/perses"
+                    type: string
+                  dashboard:
+                    description: Dashboard contains the configuration for the dashboard
+                      feature.
+                    properties:
+                      custom_lint_rules:
+                        items:
+                          properties:
+                            assertion:
+                              description: |-
+                                Assertion is a CEL expression that validates the extracted value.
+                                Refer to https://github.com/google/cel-spec/blob/master/doc/langdef.md for the syntax.
+                              type: string
+                            disable:
+                              description: Disable is a flag to disable the rule.
+                              type: boolean
+                            message:
+                              description: Message is displayed if the assertion fails.
+                              type: string
+                            name:
+                              description: Name of the rule
+                              type: string
+                            target:
+                              description: |-
+                                Target is a JSONPath expression to extract the relevant portion of the dashboard data.
+                                Refer to https://goessner.net/articles/JsonPath/ for the syntax.
+                              type: string
+                          required:
+                          - assertion
+                          - disable
+                          - message
+                          - name
+                          - target
+                          type: object
+                        type: array
+                    type: object
+                  database:
+                    description: Database contains the different configuration depending
+                      on the database you want to use
+                    properties:
+                      file:
+                        properties:
+                          case_sensitive:
+                            type: boolean
+                          extension:
+                            type: string
+                          folder:
+                            type: string
+                        required:
+                        - folder
+                        type: object
+                      sql:
+                        properties:
+                          addr:
+                            description: Network address (requires Net)
+                            type: string
+                          addr_file:
+                            description: AddrFile is a path to a file that contains
+                              the network address
+                            type: string
+                          allow_all_files:
+                            description: Allow all files to be used with LOAD DATA
+                              LOCAL INFILE
+                            type: boolean
+                          allow_cleartext_passwords:
+                            description: Allows the cleartext client side plugin
+                            type: boolean
+                          allow_fallback_to_plaintext:
+                            description: Allows fallback to unencrypted connection
+                              if server does not support TLS
+                            type: boolean
+                          allow_native_passwords:
+                            description: Allows the native password authentication
+                              method
+                            type: boolean
+                          allow_old_passwords:
+                            description: Allows the old insecure password method
+                            type: boolean
+                          case_sensitive:
+                            type: boolean
+                          check_conn_liveness:
+                            description: Check connections for liveness before using
+                              them
+                            type: boolean
+                          client_found_rows:
+                            description: Return number of matching rows instead of
+                              rows changed
+                            type: boolean
+                          collation:
+                            description: Connection collation
+                            type: string
+                          columns_with_alias:
+                            description: Prepend table alias to column names
+                            type: boolean
+                          db_name:
+                            description: Database name
+                            type: string
+                          interpolate_params:
+                            description: Interpolate placeholders into query string
+                            type: boolean
+                          loc:
+                            description: Location for time.Time values
+                            type: object
+                          max_allowed_packet:
+                            description: Max packet size allowed
+                            type: integer
+                          multi_statements:
+                            description: Allow multiple statements in one query
+                            type: boolean
+                          net:
+                            description: Network type
+                            type: string
+                          parse_time:
+                            description: Parse time values to time.Time
+                            type: boolean
+                          password:
+                            description: Password (requires User)
+                            type: string
+                          password_file:
+                            description: PasswordFile is a path to a file that contains
+                              a password
+                            type: string
+                          read_timeout:
+                            description: I/O read timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          reject_read_only:
+                            description: Reject read-only connections
+                            type: boolean
+                          server_pub_key:
+                            description: Server public key name
+                            type: string
+                          timeout:
+                            description: Dial timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          tls_config:
+                            description: TLS configuration
+                            properties:
+                              ca:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              caFile:
+                                type: string
+                              cert:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              certFile:
+                                type: string
+                              insecureSkipVerify:
+                                type: boolean
+                              key:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              keyFile:
+                                type: string
+                              maxVersion:
+                                type: string
+                              minVersion:
+                                type: string
+                              serverName:
+                                type: string
+                            type: object
+                          user:
+                            description: Username
+                            type: string
+                          user_file:
+                            description: UserFile is a path to a file that contains
+                              a username
+                            type: string
+                          write_timeout:
+                            description: I/O write timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                        required:
+                        - allow_all_files
+                        - allow_cleartext_passwords
+                        - allow_fallback_to_plaintext
+                        - allow_native_passwords
+                        - allow_old_passwords
+                        - case_sensitive
+                        - check_conn_liveness
+                        - client_found_rows
+                        - columns_with_alias
+                        - db_name
+                        - interpolate_params
+                        - max_allowed_packet
+                        - multi_statements
+                        - parse_time
+                        - read_timeout
+                        - reject_read_only
+                        - server_pub_key
+                        - timeout
+                        - write_timeout
+                        type: object
+                    type: object
+                  datasource:
+                    description: Datasource contains the configuration for the datasource.
+                    properties:
+                      disable_local:
+                        description: |-
+                          DisableLocal when used is preventing the possibility to add a datasource directly in the dashboard spec.
+                          It will also disable the associated proxy.
+                        type: boolean
+                      global:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the global datasource feature.
+                              It will also remove the associated proxy.
+                              Also, since the global variable depends on the global datasource, it will also disable the global variable feature.
+                            type: boolean
+                          discovery:
+                            description: |-
+                              Discovery is the configuration that helps to generate a list of global datasource based on the discovery chosen.
+                              Be careful: the data coming from the discovery will totally override what exists in the database.
+                              Note that this is an experimental feature. Behavior and config may change in the future.
+                            items:
+                              properties:
+                                http_sd:
+                                  description: |-
+                                    HTTP-based service discovery provides a more generic way to generate a set of global datasource and serves as an interface to plug in custom service discovery mechanisms.
+                                    It fetches an HTTP endpoint containing a list of zero or more global datasources.
+                                    The target must reply with an HTTP 200 response.
+                                    The HTTP header Content-Type must be application/json, and the body must be valid array of JSON.
+                                  properties:
+                                    authorization:
+                                      description: The HTTP authorization credentials
+                                        for the targets.
+                                      properties:
+                                        credentials:
+                                          type: string
+                                        credentialsFile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    basic_auth:
+                                      properties:
+                                        password:
+                                          type: string
+                                        passwordFile:
+                                          description: PasswordFile is a path to a
+                                            file that contains a password
+                                          type: string
+                                        username:
+                                          type: string
+                                      required:
+                                      - username
+                                      type: object
+                                    headers:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    k8s_auth:
+                                      properties:
+                                        kubeconfig:
+                                          type: string
+                                      type: object
+                                    native_auth:
+                                      properties:
+                                        login:
+                                          type: string
+                                        password:
+                                          type: string
+                                      required:
+                                      - login
+                                      - password
+                                      type: object
+                                    oauth:
+                                      properties:
+                                        authStyle:
+                                          description: |-
+                                            AuthStyle optionally specifies how the endpoint wants the
+                                            client ID & client secret sent. The zero value means to
+                                            auto-detect.
+                                          type: integer
+                                        clientID:
+                                          description: ClientID is the application's
+                                            ID.
+                                          type: string
+                                        clientSecret:
+                                          description: ClientSecret is the application's
+                                            secret.
+                                          type: string
+                                        clientSecretFile:
+                                          type: string
+                                        endpointParams:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: EndpointParams specifies additional
+                                            parameters for requests to the token endpoint.
+                                          type: object
+                                        scopes:
+                                          description: Scope specifies optional requested
+                                            permissions.
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenURL:
+                                          description: |-
+                                            TokenURL is the resource server's token endpoint
+                                            URL. This is a constant specific to each server.
+                                          type: string
+                                      required:
+                                      - authStyle
+                                      - clientID
+                                      - clientSecret
+                                      - clientSecretFile
+                                      - endpointParams
+                                      - scopes
+                                      - tokenURL
+                                      type: object
+                                    tls_config:
+                                      description: TLSConfig to use to connect to
+                                        the targets.
+                                      properties:
+                                        ca:
+                                          description: Text of the CA cert to use
+                                            for the targets.
+                                          type: string
+                                        caFile:
+                                          description: The CA cert to use for the
+                                            targets.
+                                          type: string
+                                        cert:
+                                          description: Text of the client cert file
+                                            for the targets.
+                                          type: string
+                                        certFile:
+                                          description: The client cert file for the
+                                            targets.
+                                          type: string
+                                        insecureSkipVerify:
+                                          description: Disable target certificate
+                                            validation.
+                                          type: boolean
+                                        key:
+                                          description: Text of the client key file
+                                            for the targets.
+                                          type: string
+                                        keyFile:
+                                          description: The client key file for the
+                                            targets.
+                                          type: string
+                                        maxVersion:
+                                          description: |-
+                                            Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                            If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                            See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                          type: string
+                                        minVersion:
+                                          description: |-
+                                            Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                            If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                            See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                          type: string
+                                        serverName:
+                                          description: Used to verify the hostname
+                                            for the targets.
+                                          type: string
+                                      type: object
+                                    url:
+                                      format: uri
+                                      type: string
+                                  required:
+                                  - url
+                                  type: object
+                                kubernetes_sd:
+                                  description: |-
+                                    Kubernetes SD configurations allow retrieving global datasource from Kubernetes' REST API
+                                    and always staying synchronized with the cluster state.
+                                  properties:
+                                    datasource_plugin_kind:
+                                      description: DatasourcePluginKind is the name
+                                        of the datasource plugin that should be filled
+                                        when creating datasources found.
+                                      type: string
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: The labels used to filter the list
+                                        of resource when contacting the Kubernetes
+                                        API.
+                                      type: object
+                                    namespace:
+                                      description: |-
+                                        Kubernetes namespace to constraint the query to only one namespace.
+                                        Leave empty if you are looking for datasource cross-namespace.
+                                      type: string
+                                    pod_configuration:
+                                      description: Configuration when you want to
+                                        discover the pods in Kubernetes
+                                      properties:
+                                        container_name:
+                                          description: Name of the container the target
+                                            address points to.
+                                          type: string
+                                        container_port_name:
+                                          description: Name of the container port.
+                                          type: string
+                                        container_port_number:
+                                          description: Number of the container port.
+                                          format: int32
+                                          type: integer
+                                        enable:
+                                          description: If set to true, Perses server
+                                            will discovery the pod
+                                          type: boolean
+                                      type: object
+                                    service_configuration:
+                                      description: Configuration when you want to
+                                        discover the services in Kubernetes
+                                      properties:
+                                        enable:
+                                          description: If set to true, Perses server
+                                            will discovery the service
+                                          type: boolean
+                                        port_name:
+                                          description: Name of the service port for
+                                            the target.
+                                          type: string
+                                        port_number:
+                                          description: Number of the service port
+                                            for the target.
+                                          format: int32
+                                          type: integer
+                                        service_type:
+                                          description: The type of the service.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - datasource_plugin_kind
+                                  - namespace
+                                  type: object
+                                name:
+                                  description: The name of the discovery config. It
+                                    is used for logging purposes only
+                                  type: string
+                                refresh_interval:
+                                  description: Refresh interval to re-query the endpoint.
+                                  format: duration
+                                  pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        required:
+                        - disable
+                        type: object
+                      project:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the project datasource feature.
+                              It will also remove the associated proxy.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                    required:
+                    - disable_local
+                    - global
+                    - project
+                    type: object
+                  ephemeral_dashboard:
+                    description: EphemeralDashboard contains the config about the
+                      ephemeral dashboard feature
+                    properties:
+                      cleanup_interval:
+                        description: The interval at which to trigger the cleanup
+                          of ephemeral dashboards, based on their TTLs.
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                      enable:
+                        description: When true user will be able to use the ephemeral
+                          dashboard at project level.
+                        type: boolean
+                    required:
+                    - cleanup_interval
+                    - enable
+                    type: object
+                  ephemeral_dashboards_cleanup_interval:
+                    description: |-
+                      EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
+                      DEPRECATED.
+                      Please use the config EphemeralDashboard instead.
+                    format: duration
+                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                    type: string
+                  frontend:
+                    description: Frontend contains any config that will be used by
+                      the frontend itself.
+                    properties:
+                      banner:
+                        description: BannerInfo contains the content to be display
+                          in a banner at the top of each page along with the severity
+                          of the information
+                        properties:
+                          message:
+                            type: string
+                          severity:
+                            type: string
+                        required:
+                        - message
+                        - severity
+                        type: object
+                      disable:
+                        description: When it is true, Perses won't serve the frontend
+                          anymore, and any other config set here will be ignored
+                        type: boolean
+                      explorer:
+                        description: |-
+                          Explorer is activating the different kind of explorer supported.
+                          Be sure you have installed an associated plugin for each explorer type.
+                        properties:
+                          enable:
+                            type: boolean
+                        required:
+                        - enable
+                        type: object
+                      important_dashboards:
+                        description: ImportantDashboards contains important dashboard
+                          selectors
+                        items:
+                          properties:
+                            dashboard:
+                              description: Dashboard is the name of the dashboard
+                                (dashboard.metadata.name)
+                              type: string
+                            project:
+                              description: Project is the name of the project (dashboard.metadata.project)
+                              type: string
+                          required:
+                          - dashboard
+                          - project
+                          type: object
+                        type: array
+                      information:
+                        description: Information contains markdown content to be display
+                          on the home page
+                        type: string
+                      time_range:
+                        description: TimeRange contains the time range configuration
+                          for the dropdown
+                        properties:
+                          disable_custom:
+                            type: boolean
+                          disable_zoom:
+                            type: boolean
+                          options:
+                            items:
+                              description: |-
+                                DurationString is a string that represents a duration, such as "1h", "30m", "15s", etc.
+                                It is used to unmarshal a duration string from JSON or YAML, and validate that it is a valid duration string.
+
+                                Not converting the duration string into a time.Duration type allows us to avoid the issue of changing the initial input with an alias.
+                                This is something that happens when we use Duration type, because when the duration is unmarshalled then marshaled again, the input can be changed with an equivalent duration.
+                                For example "14d" will be changed to "2w".
+
+                                So, use DurationString instead of Duration when you want to preserve the original input string.
+                                If, for any reason, you need to convert the DurationString to a time.Duration, you can use the ParseDuration function.
+                              format: duration
+                              pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                              type: string
+                            type: array
+                        type: object
+                    required:
+                    - disable
+                    - explorer
+                    type: object
+                  plugin:
+                    description: Plugin contains the config for runtime plugins.
+                    properties:
+                      archive_path:
+                        description: |-
+                          ArchivePath is the path to the directory containing the archived plugins
+                          When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
+                          DEPRECATED: This attribute is deprecated and will be removed in a future version. It is still supported for backward compatibility, but it is recommended to use the `archive_paths` attribute instead.
+                        type: string
+                      archive_paths:
+                        description: |-
+                          ArchivePaths is the list of paths to the directories containing the archived plugins. It allows to specify multiple directories for the archived plugins.
+                          When Perses is starting, it will extract any archive found in the folders specified in this attribute in the folder specified in the `path` attribute.
+                        items:
+                          type: string
+                        type: array
+                      enable_dev:
+                        description: DevEnvironment is the configuration to use when
+                          developing a plugin
+                        type: boolean
+                      path:
+                        description: Path is the path to the directory containing
+                          the runtime plugins
+                        type: string
+                    required:
+                    - enable_dev
+                    type: object
+                  provisioning:
+                    description: Provisioning contains the provisioning config that
+                      can be used if you want to provide default resources.
+                    properties:
+                      folders:
+                        items:
+                          type: string
+                        type: array
+                      interval:
+                        description: Interval is the refresh frequency
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                    type: object
+                  schemas:
+                    description: |-
+                      Schemas contain the configuration to get access to the CUE schemas
+                      DEPRECATED.
+                      Please remove it from your config.
+                    properties:
+                      datasources_path:
+                        type: string
+                      interval:
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                      panels_path:
+                        type: string
+                      queries_path:
+                        type: string
+                      variables_path:
+                        type: string
+                    type: object
+                  security:
+                    description: Security contains any configuration that changes
+                      the API behavior like the endpoints exposed or if the permissions
+                      are activated.
+                    properties:
+                      authentication:
+                        description: Authentication contains configuration regarding
+                          management of access/refresh token
+                        properties:
+                          access_token_ttl:
+                            description: AccessTokenTTL is the time to live of the
+                              access token. By default, it is 15 minutes.
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          disable_sign_up:
+                            description: |-
+                              DisableSignUp deactivates the Sign-up page in the UI.
+                              It also disables the endpoint that gives the possibility to create a user.
+                            type: boolean
+                          providers:
+                            description: Providers configure the different authentication
+                              providers
+                            properties:
+                              enable_native:
+                                type: boolean
+                              kubernetes:
+                                properties:
+                                  enable:
+                                    type: boolean
+                                required:
+                                - enable
+                                type: object
+                              oauth:
+                                items:
+                                  properties:
+                                    auth_url:
+                                      format: uri
+                                      type: string
+                                    client_credentials:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    client_id:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
+                                      type: string
+                                    custom_login_property:
+                                      type: string
+                                    device_auth_url:
+                                      format: uri
+                                      type: string
+                                    device_code:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    http:
+                                      properties:
+                                        timeout:
+                                          format: duration
+                                          pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                          type: string
+                                        tls_config:
+                                          properties:
+                                            ca:
+                                              description: Text of the CA cert to
+                                                use for the targets.
+                                              type: string
+                                            caFile:
+                                              description: The CA cert to use for
+                                                the targets.
+                                              type: string
+                                            cert:
+                                              description: Text of the client cert
+                                                file for the targets.
+                                              type: string
+                                            certFile:
+                                              description: The client cert file for
+                                                the targets.
+                                              type: string
+                                            insecureSkipVerify:
+                                              description: Disable target certificate
+                                                validation.
+                                              type: boolean
+                                            key:
+                                              description: Text of the client key
+                                                file for the targets.
+                                              type: string
+                                            keyFile:
+                                              description: The client key file for
+                                                the targets.
+                                              type: string
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                                See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                                See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            serverName:
+                                              description: Used to verify the hostname
+                                                for the targets.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - timeout
+                                      - tls_config
+                                      type: object
+                                    name:
+                                      type: string
+                                    redirect_uri:
+                                      format: uri
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    slug_id:
+                                      type: string
+                                    token_url:
+                                      format: uri
+                                      type: string
+                                    user_infos_url:
+                                      format: uri
+                                      type: string
+                                  required:
+                                  - auth_url
+                                  - client_id
+                                  - device_auth_url
+                                  - http
+                                  - name
+                                  - slug_id
+                                  - token_url
+                                  - user_infos_url
+                                  type: object
+                                type: array
+                              oidc:
+                                items:
+                                  properties:
+                                    client_credentials:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    client_id:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
+                                      type: string
+                                    device_code:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    disable_pkce:
+                                      type: boolean
+                                    discovery_url:
+                                      format: uri
+                                      type: string
+                                    http:
+                                      properties:
+                                        timeout:
+                                          format: duration
+                                          pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                          type: string
+                                        tls_config:
+                                          properties:
+                                            ca:
+                                              description: Text of the CA cert to
+                                                use for the targets.
+                                              type: string
+                                            caFile:
+                                              description: The CA cert to use for
+                                                the targets.
+                                              type: string
+                                            cert:
+                                              description: Text of the client cert
+                                                file for the targets.
+                                              type: string
+                                            certFile:
+                                              description: The client cert file for
+                                                the targets.
+                                              type: string
+                                            insecureSkipVerify:
+                                              description: Disable target certificate
+                                                validation.
+                                              type: boolean
+                                            key:
+                                              description: Text of the client key
+                                                file for the targets.
+                                              type: string
+                                            keyFile:
+                                              description: The client key file for
+                                                the targets.
+                                              type: string
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                                See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                                See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            serverName:
+                                              description: Used to verify the hostname
+                                                for the targets.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - timeout
+                                      - tls_config
+                                      type: object
+                                    issuer:
+                                      format: uri
+                                      type: string
+                                    logout:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        logout_redirect_param_name:
+                                          type: string
+                                      required:
+                                      - enabled
+                                      type: object
+                                    name:
+                                      type: string
+                                    redirect_uri:
+                                      format: uri
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    slug_id:
+                                      type: string
+                                    url_params:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  required:
+                                  - client_id
+                                  - disable_pkce
+                                  - http
+                                  - issuer
+                                  - logout
+                                  - name
+                                  - slug_id
+                                  type: object
+                                type: array
+                            required:
+                            - enable_native
+                            type: object
+                          refresh_token_ttl:
+                            description: |-
+                              RefreshTokenTTL is the time to live of the refresh token.
+                              The refresh token is used to get a new access token when it is expired.
+                              By default, it is 24 hours.
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                        required:
+                        - disable_sign_up
+                        - providers
+                        type: object
+                      authorization:
+                        description: Authorization contains all configs around rbac
+                          (permissions and roles)
+                        properties:
+                          check_latest_update_interval:
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.CheckLatestUpdateInterval
+                              instead.'
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          guest_permissions:
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.GuestPermissions
+                              instead.'
+                            items:
+                              properties:
+                                actions:
+                                  description: Actions of the permission (read, create,
+                                    update, delete, ...)
+                                  items:
+                                    type: string
+                                  type: array
+                                scopes:
+                                  description: |-
+                                    The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                    With Role, you can't target global kinds
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - actions
+                              - scopes
+                              type: object
+                            type: array
+                          provider:
+                            properties:
+                              kubernetes:
+                                properties:
+                                  authenticator_ttl:
+                                    description: 'time an authenticator response will
+                                      be cached for. Default: 2m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_allow_ttl:
+                                    description: 'time an authorizer allow response
+                                      will be cached for. Default: 5m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_deny_ttl:
+                                    description: 'time an authorizer denied will be
+                                      cached for. Default: 30s'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  burst:
+                                    description: 'burst QPS the k8s client will use
+                                      with the apiserver. Default: 1000 qps'
+                                    type: integer
+                                  enable:
+                                    type: boolean
+                                  kubeconfig:
+                                    description: |-
+                                      The active user in the kubeconfig should have "create" permissions for the `TokenReview` and
+                                      `SubjectAccessReview` resources. If the kubeconfig parameter isn't available the pods service
+                                      account token will be used
+                                    type: string
+                                  qps:
+                                    description: 'query per second (QPS) the k8s client
+                                      will use with the apiserver. Default: 500 qps'
+                                    type: integer
+                                type: object
+                              native:
+                                properties:
+                                  check_latest_update_interval:
+                                    description: CheckLatestUpdateInterval that checks
+                                      if the RBAC cache needs to be refreshed with
+                                      db content. Only for SQL database setup.
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  enable:
+                                    type: boolean
+                                  guest_permissions:
+                                    description: Default permissions for guest users
+                                      (logged-in users)
+                                    items:
+                                      properties:
+                                        actions:
+                                          description: Actions of the permission (read,
+                                            create, update, delete, ...)
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopes:
+                                          description: |-
+                                            The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                            With Role, you can't target global kinds
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - actions
+                                      - scopes
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                      cookie:
+                        description: Cookie configuration
+                        properties:
+                          same_site:
+                            description: |-
+                              Set the SameSite cookie attribute and prevents the browser from sending the cookie along with cross-site requests.
+                              The main goal is to mitigate the risk of cross-origin information leakage.
+                              This setting also provides some protection against cross-site request forgery attacks (CSRF)
+                            type: integer
+                          secure:
+                            description: Set to true if you host Perses behind HTTPS.
+                              Default is false
+                            type: boolean
+                        required:
+                        - secure
+                        type: object
+                      cors:
+                        description: Configuration for the CORS middleware.
+                        properties:
+                          allow_credentials:
+                            type: boolean
+                          allow_headers:
+                            items:
+                              type: string
+                            type: array
+                          allow_methods:
+                            items:
+                              type: string
+                            type: array
+                          allow_origins:
+                            items:
+                              type: string
+                            type: array
+                          enable:
+                            type: boolean
+                          expose_headers:
+                            items:
+                              type: string
+                            type: array
+                          max_age:
+                            type: integer
+                        required:
+                        - enable
+                        type: object
+                      enable_auth:
+                        description: |-
+                          When it is true, the authentication and authorization config are considered.
+                          And you will need a valid JWT token to contact most of the endpoints exposed by the API
+                        type: boolean
+                      encryption_key:
+                        description: |-
+                          EncryptionKey is the secret key used to encrypt and decrypt sensitive data
+                          stored in the database such as the password of the basic auth for a datasource.
+                          Note that if it is not provided, it will use a default value.
+                          On a production instance, you should set this key.
+                          Also note the key size must be exactly 32 bytes long as we are using AES-256 to encrypt the data.
+                        type: string
+                      encryption_key_file:
+                        description: EncryptionKeyFile is the path to file containing
+                          the secret key
+                        type: string
+                      readonly:
+                        description: Readonly will deactivate any HTTP POST, PUT,
+                          DELETE endpoint
+                        type: boolean
+                    required:
+                    - cookie
+                    - enable_auth
+                    - readonly
+                    type: object
+                  variable:
+                    description: Variable contains the configuration for the variable.
+                    properties:
+                      disable_local:
+                        description: DisableLocal when used is preventing the possibility
+                          to add a variable directly in the dashboard spec.
+                        type: boolean
+                      global:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the global variable feature.
+                              Note that if the global datasource is disabled, the global variable will also be disabled.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                      project:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the project variable feature.
+                              Note that if the global datasource and the project datasource are disabled,
+                              then the project variable will also be disabled.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                    required:
+                    - disable_local
+                    - global
+                    - project
+                    type: object
+                type: object
+              containerPort:
+                default: 8080
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+              image:
+                description: Image specifies the container image that should be used
+                  for the Perses deployment.
+                type: string
+              livenessProbe:
+                description: |-
+                  Probe describes a health check to be performed against a container to determine whether it is
+                  alive or ready to receive traffic.
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              metadata:
+                description: Metadata to add to deployed pods
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              readinessProbe:
+                description: |-
+                  Probe describes a health check to be performed against a container to determine whether it is
+                  alive or ready to receive traffic.
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              service:
+                description: service specifies the service configuration for the perses
+                  instance
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                type: object
+              serviceAccountName:
+                description: ServiceAccountName is the name of the service account
+                  to use for the perses deployment or statefulset.
+                type: string
+              storage:
+                default:
+                  size: 1Gi
+                description: Storage configuration used by the StatefulSet
+                properties:
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Size of the storage.
+                      cannot be decreased.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClass:
+                    description: |-
+                      StorageClass to use for PVCs.
+                      If not specified, will use the default storage class
+                    type: string
+                type: object
+              tls:
+                description: tls specifies the tls configuration for the perses instance
+                properties:
+                  caCert:
+                    description: CaCert to verify the perses certificate
+                    properties:
+                      certPath:
+                        description: Path to Certificate
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      privateKeyPath:
+                        description: Path to Private key certificate
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - certPath
+                    - type
+                    type: object
+                  enable:
+                    description: Enable TLS connection to perses
+                    type: boolean
+                  insecureSkipVerify:
+                    description: InsecureSkipVerify skip verify of perses certificate
+                    type: boolean
+                  userCert:
+                    description: UserCert client cert/key for mTLS
+                    properties:
+                      certPath:
+                        description: Path to Certificate
+                        minLength: 1
+                        type: string
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      privateKeyPath:
+                        description: Path to Private key certificate
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - certPath
+                    - type
+                    type: object
+                required:
+                - enable
+                type: object
+              tolerations:
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: PersesStatus defines the observed state of Perses
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: Perses is the Schema for the perses API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the Perses resource
+            properties:
+              affinity:
+                description: affinity specifies the pod's scheduling constraints
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              args:
+                description: args are extra command-line arguments to pass to the
+                  Perses server
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              client:
+                description: client specifies the Perses client configuration
+                properties:
+                  basicAuth:
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
+                    properties:
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
+                        type: string
+                    required:
+                    - passwordPath
+                    - type
+                    - username
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  kubernetesAuth:
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
+                    properties:
+                      enable:
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
+                        type: boolean
+                    type: object
+                  oauth:
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
+                        type: integer
+                      clientIDPath:
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
+                        type: string
+                      clientSecretPath:
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
+                        type: object
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tokenURL:
+                        description: |-
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  tls:
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
+                    properties:
+                      caCert:
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                      enable:
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
+                        type: boolean
+                      userCert:
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                    type: object
+                type: object
+              config:
+                description: config specifies the Perses server configuration
+                properties:
+                  api_prefix:
+                    description: |-
+                      Use it in case you want to prefix the API path.
+                      This can be useful if you are running Perses behind a reverse proxy.
+                      By default, the API is served with the path /api.
+                      With this config, it will be served with the path <api_prefix>/api
+                      Example: "/perses"
+                    type: string
+                  dashboard:
+                    description: Dashboard contains the configuration for the dashboard
+                      feature.
+                    properties:
+                      custom_lint_rules:
+                        items:
+                          properties:
+                            assertion:
+                              description: |-
+                                Assertion is a CEL expression that validates the extracted value.
+                                Refer to https://github.com/google/cel-spec/blob/master/doc/langdef.md for the syntax.
+                              type: string
+                            disable:
+                              description: Disable is a flag to disable the rule.
+                              type: boolean
+                            message:
+                              description: Message is displayed if the assertion fails.
+                              type: string
+                            name:
+                              description: Name of the rule
+                              type: string
+                            target:
+                              description: |-
+                                Target is a JSONPath expression to extract the relevant portion of the dashboard data.
+                                Refer to https://goessner.net/articles/JsonPath/ for the syntax.
+                              type: string
+                          required:
+                          - assertion
+                          - disable
+                          - message
+                          - name
+                          - target
+                          type: object
+                        type: array
+                    type: object
+                  database:
+                    description: Database contains the different configuration depending
+                      on the database you want to use
+                    properties:
+                      file:
+                        properties:
+                          case_sensitive:
+                            type: boolean
+                          extension:
+                            type: string
+                          folder:
+                            type: string
+                        required:
+                        - folder
+                        type: object
+                      sql:
+                        properties:
+                          addr:
+                            description: Network address (requires Net)
+                            type: string
+                          addr_file:
+                            description: AddrFile is a path to a file that contains
+                              the network address
+                            type: string
+                          allow_all_files:
+                            description: Allow all files to be used with LOAD DATA
+                              LOCAL INFILE
+                            type: boolean
+                          allow_cleartext_passwords:
+                            description: Allows the cleartext client side plugin
+                            type: boolean
+                          allow_fallback_to_plaintext:
+                            description: Allows fallback to unencrypted connection
+                              if server does not support TLS
+                            type: boolean
+                          allow_native_passwords:
+                            description: Allows the native password authentication
+                              method
+                            type: boolean
+                          allow_old_passwords:
+                            description: Allows the old insecure password method
+                            type: boolean
+                          case_sensitive:
+                            type: boolean
+                          check_conn_liveness:
+                            description: Check connections for liveness before using
+                              them
+                            type: boolean
+                          client_found_rows:
+                            description: Return number of matching rows instead of
+                              rows changed
+                            type: boolean
+                          collation:
+                            description: Connection collation
+                            type: string
+                          columns_with_alias:
+                            description: Prepend table alias to column names
+                            type: boolean
+                          db_name:
+                            description: Database name
+                            type: string
+                          interpolate_params:
+                            description: Interpolate placeholders into query string
+                            type: boolean
+                          loc:
+                            description: Location for time.Time values
+                            type: object
+                          max_allowed_packet:
+                            description: Max packet size allowed
+                            type: integer
+                          multi_statements:
+                            description: Allow multiple statements in one query
+                            type: boolean
+                          net:
+                            description: Network type
+                            type: string
+                          parse_time:
+                            description: Parse time values to time.Time
+                            type: boolean
+                          password:
+                            description: Password (requires User)
+                            type: string
+                          password_file:
+                            description: PasswordFile is a path to a file that contains
+                              a password
+                            type: string
+                          read_timeout:
+                            description: I/O read timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          reject_read_only:
+                            description: Reject read-only connections
+                            type: boolean
+                          server_pub_key:
+                            description: Server public key name
+                            type: string
+                          timeout:
+                            description: Dial timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          tls_config:
+                            description: TLS configuration
+                            properties:
+                              ca:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              caFile:
+                                type: string
+                              cert:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              certFile:
+                                type: string
+                              insecureSkipVerify:
+                                type: boolean
+                              key:
+                                description: Hidden special type for storing secrets.
+                                type: string
+                              keyFile:
+                                type: string
+                              maxVersion:
+                                type: string
+                              minVersion:
+                                type: string
+                              serverName:
+                                type: string
+                            type: object
+                          user:
+                            description: Username
+                            type: string
+                          user_file:
+                            description: UserFile is a path to a file that contains
+                              a username
+                            type: string
+                          write_timeout:
+                            description: I/O write timeout
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                        required:
+                        - allow_all_files
+                        - allow_cleartext_passwords
+                        - allow_fallback_to_plaintext
+                        - allow_native_passwords
+                        - allow_old_passwords
+                        - case_sensitive
+                        - check_conn_liveness
+                        - client_found_rows
+                        - columns_with_alias
+                        - db_name
+                        - interpolate_params
+                        - max_allowed_packet
+                        - multi_statements
+                        - parse_time
+                        - read_timeout
+                        - reject_read_only
+                        - server_pub_key
+                        - timeout
+                        - write_timeout
+                        type: object
+                    type: object
+                  datasource:
+                    description: Datasource contains the configuration for the datasource.
+                    properties:
+                      disable_local:
+                        description: |-
+                          DisableLocal when used is preventing the possibility to add a datasource directly in the dashboard spec.
+                          It will also disable the associated proxy.
+                        type: boolean
+                      global:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the global datasource feature.
+                              It will also remove the associated proxy.
+                              Also, since the global variable depends on the global datasource, it will also disable the global variable feature.
+                            type: boolean
+                          discovery:
+                            description: |-
+                              Discovery is the configuration that helps to generate a list of global datasource based on the discovery chosen.
+                              Be careful: the data coming from the discovery will totally override what exists in the database.
+                              Note that this is an experimental feature. Behavior and config may change in the future.
+                            items:
+                              properties:
+                                http_sd:
+                                  description: |-
+                                    HTTP-based service discovery provides a more generic way to generate a set of global datasource and serves as an interface to plug in custom service discovery mechanisms.
+                                    It fetches an HTTP endpoint containing a list of zero or more global datasources.
+                                    The target must reply with an HTTP 200 response.
+                                    The HTTP header Content-Type must be application/json, and the body must be valid array of JSON.
+                                  properties:
+                                    authorization:
+                                      description: The HTTP authorization credentials
+                                        for the targets.
+                                      properties:
+                                        credentials:
+                                          type: string
+                                        credentialsFile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    basic_auth:
+                                      properties:
+                                        password:
+                                          type: string
+                                        passwordFile:
+                                          description: PasswordFile is a path to a
+                                            file that contains a password
+                                          type: string
+                                        username:
+                                          type: string
+                                      required:
+                                      - username
+                                      type: object
+                                    headers:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    k8s_auth:
+                                      properties:
+                                        kubeconfig:
+                                          type: string
+                                      type: object
+                                    native_auth:
+                                      properties:
+                                        login:
+                                          type: string
+                                        password:
+                                          type: string
+                                      required:
+                                      - login
+                                      - password
+                                      type: object
+                                    oauth:
+                                      properties:
+                                        authStyle:
+                                          description: |-
+                                            AuthStyle optionally specifies how the endpoint wants the
+                                            client ID & client secret sent. The zero value means to
+                                            auto-detect.
+                                          type: integer
+                                        clientID:
+                                          description: ClientID is the application's
+                                            ID.
+                                          type: string
+                                        clientSecret:
+                                          description: ClientSecret is the application's
+                                            secret.
+                                          type: string
+                                        clientSecretFile:
+                                          type: string
+                                        endpointParams:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: EndpointParams specifies additional
+                                            parameters for requests to the token endpoint.
+                                          type: object
+                                        scopes:
+                                          description: Scope specifies optional requested
+                                            permissions.
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenURL:
+                                          description: |-
+                                            TokenURL is the resource server's token endpoint
+                                            URL. This is a constant specific to each server.
+                                          type: string
+                                      required:
+                                      - authStyle
+                                      - clientID
+                                      - clientSecret
+                                      - clientSecretFile
+                                      - endpointParams
+                                      - scopes
+                                      - tokenURL
+                                      type: object
+                                    tls_config:
+                                      description: TLSConfig to use to connect to
+                                        the targets.
+                                      properties:
+                                        ca:
+                                          description: Text of the CA cert to use
+                                            for the targets.
+                                          type: string
+                                        caFile:
+                                          description: The CA cert to use for the
+                                            targets.
+                                          type: string
+                                        cert:
+                                          description: Text of the client cert file
+                                            for the targets.
+                                          type: string
+                                        certFile:
+                                          description: The client cert file for the
+                                            targets.
+                                          type: string
+                                        insecureSkipVerify:
+                                          description: Disable target certificate
+                                            validation.
+                                          type: boolean
+                                        key:
+                                          description: Text of the client key file
+                                            for the targets.
+                                          type: string
+                                        keyFile:
+                                          description: The client key file for the
+                                            targets.
+                                          type: string
+                                        maxVersion:
+                                          description: |-
+                                            Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                            If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                            See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                          type: string
+                                        minVersion:
+                                          description: |-
+                                            Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                            If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                            See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                          type: string
+                                        serverName:
+                                          description: Used to verify the hostname
+                                            for the targets.
+                                          type: string
+                                      type: object
+                                    url:
+                                      format: uri
+                                      type: string
+                                  required:
+                                  - url
+                                  type: object
+                                kubernetes_sd:
+                                  description: |-
+                                    Kubernetes SD configurations allow retrieving global datasource from Kubernetes' REST API
+                                    and always staying synchronized with the cluster state.
+                                  properties:
+                                    datasource_plugin_kind:
+                                      description: DatasourcePluginKind is the name
+                                        of the datasource plugin that should be filled
+                                        when creating datasources found.
+                                      type: string
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: The labels used to filter the list
+                                        of resource when contacting the Kubernetes
+                                        API.
+                                      type: object
+                                    namespace:
+                                      description: |-
+                                        Kubernetes namespace to constraint the query to only one namespace.
+                                        Leave empty if you are looking for datasource cross-namespace.
+                                      type: string
+                                    pod_configuration:
+                                      description: Configuration when you want to
+                                        discover the pods in Kubernetes
+                                      properties:
+                                        container_name:
+                                          description: Name of the container the target
+                                            address points to.
+                                          type: string
+                                        container_port_name:
+                                          description: Name of the container port.
+                                          type: string
+                                        container_port_number:
+                                          description: Number of the container port.
+                                          format: int32
+                                          type: integer
+                                        enable:
+                                          description: If set to true, Perses server
+                                            will discovery the pod
+                                          type: boolean
+                                      type: object
+                                    service_configuration:
+                                      description: Configuration when you want to
+                                        discover the services in Kubernetes
+                                      properties:
+                                        enable:
+                                          description: If set to true, Perses server
+                                            will discovery the service
+                                          type: boolean
+                                        port_name:
+                                          description: Name of the service port for
+                                            the target.
+                                          type: string
+                                        port_number:
+                                          description: Number of the service port
+                                            for the target.
+                                          format: int32
+                                          type: integer
+                                        service_type:
+                                          description: The type of the service.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - datasource_plugin_kind
+                                  - namespace
+                                  type: object
+                                name:
+                                  description: The name of the discovery config. It
+                                    is used for logging purposes only
+                                  type: string
+                                refresh_interval:
+                                  description: Refresh interval to re-query the endpoint.
+                                  format: duration
+                                  pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                        required:
+                        - disable
+                        type: object
+                      project:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the project datasource feature.
+                              It will also remove the associated proxy.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                    required:
+                    - disable_local
+                    - global
+                    - project
+                    type: object
+                  ephemeral_dashboard:
+                    description: EphemeralDashboard contains the config about the
+                      ephemeral dashboard feature
+                    properties:
+                      cleanup_interval:
+                        description: The interval at which to trigger the cleanup
+                          of ephemeral dashboards, based on their TTLs.
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                      enable:
+                        description: When true user will be able to use the ephemeral
+                          dashboard at project level.
+                        type: boolean
+                    required:
+                    - cleanup_interval
+                    - enable
+                    type: object
+                  ephemeral_dashboards_cleanup_interval:
+                    description: |-
+                      EphemeralDashboardsCleanupInterval is the interval at which the ephemeral dashboards are cleaned up
+                      DEPRECATED.
+                      Please use the config EphemeralDashboard instead.
+                    format: duration
+                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                    type: string
+                  frontend:
+                    description: Frontend contains any config that will be used by
+                      the frontend itself.
+                    properties:
+                      banner:
+                        description: BannerInfo contains the content to be display
+                          in a banner at the top of each page along with the severity
+                          of the information
+                        properties:
+                          message:
+                            type: string
+                          severity:
+                            type: string
+                        required:
+                        - message
+                        - severity
+                        type: object
+                      disable:
+                        description: When it is true, Perses won't serve the frontend
+                          anymore, and any other config set here will be ignored
+                        type: boolean
+                      explorer:
+                        description: |-
+                          Explorer is activating the different kind of explorer supported.
+                          Be sure you have installed an associated plugin for each explorer type.
+                        properties:
+                          enable:
+                            type: boolean
+                        required:
+                        - enable
+                        type: object
+                      important_dashboards:
+                        description: ImportantDashboards contains important dashboard
+                          selectors
+                        items:
+                          properties:
+                            dashboard:
+                              description: Dashboard is the name of the dashboard
+                                (dashboard.metadata.name)
+                              type: string
+                            project:
+                              description: Project is the name of the project (dashboard.metadata.project)
+                              type: string
+                          required:
+                          - dashboard
+                          - project
+                          type: object
+                        type: array
+                      information:
+                        description: Information contains markdown content to be display
+                          on the home page
+                        type: string
+                      time_range:
+                        description: TimeRange contains the time range configuration
+                          for the dropdown
+                        properties:
+                          disable_custom:
+                            type: boolean
+                          disable_zoom:
+                            type: boolean
+                          options:
+                            items:
+                              description: |-
+                                DurationString is a string that represents a duration, such as "1h", "30m", "15s", etc.
+                                It is used to unmarshal a duration string from JSON or YAML, and validate that it is a valid duration string.
+
+                                Not converting the duration string into a time.Duration type allows us to avoid the issue of changing the initial input with an alias.
+                                This is something that happens when we use Duration type, because when the duration is unmarshalled then marshaled again, the input can be changed with an equivalent duration.
+                                For example "14d" will be changed to "2w".
+
+                                So, use DurationString instead of Duration when you want to preserve the original input string.
+                                If, for any reason, you need to convert the DurationString to a time.Duration, you can use the ParseDuration function.
+                              format: duration
+                              pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                              type: string
+                            type: array
+                        type: object
+                    required:
+                    - disable
+                    - explorer
+                    type: object
+                  plugin:
+                    description: Plugin contains the config for runtime plugins.
+                    properties:
+                      archive_path:
+                        description: |-
+                          ArchivePath is the path to the directory containing the archived plugins
+                          When Perses is starting, it will extract the content of the archive in the folder specified in the `folder` attribute.
+                          DEPRECATED: This attribute is deprecated and will be removed in a future version. It is still supported for backward compatibility, but it is recommended to use the `archive_paths` attribute instead.
+                        type: string
+                      archive_paths:
+                        description: |-
+                          ArchivePaths is the list of paths to the directories containing the archived plugins. It allows to specify multiple directories for the archived plugins.
+                          When Perses is starting, it will extract any archive found in the folders specified in this attribute in the folder specified in the `path` attribute.
+                        items:
+                          type: string
+                        type: array
+                      enable_dev:
+                        description: DevEnvironment is the configuration to use when
+                          developing a plugin
+                        type: boolean
+                      path:
+                        description: Path is the path to the directory containing
+                          the runtime plugins
+                        type: string
+                    required:
+                    - enable_dev
+                    type: object
+                  provisioning:
+                    description: Provisioning contains the provisioning config that
+                      can be used if you want to provide default resources.
+                    properties:
+                      folders:
+                        items:
+                          type: string
+                        type: array
+                      interval:
+                        description: Interval is the refresh frequency
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                    type: object
+                  schemas:
+                    description: |-
+                      Schemas contain the configuration to get access to the CUE schemas
+                      DEPRECATED.
+                      Please remove it from your config.
+                    properties:
+                      datasources_path:
+                        type: string
+                      interval:
+                        format: duration
+                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                        type: string
+                      panels_path:
+                        type: string
+                      queries_path:
+                        type: string
+                      variables_path:
+                        type: string
+                    type: object
+                  security:
+                    description: Security contains any configuration that changes
+                      the API behavior like the endpoints exposed or if the permissions
+                      are activated.
+                    properties:
+                      authentication:
+                        description: Authentication contains configuration regarding
+                          management of access/refresh token
+                        properties:
+                          access_token_ttl:
+                            description: AccessTokenTTL is the time to live of the
+                              access token. By default, it is 15 minutes.
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          disable_sign_up:
+                            description: |-
+                              DisableSignUp deactivates the Sign-up page in the UI.
+                              It also disables the endpoint that gives the possibility to create a user.
+                            type: boolean
+                          providers:
+                            description: Providers configure the different authentication
+                              providers
+                            properties:
+                              enable_native:
+                                type: boolean
+                              kubernetes:
+                                properties:
+                                  enable:
+                                    type: boolean
+                                required:
+                                - enable
+                                type: object
+                              oauth:
+                                items:
+                                  properties:
+                                    auth_url:
+                                      format: uri
+                                      type: string
+                                    client_credentials:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    client_id:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
+                                      type: string
+                                    custom_login_property:
+                                      type: string
+                                    device_auth_url:
+                                      format: uri
+                                      type: string
+                                    device_code:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    http:
+                                      properties:
+                                        timeout:
+                                          format: duration
+                                          pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                          type: string
+                                        tls_config:
+                                          properties:
+                                            ca:
+                                              description: Text of the CA cert to
+                                                use for the targets.
+                                              type: string
+                                            caFile:
+                                              description: The CA cert to use for
+                                                the targets.
+                                              type: string
+                                            cert:
+                                              description: Text of the client cert
+                                                file for the targets.
+                                              type: string
+                                            certFile:
+                                              description: The client cert file for
+                                                the targets.
+                                              type: string
+                                            insecureSkipVerify:
+                                              description: Disable target certificate
+                                                validation.
+                                              type: boolean
+                                            key:
+                                              description: Text of the client key
+                                                file for the targets.
+                                              type: string
+                                            keyFile:
+                                              description: The client key file for
+                                                the targets.
+                                              type: string
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                                See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                                See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            serverName:
+                                              description: Used to verify the hostname
+                                                for the targets.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - timeout
+                                      - tls_config
+                                      type: object
+                                    name:
+                                      type: string
+                                    redirect_uri:
+                                      format: uri
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    slug_id:
+                                      type: string
+                                    token_url:
+                                      format: uri
+                                      type: string
+                                    user_infos_url:
+                                      format: uri
+                                      type: string
+                                  required:
+                                  - auth_url
+                                  - client_id
+                                  - device_auth_url
+                                  - http
+                                  - name
+                                  - slug_id
+                                  - token_url
+                                  - user_infos_url
+                                  type: object
+                                type: array
+                              oidc:
+                                items:
+                                  properties:
+                                    client_credentials:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    client_id:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret:
+                                      description: Hidden special type for storing
+                                        secrets.
+                                      type: string
+                                    client_secret_file:
+                                      type: string
+                                    device_code:
+                                      properties:
+                                        client_id:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret:
+                                          description: Hidden special type for storing
+                                            secrets.
+                                          type: string
+                                        client_secret_file:
+                                          type: string
+                                        scopes:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - client_id
+                                      - scopes
+                                      type: object
+                                    disable_pkce:
+                                      type: boolean
+                                    discovery_url:
+                                      format: uri
+                                      type: string
+                                    http:
+                                      properties:
+                                        timeout:
+                                          format: duration
+                                          pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                          type: string
+                                        tls_config:
+                                          properties:
+                                            ca:
+                                              description: Text of the CA cert to
+                                                use for the targets.
+                                              type: string
+                                            caFile:
+                                              description: The CA cert to use for
+                                                the targets.
+                                              type: string
+                                            cert:
+                                              description: Text of the client cert
+                                                file for the targets.
+                                              type: string
+                                            certFile:
+                                              description: The client cert file for
+                                                the targets.
+                                              type: string
+                                            insecureSkipVerify:
+                                              description: Disable target certificate
+                                                validation.
+                                              type: boolean
+                                            key:
+                                              description: Text of the client key
+                                                file for the targets.
+                                              type: string
+                                            keyFile:
+                                              description: The client key file for
+                                                the targets.
+                                              type: string
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default maximum version, which is TLS 1.3.
+                                                See MaxVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).
+                                                If unset, Perses will use Go default minimum version, which is TLS 1.2.
+                                                See MinVersion in https://pkg.go.dev/crypto/tls#Config.
+                                              type: string
+                                            serverName:
+                                              description: Used to verify the hostname
+                                                for the targets.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - timeout
+                                      - tls_config
+                                      type: object
+                                    issuer:
+                                      format: uri
+                                      type: string
+                                    logout:
+                                      properties:
+                                        enabled:
+                                          type: boolean
+                                        logout_redirect_param_name:
+                                          type: string
+                                      required:
+                                      - enabled
+                                      type: object
+                                    name:
+                                      type: string
+                                    redirect_uri:
+                                      format: uri
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    slug_id:
+                                      type: string
+                                    url_params:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  required:
+                                  - client_id
+                                  - disable_pkce
+                                  - http
+                                  - issuer
+                                  - logout
+                                  - name
+                                  - slug_id
+                                  type: object
+                                type: array
+                            required:
+                            - enable_native
+                            type: object
+                          refresh_token_ttl:
+                            description: |-
+                              RefreshTokenTTL is the time to live of the refresh token.
+                              The refresh token is used to get a new access token when it is expired.
+                              By default, it is 24 hours.
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                        required:
+                        - disable_sign_up
+                        - providers
+                        type: object
+                      authorization:
+                        description: Authorization contains all configs around rbac
+                          (permissions and roles)
+                        properties:
+                          check_latest_update_interval:
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.CheckLatestUpdateInterval
+                              instead.'
+                            format: duration
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          guest_permissions:
+                            description: 'DEPRECATED: use NativeAuthorizationProvider.GuestPermissions
+                              instead.'
+                            items:
+                              properties:
+                                actions:
+                                  description: Actions of the permission (read, create,
+                                    update, delete, ...)
+                                  items:
+                                    type: string
+                                  type: array
+                                scopes:
+                                  description: |-
+                                    The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                    With Role, you can't target global kinds
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - actions
+                              - scopes
+                              type: object
+                            type: array
+                          provider:
+                            properties:
+                              kubernetes:
+                                properties:
+                                  authenticator_ttl:
+                                    description: 'time an authenticator response will
+                                      be cached for. Default: 2m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_allow_ttl:
+                                    description: 'time an authorizer allow response
+                                      will be cached for. Default: 5m'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  authorizer_deny_ttl:
+                                    description: 'time an authorizer denied will be
+                                      cached for. Default: 30s'
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  burst:
+                                    description: 'burst QPS the k8s client will use
+                                      with the apiserver. Default: 1000 qps'
+                                    type: integer
+                                  enable:
+                                    type: boolean
+                                  kubeconfig:
+                                    description: |-
+                                      The active user in the kubeconfig should have "create" permissions for the `TokenReview` and
+                                      `SubjectAccessReview` resources. If the kubeconfig parameter isn't available the pods service
+                                      account token will be used
+                                    type: string
+                                  qps:
+                                    description: 'query per second (QPS) the k8s client
+                                      will use with the apiserver. Default: 500 qps'
+                                    type: integer
+                                type: object
+                              native:
+                                properties:
+                                  check_latest_update_interval:
+                                    description: CheckLatestUpdateInterval that checks
+                                      if the RBAC cache needs to be refreshed with
+                                      db content. Only for SQL database setup.
+                                    format: duration
+                                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                                    type: string
+                                  enable:
+                                    type: boolean
+                                  guest_permissions:
+                                    description: Default permissions for guest users
+                                      (logged-in users)
+                                    items:
+                                      properties:
+                                        actions:
+                                          description: Actions of the permission (read,
+                                            create, update, delete, ...)
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopes:
+                                          description: |-
+                                            The list of kind targeted by the permission. For example: `Datasource`, `Dashboard`, ...
+                                            With Role, you can't target global kinds
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - actions
+                                      - scopes
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
+                      cookie:
+                        description: Cookie configuration
+                        properties:
+                          same_site:
+                            description: |-
+                              Set the SameSite cookie attribute and prevents the browser from sending the cookie along with cross-site requests.
+                              The main goal is to mitigate the risk of cross-origin information leakage.
+                              This setting also provides some protection against cross-site request forgery attacks (CSRF)
+                            type: integer
+                          secure:
+                            description: Set to true if you host Perses behind HTTPS.
+                              Default is false
+                            type: boolean
+                        required:
+                        - secure
+                        type: object
+                      cors:
+                        description: Configuration for the CORS middleware.
+                        properties:
+                          allow_credentials:
+                            type: boolean
+                          allow_headers:
+                            items:
+                              type: string
+                            type: array
+                          allow_methods:
+                            items:
+                              type: string
+                            type: array
+                          allow_origins:
+                            items:
+                              type: string
+                            type: array
+                          enable:
+                            type: boolean
+                          expose_headers:
+                            items:
+                              type: string
+                            type: array
+                          max_age:
+                            type: integer
+                        required:
+                        - enable
+                        type: object
+                      enable_auth:
+                        description: |-
+                          When it is true, the authentication and authorization config are considered.
+                          And you will need a valid JWT token to contact most of the endpoints exposed by the API
+                        type: boolean
+                      encryption_key:
+                        description: |-
+                          EncryptionKey is the secret key used to encrypt and decrypt sensitive data
+                          stored in the database such as the password of the basic auth for a datasource.
+                          Note that if it is not provided, it will use a default value.
+                          On a production instance, you should set this key.
+                          Also note the key size must be exactly 32 bytes long as we are using AES-256 to encrypt the data.
+                        type: string
+                      encryption_key_file:
+                        description: EncryptionKeyFile is the path to file containing
+                          the secret key
+                        type: string
+                      readonly:
+                        description: Readonly will deactivate any HTTP POST, PUT,
+                          DELETE endpoint
+                        type: boolean
+                    required:
+                    - cookie
+                    - enable_auth
+                    - readonly
+                    type: object
+                  variable:
+                    description: Variable contains the configuration for the variable.
+                    properties:
+                      disable_local:
+                        description: DisableLocal when used is preventing the possibility
+                          to add a variable directly in the dashboard spec.
+                        type: boolean
+                      global:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the global variable feature.
+                              Note that if the global datasource is disabled, the global variable will also be disabled.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                      project:
+                        properties:
+                          disable:
+                            description: |-
+                              Disable is used to disable the project variable feature.
+                              Note that if the global datasource and the project datasource are disabled,
+                              then the project variable will also be disabled.
+                            type: boolean
+                        required:
+                        - disable
+                        type: object
+                    required:
+                    - disable_local
+                    - global
+                    - project
+                    type: object
+                type: object
+              containerPort:
+                description: containerPort is the port on which the Perses server
+                  listens for HTTP requests
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+              image:
+                description: image specifies the container image that should be used
+                  for the Perses deployment
+                type: string
+              livenessProbe:
+                description: livenessProbe specifies the liveness probe configuration
+                  for the Perses container
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              logLevel:
+                description: logLevel defines the log level for Perses
+                enum:
+                - panic
+                - fatal
+                - error
+                - warning
+                - info
+                - debug
+                - trace
+                type: string
+              logMethodTrace:
+                description: |-
+                  logMethodTrace when true, includes the calling method as a field in the log
+                  It can be useful to see immediately where the log comes from
+                type: boolean
+              metadata:
+                description: metadata specifies additional metadata to add to deployed
+                  pods
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: annotations are key/value pairs attached to pods
+                      for non-identifying metadata
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: labels are key/value pairs attached to pods
+                    type: object
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector constrains pods to nodes with matching labels
+                type: object
+              podSecurityContext:
+                description: |-
+                  podSecurityContext holds pod-level security attributes and common container settings
+                  If not specified, defaults to fsGroup: 65534 to ensure proper volume permissions for the nobody user
+                properties:
+                  appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile loaded on the node that should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must match the loaded name of the profile.
+                          Must be set if and only if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of AppArmor profile will be applied.
+                          Valid options are:
+                            Localhost - a profile pre-loaded on the node.
+                            RuntimeDefault - the container runtime's default profile.
+                            Unconfined - no AppArmor enforcement.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  fsGroup:
+                    description: |-
+                      A special supplemental group that applies to all containers in a pod.
+                      Some volume types allow the Kubelet to change the ownership of that volume
+                      to be owned by the pod:
+
+                      1. The owning GID will be the FSGroup
+                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw----
+
+                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: |-
+                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being exposed inside Pod. This field will only apply to
+                      volume types which support fsGroup based ownership(and permissions).
+                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir.
+                      Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in SecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                      for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: |-
+                      Indicates that the container must run as a non-root user.
+                      If true, the Kubelet will validate the image at runtime to ensure that it
+                      does not run as UID 0 (root) and fail to start the container if it does.
+                      If unset or false, no such validation will be performed.
+                      May also be set in SecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext and
+                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                      for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxChangePolicy:
+                    description: |-
+                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                      Valid values are "MountOption" and "Recursive".
+
+                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                      This requires all Pods that share the same volume to use the same SELinux label.
+                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                      and "Recursive" for all other volumes.
+
+                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  seLinuxOptions:
+                    description: |-
+                      The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random SELinux context for each
+                      container.  May also be set in SecurityContext.  If set in
+                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: |-
+                      The seccomp options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: |-
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if specified).  If
+                      the SupplementalGroupsPolicy feature is enabled, the
+                      supplementalGroupsPolicy field determines whether these are in addition
+                      to or instead of any group memberships defined in the container image.
+                      If unspecified, no additional groups are added, though group memberships
+                      defined in the container image may still be used, depending on the
+                      supplementalGroupsPolicy field.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                      (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                      and the container runtime must implement support for this feature.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
+                  sysctls:
+                    description: |-
+                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                      sysctls (by the container runtime) might fail to launch.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext will be used.
+                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                      Note that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                          GMSA credential spec named by the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: |-
+                          HostProcess determines if a container should be run as a 'Host Process' container.
+                          All of a Pod's containers must have the same effective HostProcess value
+                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: |-
+                          The UserName in Windows to run the entrypoint of the container process.
+                          Defaults to the user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
+              provisioning:
+                description: provisioning configuration for provisioning secrets
+                properties:
+                  secretRefs:
+                    description: secretRefs is a list of references to Kubernetes
+                      secrets used for provisioning sensitive data.
+                    items:
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              readinessProbe:
+                description: readinessProbe specifies the readiness probe configuration
+                  for the Perses container
+                properties:
+                  exec:
+                    description: Exec specifies a command to execute in the container.
+                    properties:
+                      command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                          a shell, you need to explicitly call out to that shell.
+                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                          If this is not specified, the default behavior is defined by gRPC.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
+                    properties:
+                      host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                      The grace period is the duration in seconds after the processes running in the pod are sent
+                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                      Set this value longer than the expected cleanup time for your process.
+                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec.
+                      Value must be non-negative integer. The value zero indicates stop immediately via
+                      the kill signal (no opportunity to shut down).
+                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                    format: int32
+                    type: integer
+                type: object
+              replicas:
+                description: replicas is the number of desired pod replicas for the
+                  Perses deployment
+                format: int32
+                type: integer
+              resources:
+                description: resources defines the compute resources configured for
+                  the container
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              service:
+                description: service specifies the service configuration for the Perses
+                  instance
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: annotations are key/value pairs attached to the Service
+                      for non-identifying metadata
+                    type: object
+                  name:
+                    description: |-
+                      name is the name of the Kubernetes Service resource
+                      If not specified, a default name will be generated
+                    type: string
+                type: object
+              serviceAccountName:
+                description: serviceAccountName is the name of the ServiceAccount
+                  to use for the Perses deployment or statefulset
+                type: string
+              storage:
+                description: storage configuration used by the StatefulSet
+                properties:
+                  emptyDir:
+                    description: |-
+                      emptyDir to use for ephemeral storage.
+                      When set, data will be lost when the pod is deleted or restarted.
+                      Mutually exclusive with PersistentVolumeClaimTemplate.
+                    properties:
+                      medium:
+                        description: |-
+                          medium represents what type of storage medium should back this directory.
+                          The default is "" which means to use the node's default medium.
+                          Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                          The size limit is also applicable for memory medium.
+                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  pvcTemplate:
+                    description: |-
+                      pvcTemplate is the template for PVCs that will be created.
+                      Mutually exclusive with EmptyDir.
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          Users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: emptyDir and pvcTemplate are mutually exclusive
+                  rule: '!(has(self.emptyDir) && has(self.pvcTemplate))'
+              tls:
+                description: tls specifies the TLS configuration for the Perses instance
+                properties:
+                  caCert:
+                    description: caCert specifies the CA certificate to verify the
+                      Perses server's certificate
+                    properties:
+                      certPath:
+                        description: |-
+                          certPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the certificate is stored
+                        minLength: 1
+                        type: string
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      privateKeyPath:
+                        description: |-
+                          privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the private key is stored
+                          Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - certPath
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  enable:
+                    description: enable determines whether TLS is enabled for connections
+                      to Perses
+                    type: boolean
+                  insecureSkipVerify:
+                    description: |-
+                      insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                      Setting this to true is insecure and should only be used for testing
+                    type: boolean
+                  userCert:
+                    description: userCert specifies the client certificate and key
+                      for mutual TLS (mTLS) authentication
+                    properties:
+                      certPath:
+                        description: |-
+                          certPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the certificate is stored
+                        minLength: 1
+                        type: string
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      privateKeyPath:
+                        description: |-
+                          privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the private key is stored
+                          Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - certPath
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                type: object
+              tolerations:
+                description: tolerations allow pods to schedule onto nodes with matching
+                  taints
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              volumeMounts:
+                description: |-
+                  volumeMounts allows configuration of additional VolumeMounts on the Deployment or StatefulSet definitions.
+                  VolumeMounts specified here will be appended to other operator-managed volume mounts.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
+                        When not set, MountPropagationNone is used.
+                        This field is beta in 1.10.
+                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                        (which defaults to None).
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
+                      type: boolean
+                    recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
+
+                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                        recursively read-only, if it is supported by the container runtime.  If this
+                        field is set to Enabled, the mount is made recursively read-only if it is
+                        supported by the container runtime, otherwise the pod will not be started and
+                        an error will be generated to indicate the reason.
+
+                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                        None (or be unspecified, which defaults to None).
+
+                        If this field is not specified, it is treated as an equivalent of Disabled.
+                      type: string
+                    subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: |-
+                        Expanded path within the volume from which the container's volume should be mounted.
+                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                        Defaults to "" (volume's root).
+                        SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - mountPath
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: volumeMount mountPath must not conflict with or shadow
+                    operator-reserved paths under /etc/perses/config, /etc/perses/plugins,
+                    /etc/perses/provisioning, or /etc/perses, /perses, /ca, /tls
+                  rule: self.all(m, !m.mountPath.startsWith('/etc/perses/config')
+                    && !m.mountPath.startsWith('/etc/perses/plugins') && !m.mountPath.startsWith('/etc/perses/provisioning')
+                    && !(m.mountPath in ['/etc/perses', '/perses', '/ca', '/tls']))
+              volumes:
+                description: |-
+                  volumes allows configuration of additional volumes on the Deployment or StatefulSet definitions.
+                  Volumes specified here will be appended to other operator-managed volumes.
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: boolean
+                        volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
+                      properties:
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                      properties:
+                        monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: boolean
+                        secretFile:
+                          description: |-
+                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the ConfigMap,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
+                      properties:
+                        driver:
+                          description: |-
+                            driver is the name of the CSI driver that handles this volume.
+                            Consult with your admin for the correct name as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated CSI driver
+                            which will determine the default filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete the CSI
+                            NodePublishVolume and NodeUnpublishVolume calls.
+                            This field is optional, and  may be empty if no secret is required. If the
+                            secret object contains more than one secret, all secret references are passed.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver. Consult your driver's documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            Optional: mode bits to use on created files by default. Must be a
+                            Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                      properties:
+                        medium:
+                          description: |-
+                            medium represents what type of storage medium should back this directory.
+                            The default is "" which means to use the node's default medium.
+                            Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                            The size limit is also applicable for memory medium.
+                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                            The default is nil which means that the limit is undefined.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: |-
+                        ephemeral represents a volume that is handled by a cluster storage driver.
+                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                        and deleted when the pod is removed.
+
+                        Use this if:
+                        a) the volume is only needed while the pod runs,
+                        b) features of normal volumes like restoring from snapshot or capacity
+                           tracking are needed,
+                        c) the storage driver is specified through a storage class, and
+                        d) the storage driver supports dynamic volume provisioning through
+                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                           information on the connection between this volume type
+                           and PersistentVolumeClaim).
+
+                        Use PersistentVolumeClaim or one of the vendor-specific
+                        APIs for volumes that persist for longer than the lifecycle
+                        of an individual pod.
+
+                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                        be used that way - see the documentation of the driver for
+                        more information.
+
+                        A pod can use both types of ephemeral volumes and
+                        persistent volumes at the same time.
+                      properties:
+                        volumeClaimTemplate:
+                          description: |-
+                            Will be used to create a stand-alone PVC to provision the volume.
+                            The pod in which this EphemeralVolumeSource is embedded will be the
+                            owner of the PVC, i.e. the PVC will be deleted together with the
+                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                            entry. Pod validation will reject the pod if the concatenated name
+                            is not valid for a PVC (for example, too long).
+
+                            An existing PVC with that name that is not owned by the pod
+                            will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC is
+                            meant to be used by the pod, the PVC has to updated with an
+                            owner reference to the pod once the pod exists. Normally
+                            this should not be necessary, but it may be useful when
+                            manually reconstructing a broken cluster.
+
+                            This field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created.
+
+                            Required, must not be nil.
+                          properties:
+                            metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it. No other fields are allowed and will be rejected during
+                                validation.
+                              type: object
+                            spec:
+                              description: |-
+                                The specification for the PersistentVolumeClaim. The entire content is
+                                copied unchanged into the PVC that gets created from this
+                                template. The same fields as in a PersistentVolumeClaim
+                                are also valid here.
+                              properties:
+                                accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    Users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  type: string
+                                volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin scripts. This may be
+                            empty if no secret object is specified. If the secret object
+                            contains more than one secret, all secrets are passed to the plugin
+                            scripts.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                      properties:
+                        datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                        into the Pod's container.
+                      properties:
+                        directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                            the subdirectory with the given name.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: |-
+                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                      properties:
+                        endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
+                          type: string
+                        path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container. This is generally
+                        used for system agents or other privileged things that are allowed
+                        to see the host machine. Most containers will NOT need this.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      properties:
+                        path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                        type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    image:
+                      description: |-
+                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                      properties:
+                        pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          type: string
+                        reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
+                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                      type: object
+                    iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          type: string
+                        initiatorName:
+                          description: |-
+                            initiatorName is the custom iSCSI Initiator Name.
+                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                            <target portal>:<volume name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: |-
+                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: |-
+                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                      properties:
+                        path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: boolean
+                        server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
+                      properties:
+                        fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode are the mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
+                          items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
+                            properties:
+                              clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                  combination of signer name and a label selector.
+
+                                  Kubelet performs aggressive normalization of the PEM contents written
+                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                  may change the order over time.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                      everything".
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                      allowed not to exist.  If using signerName, then the combination of
+                                      signerName and labelSelector is allowed to match zero
+                                      ClusterTrustBundles.
+                                    type: boolean
+                                  path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
+                                    type: string
+                                  signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.  The contents of all selected
+                                      ClusterTrustBundles will be unified and deduplicated.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or server.
+
+                                  Kubelet generates a private key and uses it to send a
+                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                  request and issues a certificate chain, Kubelet writes the key and
+                                  certificate chain to the pod filesystem.  The pod does not start until
+                                  certificates have been issued for each podCertificate projected volume
+                                  source in its spec.
+
+                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                  timestamp.
+
+                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                  field, or separate files, indicated by the keyPath and
+                                  certificateChainPath fields.
+
+                                  The credential bundle is a single file in PEM format.  The first PEM
+                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                  entries are the certificate chain issued by the signer (typically,
+                                  signers will return their certificate chain in leaf-to-root order).
+
+                                  Prefer using the credential bundle format, since your application code
+                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                  your application must make two separate file reads. If these coincide
+                                  with a certificate rotation, it is possible that the private key and leaf
+                                  certificate you read may not correspond to each other.  Your application
+                                  will need to check for this condition, and re-read until they are
+                                  consistent.
+
+                                  The named signer controls chooses the format of the certificate it
+                                  issues; consult the signer implementation's documentation to learn how to
+                                  use the certificates it issues.
+                                properties:
+                                  certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  credentialBundlePath:
+                                    description: |-
+                                      Write the credential bundle at this path in the projected volume.
+
+                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                      key.
+
+                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                      certificate chain from the signer (leaf and any intermediates).
+
+                                      Using credentialBundlePath lets your Pod's application code make a single
+                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                      project them to separate files, your application code will need to
+                                      additionally check that the leaf certificate was issued to the key.
+                                    type: string
+                                  keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.  When using keyPath
+                                      and certificateChainPath, your application needs to check that the key
+                                      and leaf certificate are consistent, because it is possible to read the
+                                      files mid-rotation.
+                                    type: string
+                                  keyType:
+                                    description: |-
+                                      The type of keypair Kubelet will generate for the pod.
+
+                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                      "ECDSAP521", and "ED25519".
+                                    type: string
+                                  maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
+
+                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                      generates for this projection.
+
+                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                      value is 7862400 (91 days).
+
+                                      The signer implementation is then free to issue a certificate with any
+                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                      longer than 24 hours.
+                                    format: int32
+                                    type: integer
+                                  signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
+                                    type: string
+                                  userAnnotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                      metadata in any way.
+
+                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                      Entries are subject to the same validation as object metadata annotations,
+                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                      are placed on values, except an overall size limitation on the entire field.
+
+                                      Signers should document the keys and values they support. Signers should
+                                      deny requests that contain keys they do not recognize.
+                                    type: object
+                                required:
+                                - keyType
+                                - signerName
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: |-
+                                      audience is the intended audience of the token. A recipient of a token
+                                      must identify itself with an identifier specified in the audience of the
+                                      token, and otherwise should reject the token. The audience defaults to the
+                                      identifier of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token. As the token approaches expiration, the kubelet volume
+                                      plugin will proactively rotate the service account token. The kubelet will
+                                      start trying to rotate the token if the token is older than 80 percent of
+                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                      and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    quobyte:
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                      properties:
+                        group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
+                          type: boolean
+                        registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries are separated with commas)
+                            which acts as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                          type: string
+                        user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: |-
+                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          type: string
+                        image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        keyring:
+                          default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        pool:
+                          default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                      properties:
+                        fsType:
+                          default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
+                            Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information. If this is not provided, Login operation will fail.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          default: ThinProvisioned
+                          description: |-
+                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values
+                            for mode bits. Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the Secret,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          type: string
+                      type: object
+                    storageos:
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.  If not specified, default values will be attempted.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: |-
+                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                            namespace is specified then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                            Set VolumeName to any name to override the default behaviour.
+                            Set to "default" if you are not using namespaces within StorageOS.
+                            Namespaces that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+                x-kubernetes-validations:
+                - message: volume name must not conflict with operator-reserved names
+                    (config, plugins, storage, ca, tls) or use the 'provisioning-'
+                    prefix
+                  rule: self.all(v, !(v.name in ['config', 'plugins', 'storage', 'ca',
+                    'tls']) && !v.name.startsWith('provisioning-'))
+            type: object
+          status:
+            description: status is the observed state of the Perses resource
+            properties:
+              conditions:
+                description: conditions represent the latest observations of the Perses
+                  resource state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              provisioning:
+                description: provisioning contains the versions of provisioning secrets
+                  currently in use
+                items:
+                  description: SecretVersion represents a secret version
+                  properties:
+                    name:
+                      description: name is the name of the provisioning secret
+                      minLength: 1
+                      type: string
+                    version:
+                      description: version is the resource version of the provisioning
+                        secret
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/perses.dev_persesdashboards.yaml
+++ b/bundle/manifests/perses.dev_persesdashboards.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.20.0
+  creationTimestamp: null
+  name: persesdashboards.perses.dev
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: perses-operator-webhook-service
+          namespace: perses-operator-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: perses.dev
+  names:
+    kind: PersesDashboard
+    listKind: PersesDashboardList
+    plural: persesdashboards
+    shortNames:
+    - perdb
+    singular: persesdashboard
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PersesDashboard is the Schema for the persesdashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              datasources:
+                additionalProperties:
+                  properties:
+                    default:
+                      type: boolean
+                    display:
+                      properties:
+                        description:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    plugin:
+                      description: |-
+                        Plugin will contain the datasource configuration.
+                        The data typed is available in Cue.
+                      properties:
+                        kind:
+                          description: Kind is the type of the plugin (e.g., Panel,
+                            Variable, Datasource, etc.).
+                          type: string
+                        metadata:
+                          description: Metadata is an optional field that contains
+                            additional information such as version and registry of
+                            the plugin.
+                          properties:
+                            registry:
+                              description: 'Registry is optional. If not provided,
+                                it means the default registry: "perses.dev".'
+                              type: string
+                            version:
+                              description: Version is optional. If not provided, it
+                                means the latest version available in the Perses instance.
+                              type: string
+                          type: object
+                        spec:
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - kind
+                      - spec
+                      type: object
+                  required:
+                  - default
+                  - plugin
+                  type: object
+                description: Datasources is an optional list of datasource definition.
+                type: object
+              display:
+                properties:
+                  description:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              duration:
+                description: Duration is the default time range to use when getting
+                  data to fill the dashboard
+                format: duration
+                pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                type: string
+              layouts:
+                items:
+                  properties:
+                    kind:
+                      type: string
+                    spec:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - kind
+                  - spec
+                  type: object
+                type: array
+              links:
+                description: Links is an optional list of links to display at the
+                  dashboard level
+                items:
+                  properties:
+                    name:
+                      type: string
+                    renderVariables:
+                      type: boolean
+                    targetBlank:
+                      type: boolean
+                    tooltip:
+                      type: string
+                    url:
+                      type: string
+                  required:
+                  - url
+                  type: object
+                type: array
+              panels:
+                additionalProperties:
+                  properties:
+                    kind:
+                      type: string
+                    spec:
+                      properties:
+                        display:
+                          properties:
+                            description:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        links:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              renderVariables:
+                                type: boolean
+                              targetBlank:
+                                type: boolean
+                              tooltip:
+                                type: string
+                              url:
+                                type: string
+                            required:
+                            - url
+                            type: object
+                          type: array
+                        plugin:
+                          properties:
+                            kind:
+                              description: Kind is the type of the plugin (e.g., Panel,
+                                Variable, Datasource, etc.).
+                              type: string
+                            metadata:
+                              description: Metadata is an optional field that contains
+                                additional information such as version and registry
+                                of the plugin.
+                              properties:
+                                registry:
+                                  description: 'Registry is optional. If not provided,
+                                    it means the default registry: "perses.dev".'
+                                  type: string
+                                version:
+                                  description: Version is optional. If not provided,
+                                    it means the latest version available in the Perses
+                                    instance.
+                                  type: string
+                              type: object
+                            spec:
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - kind
+                          - spec
+                          type: object
+                        queries:
+                          items:
+                            properties:
+                              kind:
+                                type: string
+                              spec:
+                                properties:
+                                  plugin:
+                                    properties:
+                                      kind:
+                                        description: Kind is the type of the plugin
+                                          (e.g., Panel, Variable, Datasource, etc.).
+                                        type: string
+                                      metadata:
+                                        description: Metadata is an optional field
+                                          that contains additional information such
+                                          as version and registry of the plugin.
+                                        properties:
+                                          registry:
+                                            description: 'Registry is optional. If
+                                              not provided, it means the default registry:
+                                              "perses.dev".'
+                                            type: string
+                                          version:
+                                            description: Version is optional. If not
+                                              provided, it means the latest version
+                                              available in the Perses instance.
+                                            type: string
+                                        type: object
+                                      spec:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - kind
+                                    - spec
+                                    type: object
+                                required:
+                                - plugin
+                                type: object
+                            required:
+                            - kind
+                            - spec
+                            type: object
+                          type: array
+                      required:
+                      - plugin
+                      type: object
+                  required:
+                  - kind
+                  - spec
+                  type: object
+                type: object
+              refreshInterval:
+                description: RefreshInterval is the default refresh interval to use
+                  when landing on the dashboard
+                format: duration
+                pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                type: string
+              variables:
+                items:
+                  properties:
+                    kind:
+                      description: Kind is the type of the variable. Depending on
+                        the value of Kind, it will change the content of Spec.
+                      type: string
+                    spec:
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - kind
+                  - spec
+                  type: object
+                type: array
+            required:
+            - duration
+            - layouts
+            - panels
+            type: object
+          status:
+            description: PersesDashboardStatus defines the observed state of PersesDashboard
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PersesDashboard is the Schema for the persesdashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the PersesDashboard resource
+            properties:
+              config:
+                description: config specifies the Perses dashboard configuration
+                properties:
+                  datasources:
+                    additionalProperties:
+                      properties:
+                        default:
+                          type: boolean
+                        display:
+                          properties:
+                            description:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        plugin:
+                          description: |-
+                            Plugin will contain the datasource configuration.
+                            The data typed is available in Cue.
+                          properties:
+                            kind:
+                              description: Kind is the type of the plugin (e.g., Panel,
+                                Variable, Datasource, etc.).
+                              type: string
+                            metadata:
+                              description: Metadata is an optional field that contains
+                                additional information such as version and registry
+                                of the plugin.
+                              properties:
+                                registry:
+                                  description: 'Registry is optional. If not provided,
+                                    it means the default registry: "perses.dev".'
+                                  type: string
+                                version:
+                                  description: Version is optional. If not provided,
+                                    it means the latest version available in the Perses
+                                    instance.
+                                  type: string
+                              type: object
+                            spec:
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - kind
+                          - spec
+                          type: object
+                      required:
+                      - default
+                      - plugin
+                      type: object
+                    description: Datasources is an optional list of datasource definition.
+                    type: object
+                  display:
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  duration:
+                    description: Duration is the default time range to use when getting
+                      data to fill the dashboard
+                    format: duration
+                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                    type: string
+                  layouts:
+                    items:
+                      properties:
+                        kind:
+                          type: string
+                        spec:
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - kind
+                      - spec
+                      type: object
+                    type: array
+                  links:
+                    description: Links is an optional list of links to display at
+                      the dashboard level
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        renderVariables:
+                          type: boolean
+                        targetBlank:
+                          type: boolean
+                        tooltip:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - url
+                      type: object
+                    type: array
+                  panels:
+                    additionalProperties:
+                      properties:
+                        kind:
+                          type: string
+                        spec:
+                          properties:
+                            display:
+                              properties:
+                                description:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            links:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  renderVariables:
+                                    type: boolean
+                                  targetBlank:
+                                    type: boolean
+                                  tooltip:
+                                    type: string
+                                  url:
+                                    type: string
+                                required:
+                                - url
+                                type: object
+                              type: array
+                            plugin:
+                              properties:
+                                kind:
+                                  description: Kind is the type of the plugin (e.g.,
+                                    Panel, Variable, Datasource, etc.).
+                                  type: string
+                                metadata:
+                                  description: Metadata is an optional field that
+                                    contains additional information such as version
+                                    and registry of the plugin.
+                                  properties:
+                                    registry:
+                                      description: 'Registry is optional. If not provided,
+                                        it means the default registry: "perses.dev".'
+                                      type: string
+                                    version:
+                                      description: Version is optional. If not provided,
+                                        it means the latest version available in the
+                                        Perses instance.
+                                      type: string
+                                  type: object
+                                spec:
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - kind
+                              - spec
+                              type: object
+                            queries:
+                              items:
+                                properties:
+                                  kind:
+                                    type: string
+                                  spec:
+                                    properties:
+                                      plugin:
+                                        properties:
+                                          kind:
+                                            description: Kind is the type of the plugin
+                                              (e.g., Panel, Variable, Datasource,
+                                              etc.).
+                                            type: string
+                                          metadata:
+                                            description: Metadata is an optional field
+                                              that contains additional information
+                                              such as version and registry of the
+                                              plugin.
+                                            properties:
+                                              registry:
+                                                description: 'Registry is optional.
+                                                  If not provided, it means the default
+                                                  registry: "perses.dev".'
+                                                type: string
+                                              version:
+                                                description: Version is optional.
+                                                  If not provided, it means the latest
+                                                  version available in the Perses
+                                                  instance.
+                                                type: string
+                                            type: object
+                                          spec:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                        required:
+                                        - kind
+                                        - spec
+                                        type: object
+                                    required:
+                                    - plugin
+                                    type: object
+                                required:
+                                - kind
+                                - spec
+                                type: object
+                              type: array
+                          required:
+                          - plugin
+                          type: object
+                      required:
+                      - kind
+                      - spec
+                      type: object
+                    type: object
+                  refreshInterval:
+                    description: RefreshInterval is the default refresh interval to
+                      use when landing on the dashboard
+                    format: duration
+                    pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                    type: string
+                  variables:
+                    items:
+                      properties:
+                        kind:
+                          description: Kind is the type of the variable. Depending
+                            on the value of Kind, it will change the content of Spec.
+                          type: string
+                        spec:
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - kind
+                      - spec
+                      type: object
+                    type: array
+                required:
+                - duration
+                - layouts
+                - panels
+                type: object
+              instanceSelector:
+                description: instanceSelector selects Perses instances where this
+                  dashboard will be created
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - config
+            type: object
+          status:
+            description: status is the observed state of the PersesDashboard resource
+            properties:
+              conditions:
+                description: conditions represent the latest observations of the PersesDashboard
+                  resource state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/perses.dev_persesdatasources.yaml
+++ b/bundle/manifests/perses.dev_persesdatasources.yaml
@@ -1,0 +1,756 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.20.0
+  creationTimestamp: null
+  name: persesdatasources.perses.dev
+spec:
+  group: perses.dev
+  names:
+    kind: PersesDatasource
+    listKind: PersesDatasourceList
+    plural: persesdatasources
+    shortNames:
+    - perds
+    singular: persesdatasource
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    deprecationWarning: perses.dev/v1alpha1 is deprecated; use perses.dev/v1alpha2
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PersesDatasource is the Schema for the PersesDatasources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              client:
+                properties:
+                  basicAuth:
+                    description: BasicAuth basic auth config for perses client
+                    properties:
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      password_path:
+                        description: Path to password
+                        minLength: 1
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: Username for basic auth
+                        minLength: 1
+                        type: string
+                    required:
+                    - password_path
+                    - type
+                    - username
+                    type: object
+                  kubernetesAuth:
+                    description: KubernetesAuth configuration for perses client
+                    properties:
+                      enable:
+                        description: Enable kubernetes auth for perses client
+                        type: boolean
+                    required:
+                    - enable
+                    type: object
+                  oauth:
+                    description: OAuth configuration for perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          AuthStyle optionally specifies how the endpoint wants the
+                          client ID & client secret sent. The zero value means to
+                          auto-detect.
+                        type: integer
+                      clientIDPath:
+                        description: Path to client id
+                        type: string
+                      clientSecretPath:
+                        description: Path to client secret
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: EndpointParams specifies additional parameters
+                          for requests to the token endpoint.
+                        type: object
+                      name:
+                        description: Name of basic auth k8s resource (when type is
+                          secret or configmap)
+                        type: string
+                      namespace:
+                        description: Namespace of certificate k8s resource (when type
+                          is secret or configmap)
+                        type: string
+                      scopes:
+                        description: Scope specifies optional requested permissions.
+                        items:
+                          type: string
+                        type: array
+                      tokenURL:
+                        description: |-
+                          TokenURL is the resource server's token endpoint
+                          URL. This is a constant specific to each server.
+                        minLength: 1
+                        type: string
+                      type:
+                        description: Type source type of secret
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                  tls:
+                    description: TLS the equivalent to the tls_config for perses client
+                    properties:
+                      caCert:
+                        description: CaCert to verify the perses certificate
+                        properties:
+                          certPath:
+                            description: Path to Certificate
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
+                            type: string
+                          namespace:
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
+                            type: string
+                          privateKeyPath:
+                            description: Path to Private key certificate
+                            type: string
+                          type:
+                            description: Type source type of secret
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                      enable:
+                        description: Enable TLS connection to perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: InsecureSkipVerify skip verify of perses certificate
+                        type: boolean
+                      userCert:
+                        description: UserCert client cert/key for mTLS
+                        properties:
+                          certPath:
+                            description: Path to Certificate
+                            minLength: 1
+                            type: string
+                          name:
+                            description: Name of basic auth k8s resource (when type
+                              is secret or configmap)
+                            type: string
+                          namespace:
+                            description: Namespace of certificate k8s resource (when
+                              type is secret or configmap)
+                            type: string
+                          privateKeyPath:
+                            description: Path to Private key certificate
+                            type: string
+                          type:
+                            description: Type source type of secret
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                    required:
+                    - enable
+                    type: object
+                type: object
+              config:
+                properties:
+                  default:
+                    type: boolean
+                  display:
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  plugin:
+                    description: |-
+                      Plugin will contain the datasource configuration.
+                      The data typed is available in Cue.
+                    properties:
+                      kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
+                        type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - kind
+                    - spec
+                    type: object
+                required:
+                - default
+                - plugin
+                type: object
+            required:
+            - config
+            type: object
+          status:
+            description: PersesDatasourceStatus defines the observed state of PersesDatasource
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PersesDatasource is the Schema for the PersesDatasources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the PersesDatasource resource
+            properties:
+              client:
+                description: client specifies authentication and TLS configuration
+                  for the datasource
+                properties:
+                  basicAuth:
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
+                    properties:
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
+                        type: string
+                    required:
+                    - passwordPath
+                    - type
+                    - username
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  kubernetesAuth:
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
+                    properties:
+                      enable:
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
+                        type: boolean
+                    type: object
+                  oauth:
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
+                        type: integer
+                      clientIDPath:
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
+                        type: string
+                      clientSecretPath:
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
+                        type: object
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tokenURL:
+                        description: |-
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  tls:
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
+                    properties:
+                      caCert:
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                      enable:
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
+                        type: boolean
+                      userCert:
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                    type: object
+                type: object
+              config:
+                description: config specifies the Perses datasource configuration
+                properties:
+                  default:
+                    type: boolean
+                  display:
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  plugin:
+                    description: |-
+                      Plugin will contain the datasource configuration.
+                      The data typed is available in Cue.
+                    properties:
+                      kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
+                        type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - kind
+                    - spec
+                    type: object
+                required:
+                - default
+                - plugin
+                type: object
+              instanceSelector:
+                description: instanceSelector selects Perses instances where this
+                  datasource will be created
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - config
+            type: object
+          status:
+            description: status is the observed state of the PersesDatasource resource
+            properties:
+              conditions:
+                description: conditions represent the latest observations of the PersesDatasource
+                  resource state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/perses.dev_persesglobaldatasources.yaml
+++ b/bundle/manifests/perses.dev_persesglobaldatasources.yaml
@@ -1,0 +1,465 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: perses-operator-system/perses-operator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.20.0
+  creationTimestamp: null
+  name: persesglobaldatasources.perses.dev
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: perses-operator-webhook-service
+          namespace: perses-operator-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: perses.dev
+  names:
+    kind: PersesGlobalDatasource
+    listKind: PersesGlobalDatasourceList
+    plural: persesglobaldatasources
+    shortNames:
+    - pergds
+    singular: persesglobaldatasource
+  scope: Cluster
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PersesGlobalDatasource is the Schema for the PersesGlobalDatasources
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the PersesGlobalDatasource resource
+            properties:
+              client:
+                description: client specifies authentication and TLS configuration
+                  for the datasource
+                properties:
+                  basicAuth:
+                    description: basicAuth provides username/password authentication
+                      configuration for the Perses client
+                    properties:
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: username is the username credential for basic
+                          authentication
+                        minLength: 1
+                        type: string
+                    required:
+                    - passwordPath
+                    - type
+                    - username
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  kubernetesAuth:
+                    description: kubernetesAuth enables Kubernetes native authentication
+                      for the Perses client
+                    properties:
+                      enable:
+                        description: enable determines whether Kubernetes authentication
+                          is enabled for the Perses client
+                        type: boolean
+                    type: object
+                  oauth:
+                    description: oauth provides OAuth 2.0 authentication configuration
+                      for the Perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
+                        type: integer
+                      clientIDPath:
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
+                        type: string
+                      clientSecretPath:
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: endpointParams specifies additional parameters
+                          to include in requests to the token endpoint
+                        type: object
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: scopes specifies optional requested permissions
+                          for the OAuth token
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tokenURL:
+                        description: |-
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data
+                          (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                  tls:
+                    description: tls provides TLS/SSL configuration for secure connections
+                      to Perses
+                    properties:
+                      caCert:
+                        description: caCert specifies the CA certificate to verify
+                          the Perses server's certificate
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                      enable:
+                        description: enable determines whether TLS is enabled for
+                          connections to Perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
+                        type: boolean
+                      userCert:
+                        description: userCert specifies the client certificate and
+                          key for mutual TLS (mTLS) authentication
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret
+                              data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap'
+                            || has(self.namespace)
+                    type: object
+                type: object
+              config:
+                description: config specifies the Perses datasource configuration
+                properties:
+                  default:
+                    type: boolean
+                  display:
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  plugin:
+                    description: |-
+                      Plugin will contain the datasource configuration.
+                      The data typed is available in Cue.
+                    properties:
+                      kind:
+                        description: Kind is the type of the plugin (e.g., Panel,
+                          Variable, Datasource, etc.).
+                        type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional
+                          information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it
+                              means the default registry: "perses.dev".'
+                            type: string
+                          version:
+                            description: Version is optional. If not provided, it
+                              means the latest version available in the Perses instance.
+                            type: string
+                        type: object
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - kind
+                    - spec
+                    type: object
+                required:
+                - default
+                - plugin
+                type: object
+              instanceSelector:
+                description: instanceSelector selects Perses instances where this
+                  datasource will be created
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - config
+            type: object
+          status:
+            description: status is the observed state of the PersesGlobalDatasource
+              resource
+            properties:
+              conditions:
+                description: conditions represent the latest observations of the PersesGlobalDatasource
+                  resource state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/manifests/bases/perses-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/perses-operator.clusterserviceversion.yaml
@@ -1276,4 +1276,5 @@ spec:
   provider:
     name: Perses
     url: perses.dev
+  replaces: <OLD_BUNDLE_VERSION>
   version: 0.1.0

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+declare -r PROJECT_ROOT
+declare -r LOCAL_BIN="$PROJECT_ROOT/bin"
+declare -r CSV_FILE=bundle/manifests/perses-operator.clusterserviceversion.yaml
+
+VERSION=${VERSION:-"$(cat "$PROJECT_ROOT/VERSION")"}
+VERSION_REPLACED=${VERSION_REPLACED:-}
+BUNDLE_GEN_FLAGS=${BUNDLE_GEN_FLAGS:-}
+IMG=${IMG:-}
+
+declare -r VERSION BUNDLE_GEN_FLAGS IMG
+
+main() {
+	cd "$PROJECT_ROOT"
+	export PATH="$LOCAL_BIN:$PATH"
+
+	# NOTE: fetch the current version in the bundle csv, which is the
+	# the version that this generation replaces
+
+	local version_replaced="$VERSION_REPLACED"
+
+	[[ -z "$version_replaced" ]] && {
+		version_replaced="$(yq -r .spec.version "$CSV_FILE")"
+	}
+
+	local old_bundle_version="perses-operator.v${version_replaced}"
+
+	# NOTE: if regenerating the same version, preserve the existing replaces value
+	[[ "$version_replaced" == "$VERSION" ]] && {
+		old_bundle_version=$(yq -r .spec.replaces "$CSV_FILE")
+	}
+
+	echo "Generating bundle version $VERSION (replaces: $old_bundle_version)"
+
+	operator-sdk generate kustomize manifests --verbose
+	(cd config/manager && kustomize edit set image "controller=${IMG}")
+
+	local gen_opts=()
+	[[ -n "$BUNDLE_GEN_FLAGS" ]] && {
+		read -r -a gen_opts <<<"$BUNDLE_GEN_FLAGS"
+	}
+
+	kustomize build config/manifests |
+		sed "s|<OLD_BUNDLE_VERSION>|${old_bundle_version}|g" |
+		operator-sdk generate bundle "${gen_opts[@]}"
+
+	# NOTE: operator-sdk may not preserve replaces from piped input, so fix it post-generation
+	[[ "$version_replaced" != "$VERSION" ]] && {
+		sed -e "s|replaces: .*|replaces: $old_bundle_version|g" \
+			"$CSV_FILE" >"$CSV_FILE.tmp"
+		mv "$CSV_FILE.tmp" "$CSV_FILE"
+	}
+
+	tree bundle/
+
+	cat <<-EOF >bundle/ci.yaml
+		---
+		# Use replaces-mode or semver-mode. Once you switch to semver-mode, there is no easy way back.
+		updateGraph: replaces-mode
+		reviewers:
+		  - jgbernalp
+		  - Nexucis
+	EOF
+
+	operator-sdk bundle validate ./bundle \
+		--select-optional name=operatorhub \
+		--optional-values=k8s-version=1.25 \
+		--select-optional suite=operatorframework
+
+	# Reset CSV if only the createdAt timestamp changed
+	if git diff --ignore-matching-lines='createdAt:' --exit-code "$CSV_FILE" >/dev/null 2>&1; then
+		echo "No changes to $(basename "$CSV_FILE") detected; resetting it"
+		git checkout -- "$CSV_FILE"
+	fi
+
+}
+
+main "$@"


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This commit adds the support for replaces-mode in OLM bundle generation Changes include:
- New `scripts/bundle.sh` for bundle generation with replaces field substitution
- Makefile target updates to `bundle`,`bundle-check`, `jsonnet-check`
- CI workflow updates for a separate jsonnet check
- Bundle manifests generated from the current version

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
