### PR TITLE
[BUGFIX] map TLS configuration to the format expected by perses server

### DIFF
--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -1049,7 +1049,7 @@ var _ = Describe("Perses controller", func() {
 					return err
 				}
 				args := found.Spec.Template.Spec.Containers[0].Args
-				if !slices.Contains(args, "--web.tls-min-version=VersionTLS12") {
+				if !slices.Contains(args, "--web.tls-min-version=1.2") {
 					return fmt.Errorf("missing --web.tls-min-version arg in %v", args)
 				}
 				if !slices.Contains(args, "--web.tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384") {
@@ -1119,7 +1119,7 @@ var _ = Describe("Perses controller", func() {
 					return err
 				}
 				args := found.Spec.Template.Spec.Containers[0].Args
-				if !slices.Contains(args, "--web.tls-min-version=VersionTLS12") {
+				if !slices.Contains(args, "--web.tls-min-version=1.2") {
 					return fmt.Errorf("missing --web.tls-min-version arg in %v", args)
 				}
 				if !slices.Contains(args, "--web.tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384") {
@@ -1249,7 +1249,7 @@ var _ = Describe("Perses controller", func() {
 					return err
 				}
 				args := found.Spec.Template.Spec.Containers[0].Args
-				if !slices.Contains(args, "--web.tls-min-version=VersionTLS13") {
+				if !slices.Contains(args, "--web.tls-min-version=1.3") {
 					return fmt.Errorf("missing --web.tls-min-version arg in %v", args)
 				}
 				for _, arg := range args {

--- a/internal/perses/common/perses_args.go
+++ b/internal/perses/common/perses_args.go
@@ -45,7 +45,7 @@ func GetPersesArgs(perses *v1alpha2.Perses, tlsMinVersion, tlsCipherSuites strin
 	// Append cluster-wide TLS settings if operand configuration is enabled
 	if tlsConfigureOperands {
 		if tlsMinVersion != "" {
-			args = append(args, fmt.Sprintf("--web.tls-min-version=%s", tlsMinVersion))
+			args = append(args, fmt.Sprintf("--web.tls-min-version=%s", k8sToPersesTLSVersion(tlsMinVersion)))
 		}
 		if tlsCipherSuites != "" {
 			args = append(args, fmt.Sprintf("--web.tls-cipher-suites=%s", tlsCipherSuites))
@@ -66,4 +66,18 @@ func GetPersesArgs(perses *v1alpha2.Perses, tlsMinVersion, tlsCipherSuites strin
 	args = append(args, perses.Spec.Args...)
 
 	return args
+}
+
+var k8sToPersesVersion = map[string]string{
+	"VersionTLS10": "1.0",
+	"VersionTLS11": "1.1",
+	"VersionTLS12": "1.2",
+	"VersionTLS13": "1.3",
+}
+
+func k8sToPersesTLSVersion(version string) string {
+	if v, ok := k8sToPersesVersion[version]; ok {
+		return v
+	}
+	return version
 }

--- a/internal/perses/common/perses_args_test.go
+++ b/internal/perses/common/perses_args_test.go
@@ -117,7 +117,7 @@ var _ = Describe("GetPersesArgs", func() {
 				Spec:       v1alpha2.PersesSpec{},
 			},
 			"VersionTLS13", "", true,
-			[]string{configArg, "--web.tls-min-version=VersionTLS13"},
+			[]string{configArg, "--web.tls-min-version=1.3"},
 		),
 		Entry("Args with TLS cipher suites when configure operands is true",
 			&v1alpha2.Perses{
@@ -133,7 +133,7 @@ var _ = Describe("GetPersesArgs", func() {
 				Spec:       v1alpha2.PersesSpec{},
 			},
 			"VersionTLS12", "TLS_AES_128_GCM_SHA256", true,
-			[]string{configArg, "--web.tls-min-version=VersionTLS12", "--web.tls-cipher-suites=TLS_AES_128_GCM_SHA256"},
+			[]string{configArg, "--web.tls-min-version=1.2", "--web.tls-cipher-suites=TLS_AES_128_GCM_SHA256"},
 		),
 		Entry("TLS values set but configure operands is false - no TLS args added",
 			&v1alpha2.Perses{

--- a/test/e2e/perses-tls-operands/02-assert.yaml
+++ b/test/e2e/perses-tls-operands/02-assert.yaml
@@ -6,7 +6,7 @@ commands:
       ARGS=$(kubectl get statefulset perses-tls-test -n $NAMESPACE \
         -o jsonpath='{.spec.template.spec.containers[0].args}')
       echo "StatefulSet args: $ARGS"
-      echo "$ARGS" | grep -q "web.tls-min-version=VersionTLS12" || {
+      echo "$ARGS" | grep -q "web.tls-min-version=1.2" || {
         echo "FAIL: --web.tls-min-version not found in args: $ARGS"
         exit 1
       }


### PR DESCRIPTION
# Description

Map tls version to the format expected by the echo server in the perses backend

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
