### PR TITLE
[IGNORE]: skip OperatorHub PR creation when an open PR already exists

### DIFF
--- a/.github/workflows/operator-hub-release.yaml
+++ b/.github/workflows/operator-hub-release.yaml
@@ -180,7 +180,7 @@ jobs:
           cp -R tmp/bundle/tests operators/${OPERATOR_NAME}/${VERSION}/
           rm -rf tmp/
 
-      - name: Create pull request
+      - name: Create or update pull request
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           VERSION: ${{ steps.prepare_release.outputs.version }}
@@ -190,12 +190,37 @@ jobs:
 
           message="operator ${OPERATOR_NAME} (${VERSION})"
           branch="update-${OPERATOR_NAME}-to-${VERSION}"
+          head_branch="${{ env.BOT_USER }}:${branch}"
+          target_repo="${{ inputs.org }}/${{ inputs.repo }}"
 
-          git checkout -b $branch
+          git checkout -B "${branch}"
           git add -A
-          git commit -s -m "$message"
-          git push -f --set-upstream origin $branch
-          gh pr create --title "$message" \
-                       --body "Release ${OPERATOR_NAME} \`${VERSION}\`." \
-                       --repo ${{ inputs.org }}/${{ inputs.repo }} \
-                       --base main
+          if git diff --cached --quiet; then
+            echo "No operator bundle changes to commit."
+          else
+            git commit -s -m "${message}"
+          fi
+          git push -f --set-upstream origin "${branch}"
+
+          existing_pr="$(
+            gh pr list \
+              --repo "${target_repo}" \
+              --head "${head_branch}" \
+              --base main \
+              --state open \
+              --json url \
+              --jq '.[0].url // empty'
+          )"
+
+          if [ -n "${existing_pr}" ]; then
+            echo "Open pull request already exists; updated branch ${head_branch}."
+            echo "${existing_pr}"
+            exit 0
+          fi
+
+          gh pr create \
+            --title "${message}" \
+            --body "Release ${OPERATOR_NAME} \`${VERSION}\`." \
+            --head "${head_branch}" \
+            --repo "${target_repo}" \
+            --base main

--- a/bundle/ci.yaml
+++ b/bundle/ci.yaml
@@ -4,3 +4,4 @@ updateGraph: replaces-mode
 reviewers:
   - jgbernalp
   - Nexucis
+  - slashpai

--- a/bundle/manifests/perses-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/perses-operator.clusterserviceversion.yaml
@@ -1992,7 +1992,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: docker.io/persesdev/perses-operator:v0.4.0
-    createdAt: "2026-05-21T15:46:55Z"
+    createdAt: "2026-05-22T10:12:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.42.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/perses/perses-operator
@@ -2540,6 +2540,8 @@ spec:
     name: Gabriel Bernal
   - email: augustin.husson@amadeus.com
     name: Augustin Husson
+  - email: janantha@redhat.com
+    name: Jayapriya Pai
   maturity: alpha
   minKubeVersion: 1.25.0
   provider:

--- a/config/manifests/bases/perses-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/perses-operator.clusterserviceversion.yaml
@@ -518,6 +518,8 @@ spec:
     name: Gabriel Bernal
   - email: augustin.husson@amadeus.com
     name: Augustin Husson
+  - email: janantha@redhat.com
+    name: Jayapriya Pai
   maturity: alpha
   minKubeVersion: 1.25.0
   provider:

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -87,6 +87,7 @@ main() {
 		reviewers:
 		  - jgbernalp
 		  - Nexucis
+		  - slashpai
 	EOF
 
 	operator-sdk bundle validate ./bundle \


### PR DESCRIPTION
Force-push the update branch and exit successfully when persesbot:update-perses-operator-to-<version> already has an open PR against k8s-operatorhub/community-operators.


#407 fixed the issue to update branch but it still tried to create new PR which resulted in failure

it updated branch correctly https://github.com/k8s-operatorhub/community-operators/pull/8117

https://github.com/perses/perses-operator/actions/runs/26280482618/job/77355143513

This change is to skip creating PR if already exists and it updates only branch

Also adding myself to reviewer list for operatorhub submissions

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
