### PR TITLE
[BUGFIX] convert ciphers from OpenSSL to IANA format, expected on operands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift/api v0.0.0-20260416215613-f9587f6e7c60
 	github.com/openshift/controller-runtime-common v0.0.0-20260318085703-1812aed6dbd2
+	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5
 	github.com/perses/common v0.30.2
 	github.com/perses/perses v0.53.1
 	github.com/prometheus/client_golang v1.23.2
@@ -112,7 +113,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/nexucis/lamenv v0.5.2 // indirect
-	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/internal/openshift/tls_profile.go
+++ b/internal/openshift/tls_profile.go
@@ -20,6 +20,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,7 +41,12 @@ func FetchTLSProfile(ctx context.Context, c client.Client) (minVersion string, c
 		for i, c := range profileSpec.Ciphers {
 			cipherNames[i] = string(c)
 		}
-		cipherSuites = strings.Join(cipherNames, ",")
+		// The OpenShift API returns cipher names in OpenSSL format (e.g.
+		// "ECDHE-ECDSA-AES128-GCM-SHA256") but Go's crypto/tls and
+		// k8s.io/component-base expect IANA names (e.g.
+		// "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256").
+		ianaCipherNames := libgocrypto.OpenSSLToIANACipherSuites(cipherNames)
+		cipherSuites = strings.Join(ianaCipherNames, ",")
 	}
 
 	return minVersion, cipherSuites, profileSpec, nil

--- a/internal/openshift/tls_profile_test.go
+++ b/internal/openshift/tls_profile_test.go
@@ -51,6 +51,11 @@ func TestFetchTLSProfile_Intermediate(t *testing.T) {
 	assert.NotEmpty(t, profileSpec.Ciphers, "profileSpec.Ciphers should be set")
 	assert.NotEmpty(t, cipherSuites, "cipherSuites should be set for Intermediate profile")
 	assert.NotContains(t, cipherSuites, " ", "cipherSuites should not contain spaces")
+	// OpenSSL-format ciphers must be converted to IANA format
+	assert.NotContains(t, cipherSuites, "ECDHE-ECDSA-AES128-GCM-SHA256",
+		"OpenSSL cipher names should be converted to IANA format")
+	assert.Contains(t, cipherSuites, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		"cipher suites should contain IANA-format names")
 }
 
 func TestFetchTLSProfile_Old(t *testing.T) {
@@ -70,6 +75,10 @@ func TestFetchTLSProfile_Old(t *testing.T) {
 
 	assert.NotEmpty(t, minVersion)
 	assert.NotEmpty(t, cipherSuites)
+	// All Old profile ciphers should be converted to IANA format
+	assert.NotContains(t, cipherSuites, "ECDHE-ECDSA-AES128-GCM-SHA256")
+	assert.Contains(t, cipherSuites, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+	assert.Contains(t, cipherSuites, "TLS_RSA_WITH_3DES_EDE_CBC_SHA")
 }
 
 func TestFetchTLSProfile_Custom(t *testing.T) {
@@ -96,6 +105,74 @@ func TestFetchTLSProfile_Custom(t *testing.T) {
 	assert.Equal(t, "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384", cipherSuites)
 	assert.Equal(t, configv1.VersionTLS13, profileSpec.MinTLSVersion)
 	assert.Equal(t, []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"}, profileSpec.Ciphers)
+}
+
+func TestFetchTLSProfile_OpenSSLCipherNames(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"TLS_AES_128_GCM_SHA256",
+							"TLS_AES_256_GCM_SHA384",
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-RSA-AES128-GCM-SHA256",
+							"ECDHE-ECDSA-AES256-GCM-SHA384",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+							"ECDHE-ECDSA-CHACHA20-POLY1305",
+							"ECDHE-RSA-CHACHA20-POLY1305",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(apiServer).Build()
+	_, cipherSuites, _, err := FetchTLSProfile(context.Background(), c)
+	require.NoError(t, err)
+
+	expected := "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384," +
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384," +
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+	assert.Equal(t, expected, cipherSuites)
+}
+
+func TestFetchTLSProfile_UnsupportedCiphersDropped(t *testing.T) {
+	apiServer := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						MinTLSVersion: configv1.VersionTLS12,
+						Ciphers: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES128-GCM-SHA256",
+							"DHE-RSA-AES256-GCM-SHA384",
+							"ECDHE-RSA-AES256-GCM-SHA384",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(apiServer).Build()
+	_, cipherSuites, _, err := FetchTLSProfile(context.Background(), c)
+	require.NoError(t, err)
+
+	// DHE-RSA ciphers are not supported by Go's crypto/tls and should be
+	// silently dropped by OpenSSLToIANACipherSuites
+	assert.Equal(t,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		cipherSuites)
 }
 
 func TestFetchTLSProfile_NoCiphers(t *testing.T) {


### PR DESCRIPTION
# Description

This PR converts the ciphers returned by the api server TLSProfile from OpenSSL to IANA format, which is the expected format in operands.

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
