### PR TITLE
[BUGFIX] escape reserved words in CEL validation expressions

### DIFF
--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -245,7 +245,7 @@ const (
 
 // SecretSource configuration for a perses secret source
 // +kubebuilder:validation:XValidation:rule="self.type != 'secret' && self.type != 'configmap' || has(self.name)",message="name is required when type is secret or configmap"
-// +kubebuilder:validation:XValidation:rule="self.type != 'secret' && self.type != 'configmap' || has(self.namespace)",message="namespace is required when type is secret or configmap"
+// +kubebuilder:validation:XValidation:rule="self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)",message="namespace is required when type is secret or configmap"
 type SecretSource struct {
 	// type specifies the source type for secret data (secret, configmap, or file)
 	// +required

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3891,7 +3891,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -3970,7 +3970,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -4021,7 +4021,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -4077,7 +4077,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:
@@ -6267,7 +6267,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   enable:
                     description: enable determines whether TLS is enabled for connections
                       to Perses
@@ -6321,7 +6321,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                 type: object
               tolerations:
                 description: tolerations allow pods to schedule onto nodes with matching
@@ -9571,7 +9571,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -9650,7 +9650,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -9701,7 +9701,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -9757,7 +9757,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:
@@ -10029,7 +10029,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -10108,7 +10108,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -10159,7 +10159,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -10215,7 +10215,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/bundle/manifests/perses.dev_perses.yaml
+++ b/bundle/manifests/perses.dev_perses.yaml
@@ -3880,7 +3880,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -3959,7 +3959,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -4010,7 +4010,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -4066,7 +4066,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:
@@ -6256,7 +6256,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   enable:
                     description: enable determines whether TLS is enabled for connections
                       to Perses
@@ -6310,7 +6310,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                 type: object
               tolerations:
                 description: tolerations allow pods to schedule onto nodes with matching

--- a/bundle/manifests/perses.dev_persesdatasources.yaml
+++ b/bundle/manifests/perses.dev_persesdatasources.yaml
@@ -393,7 +393,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -472,7 +472,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -523,7 +523,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -579,7 +579,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/bundle/manifests/perses.dev_persesglobaldatasources.yaml
+++ b/bundle/manifests/perses.dev_persesglobaldatasources.yaml
@@ -101,7 +101,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -180,7 +180,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -231,7 +231,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -287,7 +287,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -3869,7 +3869,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -3948,7 +3948,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -3999,7 +3999,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -4055,7 +4055,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:
@@ -6245,7 +6245,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   enable:
                     description: enable determines whether TLS is enabled for connections
                       to Perses
@@ -6299,7 +6299,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                 type: object
               tolerations:
                 description: tolerations allow pods to schedule onto nodes with matching

--- a/config/crd/bases/perses.dev_persesdatasources.yaml
+++ b/config/crd/bases/perses.dev_persesdatasources.yaml
@@ -392,7 +392,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -471,7 +471,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -522,7 +522,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -578,7 +578,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/config/crd/bases/perses.dev_persesglobaldatasources.yaml
+++ b/config/crd/bases/perses.dev_persesglobaldatasources.yaml
@@ -90,7 +90,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication
                       for the Perses client
@@ -169,7 +169,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections
                       to Perses
@@ -220,7 +220,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for
                           connections to Perses
@@ -276,7 +276,7 @@ spec:
                             || has(self.name)
                         - message: namespace is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap'
-                            || has(self.namespace)
+                            || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -3660,7 +3660,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication for the Perses client
                     properties:
@@ -3733,7 +3733,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections to Perses
                     properties:
@@ -3779,7 +3779,7 @@ spec:
                         - message: name is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                         - message: namespace is required when type is secret or configmap
-                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for connections to Perses
                         type: boolean
@@ -3830,7 +3830,7 @@ spec:
                         - message: name is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                         - message: namespace is required when type is secret or configmap
-                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                     type: object
                 type: object
               config:
@@ -5886,7 +5886,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   enable:
                     description: enable determines whether TLS is enabled for connections to Perses
                     type: boolean
@@ -5937,7 +5937,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                 type: object
               tolerations:
                 description: tolerations allow pods to schedule onto nodes with matching taints

--- a/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesdatasourcesCustomResourceDefinition.yaml
@@ -373,7 +373,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   kubernetesAuth:
                     description: kubernetesAuth enables Kubernetes native authentication for the Perses client
                     properties:
@@ -446,7 +446,7 @@ spec:
                     - message: name is required when type is secret or configmap
                       rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                     - message: namespace is required when type is secret or configmap
-                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                   tls:
                     description: tls provides TLS/SSL configuration for secure connections to Perses
                     properties:
@@ -492,7 +492,7 @@ spec:
                         - message: name is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                         - message: namespace is required when type is secret or configmap
-                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                       enable:
                         description: enable determines whether TLS is enabled for connections to Perses
                         type: boolean
@@ -543,7 +543,7 @@ spec:
                         - message: name is required when type is secret or configmap
                           rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
                         - message: namespace is required when type is secret or configmap
-                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.namespace)
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
                     type: object
                 type: object
               config:

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -3818,7 +3818,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -3903,7 +3903,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -3954,7 +3954,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           },
@@ -4010,7 +4010,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           }
@@ -6287,7 +6287,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -6343,7 +6343,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       }

--- a/jsonnet/generated/perses.dev_persesdatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesdatasources-crd.json
@@ -446,7 +446,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -531,7 +531,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -582,7 +582,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           },
@@ -638,7 +638,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           }

--- a/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
+++ b/jsonnet/generated/perses.dev_persesglobaldatasources-crd.json
@@ -89,7 +89,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -174,7 +174,7 @@
                           },
                           {
                             "message": "namespace is required when type is secret or configmap",
-                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                            "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                           }
                         ]
                       },
@@ -225,7 +225,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           },
@@ -281,7 +281,7 @@
                               },
                               {
                                 "message": "namespace is required when type is secret or configmap",
-                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.namespace)"
+                                "rule": "self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)"
                               }
                             ]
                           }


### PR DESCRIPTION
# Description

This PR escapes the `namespace` field name as in older k8s versions this conflicts with CEL reserved words

https://redhat.atlassian.net/browse/OU-1375

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
