### PR TITLE
[BUGFIX] Sync resources to all pods instead of service

### DIFF
--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -24,6 +24,8 @@ import (
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
 
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,14 +89,31 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 }
 
 func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboard *persesv1alpha2.PersesDashboard) (*ctrl.Result, common.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonConnectionFailed)
 	}
 
-	_, err = persesClient.Project().Get(dashboard.Namespace)
+	var errs []error
+	reason := common.ReasonBackendError
+	for _, persesClient := range clients {
+		if rsn, err := r.syncDashboardToClient(ctx, persesClient, dashboard); err != nil {
+			reason = rsn
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithErrorAndReason(errors.Join(errs...), reason)
+	}
+
+	res, err := subreconciler.ContinueReconciling()
+	return res, "", err
+}
+
+func (r *PersesDashboardReconciler) syncDashboardToClient(ctx context.Context, persesClient v1.ClientInterface, dashboard *persesv1alpha2.PersesDashboard) (common.ConditionStatusReason, error) {
+	_, err := persesClient.Project().Get(dashboard.Namespace)
 
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
@@ -112,13 +131,13 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create perses project: %s", dashboard.Namespace)
-				return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+				return common.ReasonBackendError, err
 			}
 
 			dlog.Infof("Project created: %s", dashboard.Namespace)
 		} else {
 			dlog.WithError(err).Errorf("project error: %s", dashboard.Namespace)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+			return common.ReasonBackendError, err
 		}
 	}
 
@@ -137,48 +156,41 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
 	if err != nil && !notFound {
-		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+		return common.ReasonBackendError, err
 	}
 
 	if !notFound && common.DashboardInSync(existing, persesDashboard) {
 		dlog.Debugf("Dashboard already in sync: %s", dashboard.Name)
-		res, err := subreconciler.ContinueReconciling()
-		return res, "", err
+		return "", nil
 	}
 
 	if validateErr := validate.New(persesClient.RESTClient()).Dashboard(persesDashboard); validateErr != nil {
 		if common.IsClientError(validateErr) {
 			dlog.WithError(validateErr).Errorf("Dashboard validation failed: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(
-				fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr),
-				common.ReasonValidationFailed,
-			)
+			return common.ReasonValidationFailed, fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr)
 		}
 		dlog.WithError(validateErr).Errorf("Dashboard validation request failed: %s", dashboard.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("dashboard %q validation request failed: %w", dashboard.Name, validateErr),
-			common.ReasonBackendError,
-		)
+		return common.ReasonBackendError, fmt.Errorf("dashboard %q validation request failed: %w", dashboard.Name, validateErr)
 	}
 
 	if notFound {
 		_, err = persesClient.Dashboard(dashboard.Namespace).Create(persesDashboard)
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to create dashboard: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+			return common.ReasonBackendError, err
 		}
 		dlog.Infof("Dashboard created: %s", dashboard.Name)
-	} else {
-		_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
-		}
-		dlog.Infof("Dashboard updated: %s", dashboard.Name)
+		return "", nil
 	}
 
-	res, err := subreconciler.ContinueReconciling()
-	return res, "", err
+	_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
+	if err != nil {
+		dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
+		return common.ReasonBackendError, err
+	}
+
+	dlog.Infof("Dashboard updated: %s", dashboard.Name)
+	return "", nil
 }
 
 func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Context, _ ctrl.Request, dashbboardNamespace string, dashboardName string) (*ctrl.Result, error) {
@@ -205,35 +217,46 @@ func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Co
 }
 
 func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboardNamespace string, dashboardName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithError(err)
 	}
 
-	_, err = persesClient.Project().Get(dashboardNamespace)
+	var errs []error
+	for _, persesClient := range clients {
+		if err := r.deleteDashboardFromClient(persesClient, dashboardNamespace, dashboardName); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithError(errors.Join(errs...))
+	}
+
+	return subreconciler.ContinueReconciling()
+}
+
+func (r *PersesDashboardReconciler) deleteDashboardFromClient(persesClient v1.ClientInterface, dashboardNamespace string, dashboardName string) error {
+	_, err := persesClient.Project().Get(dashboardNamespace)
 	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			return nil
+		}
 		dlog.WithError(err).Errorf("project error: %s", dashboardNamespace)
-
-		return subreconciler.RequeueWithError(err)
+		return err
 	}
 
 	err = persesClient.Dashboard(dashboardNamespace).Delete(dashboardName)
-
-	// Ignore NotFound — the resource may have already been deleted from Perses directly.
-	// Any other error means the delete failed and should be retried.
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			dlog.Infof("Dashboard not found: %s", dashboardName)
-			return subreconciler.ContinueReconciling()
+			return nil
 		}
 		dlog.WithError(err).Errorf("Failed to delete dashboard: %s", dashboardName)
-		return subreconciler.RequeueWithError(err)
+		return err
 	}
 
 	dlog.Infof("Dashboard deleted: %s", dashboardName)
-
-	return subreconciler.ContinueReconciling()
+	return nil
 }

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -24,6 +24,8 @@ import (
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
 
+	v1 "github.com/perses/perses/pkg/client/api/v1"
+
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,13 +89,32 @@ func (r *PersesDashboardReconciler) reconcileDashboardInAllInstances(ctx context
 }
 
 func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboard *persesv1alpha2.PersesDashboard) (*ctrl.Result, common.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonConnectionFailed)
 	}
 
-	_, err = persesClient.Project().Get(dashboard.Namespace)
+	var errs []error
+	reason := common.ReasonBackendError
+	for _, persesClient := range clients {
+		if rsn, err := r.syncDashboardToClient(ctx, persesClient, dashboard); err != nil {
+			reason = rsn
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithErrorAndReason(errors.Join(errs...), reason)
+	}
+
+	res, err := subreconciler.ContinueReconciling()
+	return res, "", err
+}
+
+func (r *PersesDashboardReconciler) syncDashboardToClient(ctx context.Context, persesClient v1.ClientInterface, dashboard *persesv1alpha2.PersesDashboard) (common.ConditionStatusReason, error) {
+	_, err := persesClient.Project().Get(dashboard.Namespace)
+
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			_, err := persesClient.Project().Create(&persesv1.Project{
@@ -107,15 +128,16 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 					},
 				},
 			})
+
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create perses project: %s", dashboard.Namespace)
-				return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+				return common.ReasonBackendError, err
 			}
 
 			dlog.Infof("Project created: %s", dashboard.Namespace)
 		} else {
 			dlog.WithError(err).Errorf("project error: %s", dashboard.Namespace)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+			return common.ReasonBackendError, err
 		}
 	}
 
@@ -134,48 +156,41 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
 	if err != nil && !notFound {
-		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+		return common.ReasonBackendError, err
 	}
 
 	if !notFound && common.DashboardInSync(existing, persesDashboard) {
 		dlog.Debugf("Dashboard already in sync: %s", dashboard.Name)
-		res, err := subreconciler.ContinueReconciling()
-		return res, "", err
+		return "", nil
 	}
 
 	if validateErr := validate.New(persesClient.RESTClient()).Dashboard(persesDashboard); validateErr != nil {
 		if common.IsClientError(validateErr) {
 			dlog.WithError(validateErr).Errorf("Dashboard validation failed: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(
-				fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr),
-				common.ReasonValidationFailed,
-			)
+			return common.ReasonValidationFailed, fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr)
 		}
 		dlog.WithError(validateErr).Errorf("Dashboard validation request failed: %s", dashboard.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("dashboard %q validation request failed: %w", dashboard.Name, validateErr),
-			common.ReasonBackendError,
-		)
+		return common.ReasonBackendError, fmt.Errorf("dashboard %q validation request failed: %w", dashboard.Name, validateErr)
 	}
 
 	if notFound {
 		_, err = persesClient.Dashboard(dashboard.Namespace).Create(persesDashboard)
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to create dashboard: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+			return common.ReasonBackendError, err
 		}
 		dlog.Infof("Dashboard created: %s", dashboard.Name)
-	} else {
-		_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
-		}
-		dlog.Infof("Dashboard updated: %s", dashboard.Name)
+		return "", nil
 	}
 
-	res, err := subreconciler.ContinueReconciling()
-	return res, "", err
+	_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
+	if err != nil {
+		dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
+		return common.ReasonBackendError, err
+	}
+
+	dlog.Infof("Dashboard updated: %s", dashboard.Name)
+	return "", nil
 }
 
 func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Context, _ ctrl.Request, dashbboardNamespace string, dashboardName string) (*ctrl.Result, error) {
@@ -202,32 +217,46 @@ func (r *PersesDashboardReconciler) deleteDashboardInAllInstances(ctx context.Co
 }
 
 func (r *PersesDashboardReconciler) deleteDashboard(ctx context.Context, perses persesv1alpha2.Perses, dashboardNamespace string, dashboardName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithError(err)
 	}
 
-	_, err = persesClient.Project().Get(dashboardNamespace)
-	if err != nil {
-		dlog.WithError(err).Errorf("project error: %s", dashboardNamespace)
+	var errs []error
+	for _, persesClient := range clients {
+		if err := r.deleteDashboardFromClient(persesClient, dashboardNamespace, dashboardName); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
-		return subreconciler.RequeueWithError(err)
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithError(errors.Join(errs...))
+	}
+
+	return subreconciler.ContinueReconciling()
+}
+
+func (r *PersesDashboardReconciler) deleteDashboardFromClient(persesClient v1.ClientInterface, dashboardNamespace string, dashboardName string) error {
+	_, err := persesClient.Project().Get(dashboardNamespace)
+	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			return nil
+		}
+		dlog.WithError(err).Errorf("project error: %s", dashboardNamespace)
+		return err
 	}
 
 	err = persesClient.Dashboard(dashboardNamespace).Delete(dashboardName)
-	// Ignore NotFound — the resource may have already been deleted from Perses directly.
-	// Any other error means the delete failed and should be retried.
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			dlog.Infof("Dashboard not found: %s", dashboardName)
-			return subreconciler.ContinueReconciling()
+			return nil
 		}
 		dlog.WithError(err).Errorf("Failed to delete dashboard: %s", dashboardName)
-		return subreconciler.RequeueWithError(err)
+		return err
 	}
 
 	dlog.Infof("Dashboard deleted: %s", dashboardName)
-
-	return subreconciler.ContinueReconciling()
+	return nil
 }

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	logger "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -237,6 +238,28 @@ func (r *PersesDashboardReconciler) findDashboardsForPerses(ctx context.Context,
 	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesDashboardList"))
 }
 
+// findDashboardsForPod returns reconcile requests for all PersesDashboards
+// when a pod belonging to a Perses instance becomes ready. This ensures
+// resources are re-synced to pods that restarted and lost their state.
+func (r *PersesDashboardReconciler) findDashboardsForPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	instanceName := pod.Labels["app.kubernetes.io/instance"]
+	if instanceName == "" {
+		return nil
+	}
+
+	managedBy := pod.Labels["app.kubernetes.io/managed-by"]
+	if managedBy != "perses-operator" {
+		return nil
+	}
+
+	return r.findDashboardsForPerses(ctx, obj)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // It watches PersesDashboard resources and also watches Perses instances
 // to trigger re-reconciliation of all dashboards when a Perses instance becomes
@@ -251,6 +274,11 @@ func (r *PersesDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findDashboardsForPerses),
 			builder.WithPredicates(common.PersesAvailabilityPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findDashboardsForPod),
+			builder.WithPredicates(common.PodReadinessPredicate()),
 		).
 		Complete(r)
 }

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -67,6 +67,7 @@ var log = logger.WithField("module", "perses_dashboards_controller")
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 func (r *PersesDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
 	objKey := req.String()

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -90,14 +90,31 @@ func (r *PersesDatasourceReconciler) reconcileDatasourcesInAllInstances(ctx cont
 }
 
 func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasource *persesv1alpha2.PersesDatasource) (*ctrl.Result, persescommon.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonConnectionFailed)
 	}
 
-	_, err = persesClient.Project().Get(datasource.Namespace)
+	var errs []error
+	reason := persescommon.ReasonBackendError
+	for _, persesClient := range clients {
+		if rsn, err := r.syncDatasourceToClient(ctx, persesClient, datasource); err != nil {
+			reason = rsn
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithErrorAndReason(errors.Join(errs...), reason)
+	}
+
+	res, err := subreconciler.ContinueReconciling()
+	return res, "", err
+}
+
+func (r *PersesDatasourceReconciler) syncDatasourceToClient(ctx context.Context, persesClient v1.ClientInterface, datasource *persesv1alpha2.PersesDatasource) (persescommon.ConditionStatusReason, error) {
+	_, err := persesClient.Project().Get(datasource.Namespace)
 
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
@@ -115,13 +132,13 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 
 			if err != nil {
 				dlog.WithError(err).Errorf("Failed to create perses project: %s", datasource.Namespace)
-				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+				return persescommon.ReasonBackendError, err
 			}
 
 			dlog.Infof("Project created: %s", datasource.Namespace)
 		} else {
 			dlog.WithError(err).Errorf("project error: %s", datasource.Namespace)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+			return persescommon.ReasonBackendError, err
 		}
 	}
 
@@ -140,28 +157,21 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
 	if err != nil && !notFound {
-		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+		return persescommon.ReasonBackendError, err
 	}
 
 	if !notFound && persescommon.DatasourceInSync(existing, datasourceWithName) {
 		dlog.Debugf("Datasource already in sync: %s", datasource.Name)
-		res, err := subreconciler.ContinueReconciling()
-		return res, "", err
+		return "", nil
 	}
 
 	if validateErr := validate.New(persesClient.RESTClient()).Datasource(datasourceWithName); validateErr != nil {
 		if persescommon.IsClientError(validateErr) {
 			dlog.WithError(validateErr).Errorf("Datasource validation failed: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(
-				fmt.Errorf("datasource %q failed server-side validation: %w", datasource.Name, validateErr),
-				persescommon.ReasonValidationFailed,
-			)
+			return persescommon.ReasonValidationFailed, fmt.Errorf("datasource %q failed server-side validation: %w", datasource.Name, validateErr)
 		}
 		dlog.WithError(validateErr).Errorf("Datasource validation request failed: %s", datasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("datasource %q validation request failed: %w", datasource.Name, validateErr),
-			persescommon.ReasonBackendError,
-		)
+		return persescommon.ReasonBackendError, fmt.Errorf("datasource %q validation request failed: %w", datasource.Name, validateErr)
 	}
 
 	// Sync secret only after validation passes to avoid orphaned secrets
@@ -169,7 +179,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		_, reason, err := r.syncPersesSecret(ctx, persesClient, datasource)
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to create datasource secret: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, reason)
+			return reason, err
 		}
 	}
 
@@ -177,20 +187,20 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		_, err = persesClient.Datasource(datasource.Namespace).Create(datasourceWithName)
 		if err != nil {
 			dlog.WithError(err).Errorf("Failed to create datasource: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+			return persescommon.ReasonBackendError, err
 		}
 		dlog.Infof("Datasource created: %s", datasource.Name)
-	} else {
-		_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-		}
-		dlog.Infof("Datasource updated: %s", datasource.Name)
+		return "", nil
 	}
 
-	res, err := subreconciler.ContinueReconciling()
-	return res, "", err
+	_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
+	if err != nil {
+		dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
+		return persescommon.ReasonBackendError, err
+	}
+
+	dlog.Infof("Datasource updated: %s", datasource.Name)
+	return "", nil
 }
 
 // creates/updates a Perses Secret with configuration,
@@ -402,51 +412,60 @@ func (r *PersesDatasourceReconciler) deleteDatasourceInAllInstances(ctx context.
 }
 
 func (r *PersesDatasourceReconciler) deleteDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasourceNamespace string, datasourceName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		dlog.WithError(err).Error("Failed to create perses rest client")
+		dlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithError(err)
 	}
 
-	_, err = persesClient.Project().Get(datasourceNamespace)
+	var errs []error
+	for _, persesClient := range clients {
+		if err := r.deleteDatasourceFromClient(persesClient, datasourceNamespace, datasourceName); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithError(errors.Join(errs...))
+	}
+
+	return subreconciler.ContinueReconciling()
+}
+
+func (r *PersesDatasourceReconciler) deleteDatasourceFromClient(persesClient v1.ClientInterface, datasourceNamespace string, datasourceName string) error {
+	_, err := persesClient.Project().Get(datasourceNamespace)
 	if err != nil {
+		if errors.Is(err, perseshttp.RequestNotFoundError) {
+			return nil
+		}
 		dlog.WithError(err).Errorf("project error: %s", datasourceNamespace)
-
-		return subreconciler.RequeueWithError(err)
+		return err
 	}
 
-	// Ignore NotFound — the resource may have already been deleted from Perses directly.
-	// Any other error means the delete failed and should be retried.
-	// Secret delete is attempted regardless of whether the datasource was found or not.
 	err = persesClient.Datasource(datasourceNamespace).Delete(datasourceName)
-
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			dlog.Infof("Datasource not found: %s", datasourceName)
 		} else {
 			dlog.WithError(err).Errorf("Failed to delete datasource: %s", datasourceName)
-			return subreconciler.RequeueWithError(err)
+			return err
 		}
 	} else {
 		dlog.Infof("Datasource deleted: %s", datasourceName)
 	}
 
 	secretName := datasourceName + persescommon.SecretNameSuffix
-
 	err = persesClient.Secret(datasourceNamespace).Delete(secretName)
-
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			dlog.Infof("Secret not found: %s", secretName)
 		} else {
 			dlog.WithError(err).Errorf("Failed to delete secret: %s", secretName)
-			return subreconciler.RequeueWithError(err)
+			return err
 		}
 	} else {
 		dlog.Infof("Secret deleted: %s", secretName)
 	}
 
-	return subreconciler.ContinueReconciling()
+	return nil
 }

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	logger "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -237,6 +238,25 @@ func (r *PersesDatasourceReconciler) findDatasourcesForPerses(ctx context.Contex
 	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesDatasourceList"))
 }
 
+func (r *PersesDatasourceReconciler) findDatasourcesForPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	instanceName := pod.Labels["app.kubernetes.io/instance"]
+	if instanceName == "" {
+		return nil
+	}
+
+	managedBy := pod.Labels["app.kubernetes.io/managed-by"]
+	if managedBy != "perses-operator" {
+		return nil
+	}
+
+	return r.findDatasourcesForPerses(ctx, obj)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // It watches PersesDatasource resources and also watches Perses instances
 // to trigger re-reconciliation of all datasources when a Perses instance becomes
@@ -251,6 +271,11 @@ func (r *PersesDatasourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findDatasourcesForPerses),
 			builder.WithPredicates(common.PersesAvailabilityPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findDatasourcesForPod),
+			builder.WithPredicates(common.PodReadinessPredicate()),
 		).
 		Complete(r)
 }

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -67,6 +67,7 @@ var log = logger.WithField("module", "perses_datasource_controller")
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=persesdatasources/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=watch;get
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 func (r *PersesDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
 	objKey := req.String()

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -88,14 +88,30 @@ func (r *PersesGlobalDatasourceReconciler) reconcileGlobalDatasourcesInAllInstan
 }
 
 func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx context.Context, perses persesv1alpha2.Perses, globaldatasource *persesv1alpha2.PersesGlobalDatasource) (*ctrl.Result, persescommon.ConditionStatusReason, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		gdlog.WithError(err).Error("Failed to create perses rest client")
+		gdlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonConnectionFailed)
-
 	}
 
+	var errs []error
+	reason := persescommon.ReasonBackendError
+	for _, persesClient := range clients {
+		if rsn, err := r.syncGlobalDatasourceToClient(ctx, persesClient, globaldatasource); err != nil {
+			reason = rsn
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithErrorAndReason(errors.Join(errs...), reason)
+	}
+
+	res, err := subreconciler.ContinueReconciling()
+	return res, "", err
+}
+
+func (r *PersesGlobalDatasourceReconciler) syncGlobalDatasourceToClient(ctx context.Context, persesClient v1.ClientInterface, globaldatasource *persesv1alpha2.PersesGlobalDatasource) (persescommon.ConditionStatusReason, error) {
 	globalDatasourceWithName := &persesv1.GlobalDatasource{
 		Kind: persesv1.KindGlobalDatasource,
 		Metadata: persesv1.Metadata{
@@ -109,29 +125,21 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
 	if err != nil && !notFound {
-		res, err := subreconciler.RequeueWithError(err)
-		return res, persescommon.ReasonBackendError, err
+		return persescommon.ReasonBackendError, err
 	}
 
 	if !notFound && persescommon.GlobalDatasourceInSync(existing, globalDatasourceWithName) {
 		gdlog.Debugf("GlobalDatasource already in sync: %s", globaldatasource.Name)
-		res, err := subreconciler.ContinueReconciling()
-		return res, "", err
+		return "", nil
 	}
 
 	if validateErr := validate.New(persesClient.RESTClient()).GlobalDatasource(globalDatasourceWithName); validateErr != nil {
 		if persescommon.IsClientError(validateErr) {
 			gdlog.WithError(validateErr).Errorf("GlobalDatasource validation failed: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(
-				fmt.Errorf("global datasource %q failed server-side validation: %w", globaldatasource.Name, validateErr),
-				persescommon.ReasonValidationFailed,
-			)
+			return persescommon.ReasonValidationFailed, fmt.Errorf("global datasource %q failed server-side validation: %w", globaldatasource.Name, validateErr)
 		}
 		gdlog.WithError(validateErr).Errorf("GlobalDatasource validation request failed: %s", globaldatasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("global datasource %q validation request failed: %w", globaldatasource.Name, validateErr),
-			persescommon.ReasonBackendError,
-		)
+		return persescommon.ReasonBackendError, fmt.Errorf("global datasource %q validation request failed: %w", globaldatasource.Name, validateErr)
 	}
 
 	// Sync secret only after validation passes to avoid orphaned secrets
@@ -139,7 +147,7 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 		_, reason, err := r.syncPersesGlobalSecret(ctx, persesClient, globaldatasource)
 		if err != nil {
 			gdlog.WithError(err).Errorf("Failed to create globaldatasource secret: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, reason)
+			return reason, err
 		}
 	}
 
@@ -147,20 +155,20 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 		_, err = persesClient.GlobalDatasource().Create(globalDatasourceWithName)
 		if err != nil {
 			gdlog.WithError(err).Errorf("Failed to create globaldatasource: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+			return persescommon.ReasonBackendError, err
 		}
 		gdlog.Infof("GlobalDatasource created: %s", globaldatasource.Name)
-	} else {
-		_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
-		if err != nil {
-			gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-		}
-		gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
+		return "", nil
 	}
 
-	res, err := subreconciler.ContinueReconciling()
-	return res, "", err
+	_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
+	if err != nil {
+		gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
+		return persescommon.ReasonBackendError, err
+	}
+
+	gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
+	return "", nil
 }
 
 // creates/updates a Perses Global Secret with configuration,
@@ -385,43 +393,51 @@ func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasourceInAllInstances(
 }
 
 func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasource(ctx context.Context, perses persesv1alpha2.Perses, datasourceName string) (*ctrl.Result, error) {
-	persesClient, err := r.ClientFactory.CreateClient(ctx, r.APIReader, perses)
-
+	clients, err := r.ClientFactory.CreateClientsForAllPods(ctx, r.APIReader, perses)
 	if err != nil {
-		gdlog.WithError(err).Error("Failed to create perses rest client")
+		gdlog.WithError(err).Error("Failed to create perses rest clients")
 		return subreconciler.RequeueWithError(err)
 	}
 
-	// Ignore NotFound — the resource may have already been deleted from Perses directly.
-	// Any other error means the delete failed and should be retried.
-	// Secret delete is attempted regardless of whether the datasource was found or not.
-	err = persesClient.GlobalDatasource().Delete(datasourceName)
+	var errs []error
+	for _, persesClient := range clients {
+		if err := r.deleteGlobalDatasourceFromClient(persesClient, datasourceName); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
+	if len(errs) > 0 {
+		return subreconciler.RequeueWithError(errors.Join(errs...))
+	}
+
+	return subreconciler.ContinueReconciling()
+}
+
+func (r *PersesGlobalDatasourceReconciler) deleteGlobalDatasourceFromClient(persesClient v1.ClientInterface, datasourceName string) error {
+	err := persesClient.GlobalDatasource().Delete(datasourceName)
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			gdlog.Infof("GlobalDatasource not found: %s", datasourceName)
 		} else {
 			gdlog.WithError(err).Errorf("Failed to delete global datasource: %s", datasourceName)
-			return subreconciler.RequeueWithError(err)
+			return err
 		}
 	} else {
 		gdlog.Infof("GlobalDatasource deleted: %s", datasourceName)
 	}
 
 	secretName := datasourceName + persescommon.SecretNameSuffix
-
 	err = persesClient.GlobalSecret().Delete(secretName)
-
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {
 			gdlog.Infof("GlobalSecret not found: %s", secretName)
 		} else {
 			gdlog.WithError(err).Errorf("Failed to delete global secret: %s", secretName)
-			return subreconciler.RequeueWithError(err)
+			return err
 		}
 	} else {
 		gdlog.Infof("GlobalSecret deleted: %s", secretName)
 	}
 
-	return subreconciler.ContinueReconciling()
+	return nil
 }

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -67,6 +67,7 @@ var log = logger.WithField("module", "perses_globaldatasource_controller")
 // +kubebuilder:rbac:groups=perses.dev,resources=persesglobaldatasources/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=perses.dev,resources=persesglobaldatasources/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps;secrets,verbs=watch;get
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
 	objKey := req.String()

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	logger "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -237,6 +238,25 @@ func (r *PersesGlobalDatasourceReconciler) findGlobalDatasourcesForPerses(ctx co
 	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesGlobalDatasourceList"))
 }
 
+func (r *PersesGlobalDatasourceReconciler) findGlobalDatasourcesForPod(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+
+	instanceName := pod.Labels["app.kubernetes.io/instance"]
+	if instanceName == "" {
+		return nil
+	}
+
+	managedBy := pod.Labels["app.kubernetes.io/managed-by"]
+	if managedBy != "perses-operator" {
+		return nil
+	}
+
+	return r.findGlobalDatasourcesForPerses(ctx, obj)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 // It watches PersesGlobalDatasource resources and also watches Perses instances
 // to trigger re-reconciliation of all global datasources when a Perses instance becomes
@@ -250,6 +270,11 @@ func (r *PersesGlobalDatasourceReconciler) SetupWithManager(mgr ctrl.Manager) er
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findGlobalDatasourcesForPerses),
 			builder.WithPredicates(common.PersesAvailabilityPredicate()),
+		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findGlobalDatasourcesForPod),
+			builder.WithPredicates(common.PodReadinessPredicate()),
 		).
 		Complete(r)
 }

--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -21,6 +21,7 @@ import (
 	"github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	logger "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -218,6 +219,48 @@ func PersesAvailabilityPredicate() predicate.Funcs {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return PersesBecameAvailable(e.ObjectOld, e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// PodBecameReady returns true when a pod transitions from non-Ready to Ready.
+func PodBecameReady(oldObj, newObj client.Object) bool {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	return !isPodConditionReady(oldPod) && isPodConditionReady(newPod)
+}
+
+func isPodConditionReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// PodReadinessPredicate returns a predicate that triggers reconciliation
+// when a pod transitions to Ready. This is used to re-sync resources to
+// pods that restarted and lost their in-memory or emptyDir state.
+func PodReadinessPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return PodBecameReady(e.ObjectOld, e.ObjectNew)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false

--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -21,6 +21,7 @@ import (
 	"github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	logger "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -211,6 +212,48 @@ func PersesAvailabilityPredicate() predicate.Funcs {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return PersesBecameAvailable(e.ObjectOld, e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// PodBecameReady returns true when a pod transitions from non-Ready to Ready.
+func PodBecameReady(oldObj, newObj client.Object) bool {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	return !isPodConditionReady(oldPod) && isPodConditionReady(newPod)
+}
+
+func isPodConditionReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// PodReadinessPredicate returns a predicate that triggers reconciliation
+// when a pod transitions to Ready. This is used to re-sync resources to
+// pods that restarted and lost their in-memory or emptyDir state.
+func PodReadinessPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return PodBecameReady(e.ObjectOld, e.ObjectNew)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return false

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -372,6 +372,16 @@ func (f *PersesClientFactoryWithConfig) CreateClientsForAllPods(ctx context.Cont
 		return nil, err
 	}
 
+	// Pods are dialed by IP, but the server cert is issued for the Service DNS
+	// name. Pin ServerName so the cert is verified against the Service FQDN
+	// rather than the pod IP.
+	if isTLSEnabled(&perses) {
+		if baseConfig.TLSConfig == nil {
+			baseConfig.TLSConfig = &secret.TLSConfig{}
+		}
+		baseConfig.TLSConfig.ServerName = fmt.Sprintf("%s.%s.svc.cluster.local", perses.Name, perses.Namespace)
+	}
+
 	podList := &corev1.PodList{}
 	err = k8sClient.List(ctx, podList,
 		client.InNamespace(perses.Namespace),

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -17,11 +17,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/perses/perses/pkg/client/api/v1"
@@ -36,6 +39,7 @@ const tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 type PersesClientFactory interface {
 	CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error)
+	CreateClientsForAllPods(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) ([]v1.ClientInterface, error)
 }
 
 type PersesClientCacheInvalidator interface {
@@ -134,7 +138,109 @@ func (f *PersesClientFactoryWithConfig) cacheHit(instanceKey, fingerprint string
 	return entry.client, true
 }
 
-func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
+func (f *PersesClientFactoryWithConfig) getProtocolAndPort(perses *persesv1alpha2.Perses) (string, int32) {
+	httpProtocol := "http"
+	if isTLSEnabled(perses) {
+		httpProtocol = "https"
+	}
+	containerPort := DefaultContainerPort
+	if perses.Spec.ContainerPort != nil {
+		containerPort = *perses.Spec.ContainerPort
+	}
+	return httpProtocol, containerPort
+}
+
+func (f *PersesClientFactoryWithConfig) buildBaseConfig(ctx context.Context, k8sClient client.Reader, perses *persesv1alpha2.Perses) (clientConfig.RestConfigClient, error) {
+	config := clientConfig.RestConfigClient{}
+
+	if isKubernetesAuthEnabled(perses) {
+		tokenBytes, err := os.ReadFile(tokenPath)
+		if err != nil {
+			return config, fmt.Errorf("failed to read service account token from %s: %w", tokenPath, err)
+		}
+		saToken := string(tokenBytes)
+		if saToken == "" {
+			return config, fmt.Errorf("service account token is empty, ensure the Perses operator has the correct permissions")
+		}
+		config.Headers = map[string]string{
+			"Authorization": "Bearer " + saToken,
+		}
+	}
+
+	if isClientTLSEnabled(perses) {
+		tls := perses.Spec.Client.TLS
+
+		insecureSkipVerify := false
+		if tls.InsecureSkipVerify != nil {
+			insecureSkipVerify = *tls.InsecureSkipVerify
+		}
+
+		tlsConfig := &secret.TLSConfig{
+			InsecureSkipVerify: insecureSkipVerify,
+		}
+
+		if tls.CaCert != nil {
+			switch tls.CaCert.Type {
+			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
+				caData, _, err := GetTLSCertData(ctx, k8sClient, perses.Namespace, perses.Name, tls.CaCert)
+				if err != nil {
+					return config, err
+				}
+				tlsConfig.CA = caData
+			case persesv1alpha2.SecretSourceTypeFile:
+				tlsConfig.CAFile = tls.CaCert.CertPath
+			}
+		}
+
+		if tls.UserCert != nil {
+			switch tls.UserCert.Type {
+			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
+				cert, key, err := GetTLSCertData(ctx, k8sClient, perses.Namespace, perses.Name, tls.UserCert)
+				if err != nil {
+					return config, err
+				}
+				tlsConfig.Cert = cert
+				tlsConfig.Key = key
+			case persesv1alpha2.SecretSourceTypeFile:
+				tlsConfig.CertFile = tls.UserCert.CertPath
+			}
+		}
+
+		config.TLSConfig = tlsConfig
+	}
+
+	return config, nil
+}
+
+func (f *PersesClientFactoryWithConfig) createClientForURL(urlStr string, baseConfig clientConfig.RestConfigClient) (v1.ClientInterface, error) {
+	parsedURL, err := speccommon.ParseURL(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	config := baseConfig
+	config.URL = parsedURL
+
+	restClient, err := clientConfig.NewRESTClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return v1.NewWithClient(restClient), nil
+}
+
+func (f *PersesClientFactoryWithConfig) getServiceURL(perses *persesv1alpha2.Perses) string {
+	httpProtocol, containerPort := f.getProtocolAndPort(perses)
+
+	serverURLFlag := flag.Lookup(PersesServerURLFlag)
+	if serverURLFlag != nil && serverURLFlag.Value.String() != "" {
+		return serverURLFlag.Value.String()
+	}
+
+	return fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d%s", httpProtocol, perses.Name, perses.Namespace, containerPort, perses.Spec.Config.APIPrefix)
+}
+
+func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	instanceKey := fmt.Sprintf("%s/%s", perses.Namespace, perses.Name)
 	fingerprint := configFingerprint(perses)
 
@@ -150,7 +256,11 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 
 	// Build the client without holding any lock to avoid blocking other
 	// controllers during slow operations (TLS cert fetches from API server).
-	newClient, err := f.buildClient(ctx, client, perses)
+	baseConfig, err := f.buildBaseConfig(ctx, k8sClient, &perses)
+	if err != nil {
+		return nil, err
+	}
+	newClient, err := f.createClientForURL(f.getServiceURL(&perses), baseConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -175,99 +285,63 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 	return newClient, nil
 }
 
-func (f *PersesClientFactoryWithConfig) buildClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
-	var urlStr string
-
-	var httpProtocol = "http"
-	if isTLSEnabled(&perses) {
-		httpProtocol = "https"
-	}
-
-	serverURLFlag := flag.Lookup(PersesServerURLFlag)
-	if serverURLFlag != nil && serverURLFlag.Value.String() != "" {
-		urlStr = serverURLFlag.Value.String()
-	} else {
-		containerPort := DefaultContainerPort
-		if perses.Spec.ContainerPort != nil {
-			containerPort = *perses.Spec.ContainerPort
-		}
-		urlStr = fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d%s", httpProtocol, perses.Name, perses.Namespace, containerPort, perses.Spec.Config.APIPrefix)
-	}
-	parsedURL, err := speccommon.ParseURL(urlStr)
-	if err != nil {
-		return nil, err
-	}
-
-	config := clientConfig.RestConfigClient{
-		URL: parsedURL,
-	}
-
-	if isKubernetesAuthEnabled(&perses) {
-		tokenBytes, err := os.ReadFile(tokenPath)
+func (f *PersesClientFactoryWithConfig) CreateClientsForAllPods(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) ([]v1.ClientInterface, error) {
+	if perses.Spec.Config.Database.SQL != nil {
+		c, err := f.CreateClient(ctx, k8sClient, perses)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read service account token from %s: %w", tokenPath, err)
+			return nil, err
 		}
-		saToken := string(tokenBytes)
-		if saToken == "" {
-			return nil, fmt.Errorf("service account token is empty, ensure the Perses operator has the correct permissions")
-		}
-		config.Headers = map[string]string{
-			"Authorization": "Bearer " + saToken,
-		}
+		return []v1.ClientInterface{c}, nil
 	}
 
-	if isClientTLSEnabled(&perses) {
-		tls := perses.Spec.Client.TLS
-
-		insecureSkipVerify := false
-		if tls.InsecureSkipVerify != nil {
-			insecureSkipVerify = *tls.InsecureSkipVerify
-		}
-
-		tlsConfig := &secret.TLSConfig{
-			InsecureSkipVerify: insecureSkipVerify,
-		}
-
-		if tls.CaCert != nil {
-			switch tls.CaCert.Type {
-			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				caData, _, err := GetTLSCertData(ctx, client, perses.Namespace, perses.Name, tls.CaCert)
-
-				if err != nil {
-					return nil, err
-				}
-
-				tlsConfig.CA = caData
-			case persesv1alpha2.SecretSourceTypeFile:
-				tlsConfig.CAFile = tls.CaCert.CertPath
-			}
-		}
-
-		if tls.UserCert != nil {
-			switch tls.UserCert.Type {
-			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				cert, key, err := GetTLSCertData(ctx, client, perses.Namespace, perses.Name, tls.UserCert)
-
-				if err != nil {
-					return nil, err
-				}
-
-				tlsConfig.Cert = cert
-				tlsConfig.Key = key
-			case persesv1alpha2.SecretSourceTypeFile:
-				tlsConfig.CertFile = tls.UserCert.CertPath
-			}
-		}
-
-		config.TLSConfig = tlsConfig
-	}
-
-	restClient, err := clientConfig.NewRESTClient(config)
+	baseConfig, err := f.buildBaseConfig(ctx, k8sClient, &perses)
 	if err != nil {
 		return nil, err
 	}
 
-	return v1.NewWithClient(restClient), nil
+	podList := &corev1.PodList{}
+	err = k8sClient.List(ctx, podList,
+		client.InNamespace(perses.Namespace),
+		client.MatchingLabels(LabelsForPerses(perses.Name, &perses)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods for Perses instance %s/%s: %w", perses.Namespace, perses.Name, err)
+	}
+
+	httpProtocol, containerPort := f.getProtocolAndPort(&perses)
+
+	var clients []v1.ClientInterface
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !isPodReady(pod) {
+			continue
+		}
+		hostPort := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(containerPort)))
+		urlStr := fmt.Sprintf("%s://%s%s", httpProtocol, hostPort, perses.Spec.Config.APIPrefix)
+		c, err := f.createClientForURL(urlStr, baseConfig)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, c)
+	}
+
+	if len(clients) == 0 {
+		return nil, fmt.Errorf("no ready pods found for Perses instance %s/%s", perses.Namespace, perses.Name)
+	}
+
+	return clients, nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 type PersesClientFactoryWithClient struct {
@@ -280,4 +354,8 @@ func NewWithClient(client v1.ClientInterface) PersesClientFactory {
 
 func (f *PersesClientFactoryWithClient) CreateClient(_ context.Context, _ client.Reader, _ persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	return f.client, nil
+}
+
+func (f *PersesClientFactoryWithClient) CreateClientsForAllPods(_ context.Context, _ client.Reader, _ persesv1alpha2.Perses) ([]v1.ClientInterface, error) {
+	return []v1.ClientInterface{f.client}, nil
 }

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -299,6 +299,16 @@ func (f *PersesClientFactoryWithConfig) CreateClientsForAllPods(ctx context.Cont
 		return nil, err
 	}
 
+	// Pods are dialed by IP, but the server cert is issued for the Service DNS
+	// name. Pin ServerName so the cert is verified against the Service FQDN
+	// rather than the pod IP.
+	if isTLSEnabled(&perses) {
+		if baseConfig.TLSConfig == nil {
+			baseConfig.TLSConfig = &secret.TLSConfig{}
+		}
+		baseConfig.TLSConfig.ServerName = fmt.Sprintf("%s.%s.svc.cluster.local", perses.Name, perses.Namespace)
+	}
+
 	podList := &corev1.PodList{}
 	err = k8sClient.List(ctx, podList,
 		client.InNamespace(perses.Namespace),

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -17,11 +17,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/perses/perses/pkg/client/api/v1"
@@ -36,6 +39,7 @@ const tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 type PersesClientFactory interface {
 	CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error)
+	CreateClientsForAllPods(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) ([]v1.ClientInterface, error)
 }
 
 type PersesClientCacheInvalidator interface {
@@ -150,7 +154,170 @@ func (f *PersesClientFactoryWithConfig) cacheHit(instanceKey, fingerprint string
 	return entry.client, true
 }
 
-func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
+func (f *PersesClientFactoryWithConfig) getProtocolAndPort(perses *persesv1alpha2.Perses) (string, int32) {
+	httpProtocol := "http"
+	if isTLSEnabled(perses) {
+		httpProtocol = "https"
+	}
+	containerPort := DefaultContainerPort
+	if perses.Spec.ContainerPort != nil {
+		containerPort = *perses.Spec.ContainerPort
+	}
+	return httpProtocol, containerPort
+}
+
+func (f *PersesClientFactoryWithConfig) buildBaseConfig(ctx context.Context, k8sClient client.Reader, perses *persesv1alpha2.Perses) (clientConfig.RestConfigClient, error) {
+	config := clientConfig.RestConfigClient{}
+
+	if isKubernetesAuthEnabled(perses) && isClientOAuthEnabled(perses) {
+		return config, fmt.Errorf("kubernetesAuth and oauth are mutually exclusive; cannot configure both for Perses %s/%s", perses.Namespace, perses.Name)
+	}
+
+	if isKubernetesAuthEnabled(perses) {
+		tokenBytes, err := os.ReadFile(tokenPath)
+		if err != nil {
+			return config, fmt.Errorf("failed to read service account token from %s: %w", tokenPath, err)
+		}
+		saToken := string(tokenBytes)
+		if saToken == "" {
+			return config, fmt.Errorf("service account token is empty, ensure the Perses operator has the correct permissions")
+		}
+		config.Headers = map[string]string{
+			"Authorization": "Bearer " + saToken,
+		}
+	}
+
+	if isClientTLSEnabled(perses) {
+		tls := perses.Spec.Client.TLS
+
+		insecureSkipVerify := false
+		if tls.InsecureSkipVerify != nil {
+			insecureSkipVerify = *tls.InsecureSkipVerify
+		}
+
+		tlsConfig := &secret.TLSConfig{
+			InsecureSkipVerify: insecureSkipVerify,
+		}
+
+		if tls.CaCert != nil {
+			switch tls.CaCert.Type {
+			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
+				caData, _, err := GetTLSCertData(ctx, k8sClient, perses.Namespace, perses.Name, tls.CaCert)
+				if err != nil {
+					return config, err
+				}
+				tlsConfig.CA = caData
+			case persesv1alpha2.SecretSourceTypeFile:
+				tlsConfig.CAFile = tls.CaCert.CertPath
+			}
+		}
+
+		if tls.UserCert != nil {
+			switch tls.UserCert.Type {
+			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
+				cert, key, err := GetTLSCertData(ctx, k8sClient, perses.Namespace, perses.Name, tls.UserCert)
+				if err != nil {
+					return config, err
+				}
+				tlsConfig.Cert = cert
+				tlsConfig.Key = key
+			case persesv1alpha2.SecretSourceTypeFile:
+				tlsConfig.CertFile = tls.UserCert.CertPath
+			}
+		}
+
+		config.TLSConfig = tlsConfig
+	}
+
+	// OAuth 2.0 client_credentials: the token URL points at Perses's own native
+	// provider token endpoint (e.g. <perses-url>/api/auth/providers/oidc/<slug>/token).
+	// Perses exchanges these credentials with the external identity provider, syncs
+	// the user, and issues its own token. The underlying REST client fetches and
+	// auto-refreshes that token, so tokens are always minted by Perses itself.
+	if isClientOAuthEnabled(perses) {
+		oauthCfg := perses.Spec.Client.OAuth
+
+		authStyle := 0
+		if oauthCfg.AuthStyle != nil {
+			authStyle = int(*oauthCfg.AuthStyle)
+		}
+
+		oauthConfig := &secret.OAuth{
+			TokenURL:       oauthCfg.TokenURL,
+			Scopes:         oauthCfg.Scopes,
+			AuthStyle:      authStyle,
+			EndpointParams: oauthCfg.EndpointParams,
+		}
+
+		switch oauthCfg.Type {
+		case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
+			clientID, clientSecret, err := GetOAuthData(ctx, k8sClient, perses.Namespace, perses.Name, oauthCfg)
+			if err != nil {
+				return config, err
+			}
+			oauthConfig.ClientID = clientID
+			oauthConfig.ClientSecret = clientSecret
+		case persesv1alpha2.SecretSourceTypeFile:
+			if oauthCfg.ClientIDPath == nil {
+				return config, fmt.Errorf("clientIDPath is required when OAuth type is file for Perses %s/%s", perses.Namespace, perses.Name)
+			}
+			clientIDBytes, err := os.ReadFile(*oauthCfg.ClientIDPath)
+			if err != nil {
+				return config, fmt.Errorf("failed to read OAuth client ID file %s for Perses %s/%s: %w", *oauthCfg.ClientIDPath, perses.Namespace, perses.Name, err)
+			}
+			oauthConfig.ClientID = string(clientIDBytes)
+			if oauthCfg.ClientSecretPath == nil {
+				return config, fmt.Errorf("clientSecretPath is required when OAuth type is file for Perses %s/%s", perses.Namespace, perses.Name)
+			}
+			oauthConfig.ClientSecretFile = *oauthCfg.ClientSecretPath
+		default:
+			return config, fmt.Errorf("unsupported OAuth source type %q for Perses %s/%s", oauthCfg.Type, perses.Namespace, perses.Name)
+		}
+
+		config.OAuth = oauthConfig
+	}
+
+	return config, nil
+}
+
+func (f *PersesClientFactoryWithConfig) createClientForURL(urlStr string, baseConfig clientConfig.RestConfigClient) (v1.ClientInterface, error) {
+	parsedURL, err := speccommon.ParseURL(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	config := baseConfig
+	config.URL = parsedURL
+
+	restClient, err := clientConfig.NewRESTClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return v1.NewWithClient(restClient), nil
+}
+
+func (f *PersesClientFactoryWithConfig) getServiceURL(perses *persesv1alpha2.Perses) string {
+	httpProtocol, containerPort := f.getProtocolAndPort(perses)
+
+	serverURLFlag := flag.Lookup(PersesServerURLFlag)
+	if serverURLFlag != nil && serverURLFlag.Value.String() != "" {
+		return serverURLFlag.Value.String()
+	}
+
+	return fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d%s", httpProtocol, perses.Name, perses.Namespace, containerPort, perses.Spec.Config.APIPrefix)
+}
+
+// buildClient builds a single REST client targeting the Perses Service URL.
+func (f *PersesClientFactoryWithConfig) buildClient(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
+	baseConfig, err := f.buildBaseConfig(ctx, k8sClient, &perses)
+	if err != nil {
+		return nil, err
+	}
+	return f.createClientForURL(f.getServiceURL(&perses), baseConfig)
+}
+
+func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	instanceKey := fmt.Sprintf("%s/%s", perses.Namespace, perses.Name)
 	fingerprint := configFingerprint(perses)
 
@@ -166,7 +333,7 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 
 	// Build the client without holding any lock to avoid blocking other
 	// controllers during slow operations (TLS cert fetches from API server).
-	newClient, err := f.buildClient(ctx, client, perses)
+	newClient, err := f.buildClient(ctx, k8sClient, perses)
 	if err != nil {
 		return nil, err
 	}
@@ -191,149 +358,63 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 	return newClient, nil
 }
 
-func (f *PersesClientFactoryWithConfig) buildClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
-	var urlStr string
-
-	httpProtocol := "http"
-	if isTLSEnabled(&perses) {
-		httpProtocol = "https"
-	}
-
-	serverURLFlag := flag.Lookup(PersesServerURLFlag)
-	if serverURLFlag != nil && serverURLFlag.Value.String() != "" {
-		urlStr = serverURLFlag.Value.String()
-	} else {
-		containerPort := DefaultContainerPort
-		if perses.Spec.ContainerPort != nil {
-			containerPort = *perses.Spec.ContainerPort
-		}
-		urlStr = fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d%s", httpProtocol, perses.Name, perses.Namespace, containerPort, perses.Spec.Config.APIPrefix)
-	}
-	parsedURL, err := speccommon.ParseURL(urlStr)
-	if err != nil {
-		return nil, err
-	}
-
-	config := clientConfig.RestConfigClient{
-		URL: parsedURL,
-	}
-
-	if isKubernetesAuthEnabled(&perses) && isClientOAuthEnabled(&perses) {
-		return nil, fmt.Errorf("kubernetesAuth and oauth are mutually exclusive; cannot configure both for Perses %s/%s", perses.Namespace, perses.Name)
-	}
-
-	if isKubernetesAuthEnabled(&perses) {
-		tokenBytes, err := os.ReadFile(tokenPath)
+func (f *PersesClientFactoryWithConfig) CreateClientsForAllPods(ctx context.Context, k8sClient client.Reader, perses persesv1alpha2.Perses) ([]v1.ClientInterface, error) {
+	if perses.Spec.Config.Database.SQL != nil {
+		c, err := f.CreateClient(ctx, k8sClient, perses)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read service account token from %s: %w", tokenPath, err)
+			return nil, err
 		}
-		saToken := string(tokenBytes)
-		if saToken == "" {
-			return nil, fmt.Errorf("service account token is empty, ensure the Perses operator has the correct permissions")
-		}
-		config.Headers = map[string]string{
-			"Authorization": "Bearer " + saToken,
-		}
+		return []v1.ClientInterface{c}, nil
 	}
 
-	if isClientTLSEnabled(&perses) {
-		tls := perses.Spec.Client.TLS
-
-		insecureSkipVerify := false
-		if tls.InsecureSkipVerify != nil {
-			insecureSkipVerify = *tls.InsecureSkipVerify
-		}
-
-		tlsConfig := &secret.TLSConfig{
-			InsecureSkipVerify: insecureSkipVerify,
-		}
-
-		if tls.CaCert != nil {
-			switch tls.CaCert.Type {
-			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				caData, _, err := GetTLSCertData(ctx, client, perses.Namespace, perses.Name, tls.CaCert)
-				if err != nil {
-					return nil, err
-				}
-
-				tlsConfig.CA = caData
-			case persesv1alpha2.SecretSourceTypeFile:
-				tlsConfig.CAFile = tls.CaCert.CertPath
-			}
-		}
-
-		if tls.UserCert != nil {
-			switch tls.UserCert.Type {
-			case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-				cert, key, err := GetTLSCertData(ctx, client, perses.Namespace, perses.Name, tls.UserCert)
-				if err != nil {
-					return nil, err
-				}
-
-				tlsConfig.Cert = cert
-				tlsConfig.Key = key
-			case persesv1alpha2.SecretSourceTypeFile:
-				tlsConfig.CertFile = tls.UserCert.CertPath
-			}
-		}
-
-		config.TLSConfig = tlsConfig
-	}
-
-	// OAuth 2.0 client_credentials: the token URL points at Perses's own native
-	// provider token endpoint (e.g. <perses-url>/api/auth/providers/oidc/<slug>/token).
-	// Perses exchanges these credentials with the external identity provider, syncs
-	// the user, and issues its own token. The underlying REST client fetches and
-	// auto-refreshes that token, so tokens are always minted by Perses itself.
-	if isClientOAuthEnabled(&perses) {
-		oauthCfg := perses.Spec.Client.OAuth
-
-		authStyle := 0
-		if oauthCfg.AuthStyle != nil {
-			authStyle = int(*oauthCfg.AuthStyle)
-		}
-
-		oauthConfig := &secret.OAuth{
-			TokenURL:       oauthCfg.TokenURL,
-			Scopes:         oauthCfg.Scopes,
-			AuthStyle:      authStyle,
-			EndpointParams: oauthCfg.EndpointParams,
-		}
-
-		switch oauthCfg.Type {
-		case persesv1alpha2.SecretSourceTypeSecret, persesv1alpha2.SecretSourceTypeConfigMap:
-			clientID, clientSecret, err := GetOAuthData(ctx, client, perses.Namespace, perses.Name, oauthCfg)
-			if err != nil {
-				return nil, err
-			}
-			oauthConfig.ClientID = clientID
-			oauthConfig.ClientSecret = clientSecret
-		case persesv1alpha2.SecretSourceTypeFile:
-			if oauthCfg.ClientIDPath == nil {
-				return nil, fmt.Errorf("clientIDPath is required when OAuth type is file for Perses %s/%s", perses.Namespace, perses.Name)
-			}
-			clientIDBytes, err := os.ReadFile(*oauthCfg.ClientIDPath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read OAuth client ID file %s for Perses %s/%s: %w", *oauthCfg.ClientIDPath, perses.Namespace, perses.Name, err)
-			}
-			oauthConfig.ClientID = string(clientIDBytes)
-			if oauthCfg.ClientSecretPath == nil {
-				return nil, fmt.Errorf("clientSecretPath is required when OAuth type is file for Perses %s/%s", perses.Namespace, perses.Name)
-			}
-			oauthConfig.ClientSecretFile = *oauthCfg.ClientSecretPath
-		default:
-			return nil, fmt.Errorf("unsupported OAuth source type %q for Perses %s/%s", oauthCfg.Type, perses.Namespace, perses.Name)
-		}
-
-		config.OAuth = oauthConfig
-	}
-
-	restClient, err := clientConfig.NewRESTClient(config)
+	baseConfig, err := f.buildBaseConfig(ctx, k8sClient, &perses)
 	if err != nil {
 		return nil, err
 	}
 
-	return v1.NewWithClient(restClient), nil
+	podList := &corev1.PodList{}
+	err = k8sClient.List(ctx, podList,
+		client.InNamespace(perses.Namespace),
+		client.MatchingLabels(LabelsForPerses(perses.Name, &perses)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods for Perses instance %s/%s: %w", perses.Namespace, perses.Name, err)
+	}
+
+	httpProtocol, containerPort := f.getProtocolAndPort(&perses)
+
+	var clients []v1.ClientInterface
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !isPodReady(pod) {
+			continue
+		}
+		hostPort := net.JoinHostPort(pod.Status.PodIP, strconv.Itoa(int(containerPort)))
+		urlStr := fmt.Sprintf("%s://%s%s", httpProtocol, hostPort, perses.Spec.Config.APIPrefix)
+		c, err := f.createClientForURL(urlStr, baseConfig)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, c)
+	}
+
+	if len(clients) == 0 {
+		return nil, fmt.Errorf("no ready pods found for Perses instance %s/%s", perses.Namespace, perses.Name)
+	}
+
+	return clients, nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP == "" {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 type PersesClientFactoryWithClient struct {
@@ -346,4 +427,8 @@ func NewWithClient(client v1.ClientInterface) PersesClientFactory {
 
 func (f *PersesClientFactoryWithClient) CreateClient(_ context.Context, _ client.Reader, _ persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	return f.client, nil
+}
+
+func (f *PersesClientFactoryWithClient) CreateClientsForAllPods(_ context.Context, _ client.Reader, _ persesv1alpha2.Perses) ([]v1.ClientInterface, error) {
+	return []v1.ClientInterface{f.client}, nil
 }

--- a/internal/perses/common/perses_client_factory_test.go
+++ b/internal/perses/common/perses_client_factory_test.go
@@ -15,11 +15,14 @@ package common
 
 import (
 	"context"
+	"flag"
+	"net/http"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -1048,4 +1051,150 @@ func TestConfigFingerprintOtherFields(t *testing.T) {
 	// Client nil should not crash and produce stable fingerprint
 	fpNilClient := configFingerprint(base)
 	assert.Equal(t, fpBase, fpNilClient, "Nil/empty Client should not alter fingerprint")
+}
+
+func newPersesForPods() persesv1alpha2.Perses {
+	return persesv1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perses-1",
+			Namespace: "default",
+		},
+		Spec: persesv1alpha2.PersesSpec{
+			ContainerPort: ptr.To(int32(8080)),
+		},
+	}
+}
+
+// readyPod builds a pod carrying the operator's selector labels, with a
+// configurable phase, IP, and Ready condition.
+func readyPod(name, ip string, phase corev1.PodPhase, ready bool) *corev1.Pod {
+	perses := newPersesForPods()
+	condStatus := corev1.ConditionFalse
+	if ready {
+		condStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: perses.Namespace,
+			Labels:    LabelsForPerses(perses.Name, &perses),
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			PodIP: ip,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: condStatus},
+			},
+		},
+	}
+}
+
+func TestCreateClientsForAllPods(t *testing.T) {
+	ctx := context.Background()
+	perses := newPersesForPods()
+
+	t.Run("returns a client only for ready pods", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-1", "10.0.0.1", corev1.PodRunning, true),
+			readyPod("ready-2", "10.0.0.2", corev1.PodRunning, true),
+			readyPod("pending", "10.0.0.3", corev1.PodPending, true),
+			readyPod("no-ip", "", corev1.PodRunning, true),
+			readyPod("not-ready", "10.0.0.4", corev1.PodRunning, false),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.NoError(t, err)
+		require.Len(t, clients, 2, "only the two running, IP-assigned, ready pods should yield clients")
+
+		got := []string{
+			clients[0].RESTClient().BaseURL.String(),
+			clients[1].RESTClient().BaseURL.String(),
+		}
+		assert.ElementsMatch(t, []string{
+			"http://10.0.0.1:8080",
+			"http://10.0.0.2:8080",
+		}, got)
+	})
+
+	t.Run("errors when no pods are ready", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("not-ready", "10.0.0.4", corev1.PodRunning, false),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ready pods found")
+		assert.Nil(t, clients)
+	})
+
+	t.Run("brackets IPv6 pod IPs", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-v6", "fd00::1", corev1.PodRunning, true),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+		assert.Equal(t, "http://[fd00::1]:8080", clients[0].RESTClient().BaseURL.String())
+	})
+
+	t.Run("pins TLS ServerName to the service FQDN for pod-direct HTTPS", func(t *testing.T) {
+		tlsPerses := newPersesForPods()
+		tlsPerses.Spec.TLS = &persesv1alpha2.TLS{Enable: ptr.To(true)}
+
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-1", "10.0.0.1", corev1.PodRunning, true),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, tlsPerses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+
+		// The client dials the pod IP but must verify against the service DNS name.
+		assert.Equal(t, "https://10.0.0.1:8080", clients[0].RESTClient().BaseURL.String())
+		transport, ok := clients[0].RESTClient().Client.Transport.(*http.Transport)
+		require.True(t, ok, "expected an *http.Transport")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.Equal(t, "perses-1.default.svc.cluster.local", transport.TLSClientConfig.ServerName)
+	})
+
+	t.Run("SQL mode returns a single service client", func(t *testing.T) {
+		// A configured server URL flag makes the service client deterministic
+		// and independent of cluster DNS. The flag is normally registered by
+		// main.go, so register it here if the test binary hasn't.
+		if flag.Lookup(PersesServerURLFlag) == nil {
+			flag.String(PersesServerURLFlag, "", "The Perses backend server URL")
+		}
+		require.NoError(t, flag.Set(PersesServerURLFlag, "http://perses.example:8080"))
+		t.Cleanup(func() { _ = flag.Set(PersesServerURLFlag, "") })
+
+		sqlPerses := newPersesForPods()
+		sqlPerses.Spec.Config.Database = config.Database{SQL: &config.SQL{}}
+
+		// No pods exist: SQL mode must not list pods, so this still succeeds.
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, sqlPerses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+		assert.Equal(t, "http://perses.example:8080", clients[0].RESTClient().BaseURL.String())
+	})
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{"running, ready, with IP", readyPod("p", "10.0.0.1", corev1.PodRunning, true), true},
+		{"not running", readyPod("p", "10.0.0.1", corev1.PodPending, true), false},
+		{"no IP", readyPod("p", "", corev1.PodRunning, true), false},
+		{"ready condition false", readyPod("p", "10.0.0.1", corev1.PodRunning, false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPodReady(tt.pod))
+		})
+	}
 }

--- a/internal/perses/common/perses_client_factory_test.go
+++ b/internal/perses/common/perses_client_factory_test.go
@@ -14,13 +14,20 @@
 package common
 
 import (
+	"context"
+	"flag"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/perses/perses/pkg/model/api/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 )
@@ -210,4 +217,150 @@ func TestClientCacheConcurrency(t *testing.T) {
 	wg.Wait()
 
 	assert.NotNil(t, factory.cache)
+}
+
+func newPersesForPods() persesv1alpha2.Perses {
+	return persesv1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "perses-1",
+			Namespace: "default",
+		},
+		Spec: persesv1alpha2.PersesSpec{
+			ContainerPort: ptr.To(int32(8080)),
+		},
+	}
+}
+
+// readyPod builds a pod carrying the operator's selector labels, with a
+// configurable phase, IP, and Ready condition.
+func readyPod(name, ip string, phase corev1.PodPhase, ready bool) *corev1.Pod {
+	perses := newPersesForPods()
+	condStatus := corev1.ConditionFalse
+	if ready {
+		condStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: perses.Namespace,
+			Labels:    LabelsForPerses(perses.Name, &perses),
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
+			PodIP: ip,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: condStatus},
+			},
+		},
+	}
+}
+
+func TestCreateClientsForAllPods(t *testing.T) {
+	ctx := context.Background()
+	perses := newPersesForPods()
+
+	t.Run("returns a client only for ready pods", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-1", "10.0.0.1", corev1.PodRunning, true),
+			readyPod("ready-2", "10.0.0.2", corev1.PodRunning, true),
+			readyPod("pending", "10.0.0.3", corev1.PodPending, true),
+			readyPod("no-ip", "", corev1.PodRunning, true),
+			readyPod("not-ready", "10.0.0.4", corev1.PodRunning, false),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.NoError(t, err)
+		require.Len(t, clients, 2, "only the two running, IP-assigned, ready pods should yield clients")
+
+		got := []string{
+			clients[0].RESTClient().BaseURL.String(),
+			clients[1].RESTClient().BaseURL.String(),
+		}
+		assert.ElementsMatch(t, []string{
+			"http://10.0.0.1:8080",
+			"http://10.0.0.2:8080",
+		}, got)
+	})
+
+	t.Run("errors when no pods are ready", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("not-ready", "10.0.0.4", corev1.PodRunning, false),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no ready pods found")
+		assert.Nil(t, clients)
+	})
+
+	t.Run("brackets IPv6 pod IPs", func(t *testing.T) {
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-v6", "fd00::1", corev1.PodRunning, true),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, perses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+		assert.Equal(t, "http://[fd00::1]:8080", clients[0].RESTClient().BaseURL.String())
+	})
+
+	t.Run("pins TLS ServerName to the service FQDN for pod-direct HTTPS", func(t *testing.T) {
+		tlsPerses := newPersesForPods()
+		tlsPerses.Spec.TLS = &persesv1alpha2.TLS{Enable: ptr.To(true)}
+
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(
+			readyPod("ready-1", "10.0.0.1", corev1.PodRunning, true),
+		).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, tlsPerses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+
+		// The client dials the pod IP but must verify against the service DNS name.
+		assert.Equal(t, "https://10.0.0.1:8080", clients[0].RESTClient().BaseURL.String())
+		transport, ok := clients[0].RESTClient().Client.Transport.(*http.Transport)
+		require.True(t, ok, "expected an *http.Transport")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.Equal(t, "perses-1.default.svc.cluster.local", transport.TLSClientConfig.ServerName)
+	})
+
+	t.Run("SQL mode returns a single service client", func(t *testing.T) {
+		// A configured server URL flag makes the service client deterministic
+		// and independent of cluster DNS. The flag is normally registered by
+		// main.go, so register it here if the test binary hasn't.
+		if flag.Lookup(PersesServerURLFlag) == nil {
+			flag.String(PersesServerURLFlag, "", "The Perses backend server URL")
+		}
+		require.NoError(t, flag.Set(PersesServerURLFlag, "http://perses.example:8080"))
+		t.Cleanup(func() { _ = flag.Set(PersesServerURLFlag, "") })
+
+		sqlPerses := newPersesForPods()
+		sqlPerses.Spec.Config.Database = config.Database{SQL: &config.SQL{}}
+
+		// No pods exist: SQL mode must not list pods, so this still succeeds.
+		reader := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+		clients, err := NewWithConfig().CreateClientsForAllPods(ctx, reader, sqlPerses)
+		require.NoError(t, err)
+		require.Len(t, clients, 1)
+		assert.Equal(t, "http://perses.example:8080", clients[0].RESTClient().BaseURL.String())
+	})
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{"running, ready, with IP", readyPod("p", "10.0.0.1", corev1.PodRunning, true), true},
+		{"not running", readyPod("p", "10.0.0.1", corev1.PodPending, true), false},
+		{"no IP", readyPod("p", "", corev1.PodRunning, true), false},
+		{"ready condition false", readyPod("p", "10.0.0.1", corev1.PodRunning, false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPodReady(tt.pod))
+		})
+	}
 }


### PR DESCRIPTION
# Description

For file-based storage with multiple replicas, push resources to each pod individually rather than through the ClusterIP Service. The operator now lists ready pods by label selector, creates an HTTP client per pod IP, and syncs to all of them with best-effort error aggregation.

Closes: #409

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
