### PR TITLE
[IGNORE] update perses default image to v0.53.1

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -48,7 +48,7 @@ spec:
         privateKeyPath: tls.key
 
   # Optional container image to use as the Perses server operand
-  image: docker.io/persesdev/perses:v0.53.0
+  image: docker.io/persesdev/perses:v0.53.1
 
   # Optional service configuration
   service:
@@ -365,7 +365,7 @@ metadata:
   name: perses
   namespace: monitoring
 spec:
-  image: docker.io/persesdev/perses:v0.53.0
+  image: docker.io/persesdev/perses:v0.53.1
   config:
     database:
       file:

--- a/internal/operator/defaults.go
+++ b/internal/operator/defaults.go
@@ -15,7 +15,7 @@ package operator
 
 const (
 	// DefaultPersesVersion is the default image tag for Perses.
-	DefaultPersesVersion = "v0.53.0"
+	DefaultPersesVersion = "v0.53.1"
 	// DefaultPersesBaseImage is the base container registry address for Perses.
 	DefaultPersesBaseImage = "docker.io/persesdev/perses"
 	// DefaultPersesImage is the default image used for Perses Deployment or StatefulSet operands.


### PR DESCRIPTION
# Description

Update the perses operand default image to v0.53.1

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
