### PR TITLE
[ENHANCEMENT] cache perses clients and cleanup metrics when resources are deleted

### DIFF
--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -258,6 +258,135 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 		})
 
+		It("should call Update on the Perses API when the dashboard spec changes", func() {
+			By("Creating the custom resource for the Kind PersesDashboard")
+			dashboard := &persesv1alpha2.PersesDashboard{}
+			err := k8sClient.Get(ctx, dashboardNamespaceName, dashboard)
+			if err != nil && errors.IsNotFound(err) {
+				dashboard = &persesv1alpha2.PersesDashboard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DashboardName,
+						Namespace: PersesNamespace,
+					},
+					Spec: persesv1alpha2.PersesDashboardSpec{
+						Config: persesv1alpha2.Dashboard{
+							DashboardSpec: newDashboard.Spec,
+						},
+					},
+				}
+				err = k8sClient.Create(ctx, dashboard)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Checking if the custom resource was successfully created")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, dashboardNamespaceName, dashboard)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Initial reconciliation - creates the dashboard in Perses")
+			mockPersesClient := new(internal.MockClient)
+			mockDashboard := new(internal.MockDashboard)
+			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
+			mockDashboard.On("Get", DashboardName).Return(&persesv1.Dashboard{}, perseshttp.RequestNotFoundError)
+			mockDashboard.On("Create", newDashboard).Return(&persesv1.Dashboard{}, nil)
+
+			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
+				Client:        k8sClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			_, err = dashboardReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: dashboardNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+			mockDashboard.AssertCalled(GinkgoT(), "Create", newDashboard)
+
+			By("Updating the dashboard spec")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, dashboardNamespaceName, dashboard); err != nil {
+					return err
+				}
+				dashboard.Spec.Config.DashboardSpec.Duration = "10m"
+				dashboard.Spec.Config.DashboardSpec.Display = &persescommon.Display{Name: "Updated Dashboard"}
+				return k8sClient.Update(ctx, dashboard)
+			}, time.Second*10, time.Millisecond*250).Should(Succeed())
+
+			By("Re-reconciling with the updated spec")
+			mockPersesClient2 := new(internal.MockClient)
+			mockDashboard2 := new(internal.MockDashboard)
+			mockPersesClient2.On("Dashboard", PersesNamespace).Return(mockDashboard2)
+
+			existingDashboard := &persesv1.Dashboard{
+				Kind: persesv1.KindDashboard,
+				Metadata: persesv1.ProjectMetadata{
+					Metadata: persesv1.Metadata{
+						Name: DashboardName,
+					},
+				},
+				Spec: newDashboard.Spec,
+			}
+			mockDashboard2.On("Get", DashboardName).Return(existingDashboard, nil)
+
+			updatedDashboard := &persesv1.Dashboard{
+				Kind: persesv1.KindDashboard,
+				Metadata: persesv1.ProjectMetadata{
+					Metadata: persesv1.Metadata{
+						Name: DashboardName,
+					},
+				},
+				Spec: persesv1.DashboardSpec{
+					Display:  &persescommon.Display{Name: "Updated Dashboard"},
+					Duration: "10m",
+					Layouts:  []persesdashboard.Layout{},
+					Panels: map[string]*persesv1.Panel{
+						"panel1": {
+							Kind: "Panel",
+							Spec: persesv1.PanelSpec{
+								Display: &persesv1.PanelDisplay{
+									Name: "test-panel",
+								},
+								Plugin: persescommon.Plugin{
+									Kind: "PrometheusPlugin",
+									Spec: map[string]any{},
+								},
+							},
+						},
+					},
+				},
+			}
+			mockDashboard2.On("Update", updatedDashboard).Return(updatedDashboard, nil)
+
+			dashboardReconciler2 := &dashboardcontroller.PersesDashboardReconciler{
+				Client:        k8sClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient2),
+			}
+
+			_, err = dashboardReconciler2.Reconcile(ctx, reconcile.Request{
+				NamespacedName: dashboardNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+
+			By("Verifying that Update was called (not Create)")
+			mockDashboard2.AssertCalled(GinkgoT(), "Update", updatedDashboard)
+			mockDashboard2.AssertNotCalled(GinkgoT(), "Create")
+
+			By("Cleaning up")
+			mockDashboard2.On("Delete", DashboardName).Return(nil)
+			dashboardToDelete := &persesv1alpha2.PersesDashboard{}
+			err = k8sClient.Get(ctx, dashboardNamespaceName, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			_, err = dashboardReconciler2.Reconcile(ctx, reconcile.Request{
+				NamespacedName: dashboardNamespaceName,
+			})
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
 		It("should show the error on CR dashboard status when the backend returns one", func() {
 			By("Creating the custom resource for the Kind PersesDashboard")
 			dashboard := &persesv1alpha2.PersesDashboard{}

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -121,7 +121,7 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 		}
 	}
 
-	_, err = persesClient.Dashboard(dashboard.Namespace).Get(dashboard.Name)
+	existing, err := persesClient.Dashboard(dashboard.Namespace).Get(dashboard.Name)
 
 	persesDashboard := &persesv1.Dashboard{
 		Kind: persesv1.KindDashboard,
@@ -150,17 +150,21 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 		}
 
 		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
-	} else {
-		_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
-
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
-
-			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
-		}
-
-		dlog.Infof("Dashboard updated: %s", dashboard.Name)
 	}
+
+	if common.DashboardInSync(existing, persesDashboard) {
+		dlog.Debugf("Dashboard already in sync: %s", dashboard.Name)
+		res, err := subreconciler.ContinueReconciling()
+		return res, "", err
+	}
+
+	_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
+	if err != nil {
+		dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
+		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+	}
+
+	dlog.Infof("Dashboard updated: %s", dashboard.Name)
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -156,7 +156,11 @@ func (r *PersesDashboardReconciler) updateDashboardStatus(
 		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
+		before := common.SnapshotConditions(fresh.Status.Conditions)
 		updateFn(fresh)
+		if !common.ConditionsChanged(before, fresh.Status.Conditions) {
+			return nil
+		}
 		return r.Status().Update(ctx, fresh)
 	})
 

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -55,7 +55,7 @@ func dashboardFromContext(ctx context.Context) (*persesv1alpha2.PersesDashboard,
 // PersesDashboardReconciler reconciles a PersesDashboard object
 type PersesDashboardReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
+	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -80,7 +80,7 @@ func (r *PersesDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Find once and store in context for all sub-reconcilers, handle deletion if not found
 	dashboard := &persesv1alpha2.PersesDashboard{}
-	if err := r.Get(ctx, req.NamespacedName, dashboard); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, dashboard); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Infof("perses dashboard resource not found. Deleting '%s' in '%s'", req.Name, req.Namespace)
 			if r.ReconciliationTracker != nil {

--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -86,6 +86,9 @@ func (r *PersesDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			if r.ReconciliationTracker != nil {
 				r.ReconciliationTracker.ForgetObject(objKey)
 			}
+			if r.Metrics != nil {
+				r.Metrics.ForgetObject(objKey)
+			}
 			return subreconciler.Evaluate(r.deleteDashboardInAllInstances(ctx, req, req.Namespace, req.Name))
 		}
 		log.WithError(err).Error("Failed to get perses dashboard")

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -133,7 +133,7 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		}
 	}
 
-	_, err = persesClient.Datasource(datasource.Namespace).Get(datasource.Name)
+	existing, err := persesClient.Datasource(datasource.Namespace).Get(datasource.Name)
 
 	datasourceWithName := &persesv1.Datasource{
 		Kind: persesv1.KindDatasource,
@@ -162,16 +162,21 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		}
 
 		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-	} else {
-		_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
-
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-		}
-
-		dlog.Infof("Datasource updated: %s", datasource.Name)
 	}
+
+	if persescommon.DatasourceInSync(existing, datasourceWithName) {
+		dlog.Debugf("Datasource already in sync: %s", datasource.Name)
+		res, err := subreconciler.ContinueReconciling()
+		return res, "", err
+	}
+
+	_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
+	if err != nil {
+		dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+	}
+
+	dlog.Infof("Datasource updated: %s", datasource.Name)
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -156,7 +156,11 @@ func (r *PersesDatasourceReconciler) updateDatasourceStatus(
 		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
+		before := common.SnapshotConditions(fresh.Status.Conditions)
 		updateFn(fresh)
+		if !common.ConditionsChanged(before, fresh.Status.Conditions) {
+			return nil
+		}
 		return r.Status().Update(ctx, fresh)
 	})
 

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -54,7 +54,7 @@ func datasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesDatasourc
 // PersesDatasourceReconciler reconciles a PersesDatasource object
 type PersesDatasourceReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
+	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -80,7 +80,7 @@ func (r *PersesDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Find once and store in context for all sub-reconcilers, handle deletion if not found
 	datasource := &persesv1alpha2.PersesDatasource{}
-	if err := r.Get(ctx, req.NamespacedName, datasource); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, datasource); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Infof("perses datasource resource not found. Deleting '%s' in '%s'", req.Name, req.Namespace)
 			if r.ReconciliationTracker != nil {

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -86,6 +86,9 @@ func (r *PersesDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if r.ReconciliationTracker != nil {
 				r.ReconciliationTracker.ForgetObject(objKey)
 			}
+			if r.Metrics != nil {
+				r.Metrics.ForgetObject(objKey)
+			}
 			return subreconciler.Evaluate(r.deleteDatasourceInAllInstances(ctx, req.Namespace, req.Name))
 		}
 		log.WithError(err).Error("Failed to get perses datasource")

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -104,7 +104,7 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 		}
 	}
 
-	_, err = persesClient.GlobalDatasource().Get(globaldatasource.Name)
+	existing, err := persesClient.GlobalDatasource().Get(globaldatasource.Name)
 
 	globalDatasourceWithName := &persesv1.GlobalDatasource{
 		Kind: persesv1.KindGlobalDatasource,
@@ -122,7 +122,6 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 			if err != nil {
 				gdlog.WithError(err).Errorf("Failed to create globaldatasource: %s", globaldatasource.Name)
 				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-
 			}
 
 			gdlog.Infof("GlobalDatasource created: %s", globaldatasource.Name)
@@ -133,16 +132,21 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 
 		res, err := subreconciler.RequeueWithError(err)
 		return res, persescommon.ReasonBackendError, err
-	} else {
-		_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
-
-		if err != nil {
-			gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-		}
-
-		gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
 	}
+
+	if persescommon.GlobalDatasourceInSync(existing, globalDatasourceWithName) {
+		gdlog.Debugf("GlobalDatasource already in sync: %s", globaldatasource.Name)
+		res, err := subreconciler.ContinueReconciling()
+		return res, "", err
+	}
+
+	_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
+	if err != nil {
+		gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+	}
+
+	gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -156,7 +156,11 @@ func (r *PersesGlobalDatasourceReconciler) updateGlobalDatasourceStatus(
 		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
+		before := common.SnapshotConditions(fresh.Status.Conditions)
 		updateFn(fresh)
+		if !common.ConditionsChanged(before, fresh.Status.Conditions) {
+			return nil
+		}
 		return r.Status().Update(ctx, fresh)
 	})
 

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -54,7 +54,7 @@ func globalDatasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesGlo
 // PersesGlobalDatasourceReconciler reconciles a PersesDatasource object
 type PersesGlobalDatasourceReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
+	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -79,7 +79,7 @@ func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ct
 	log.Infof("Reconciling PersesGlobalDatasource: %s", req.Name)
 
 	globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
-	if err := r.Get(ctx, req.NamespacedName, globaldatasource); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, globaldatasource); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Infof("perses globaldatasource resource not found. Deleting '%s'", req.Name)
 			if r.ReconciliationTracker != nil {

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -85,6 +85,9 @@ func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ct
 			if r.ReconciliationTracker != nil {
 				r.ReconciliationTracker.ForgetObject(objKey)
 			}
+			if r.Metrics != nil {
+				r.Metrics.ForgetObject(objKey)
+			}
 			return subreconciler.Evaluate(r.deleteGlobalDatasourceInAllInstances(ctx, req.Name))
 		}
 		log.WithError(err).Error("Failed to get perses globaldatasource")

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -65,12 +65,13 @@ type Config struct {
 // PersesReconciler reconciles a Perses object
 type PersesReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
-	Scheme                *runtime.Scheme
-	Recorder              record.EventRecorder
-	Config                Config
-	Metrics               *operatormetrics.Metrics
-	ReconciliationTracker *operatormetrics.ReconciliationTracker
+	APIReader              client.Reader // uncached reader for Secret data (cached client strips Data via Transform)
+	Scheme                 *runtime.Scheme
+	Recorder               record.EventRecorder
+	Config                 Config
+	Metrics                *operatormetrics.Metrics
+	ReconciliationTracker  *operatormetrics.ReconciliationTracker
+	ClientCacheInvalidator common.PersesClientCacheInvalidator
 }
 
 var log = logger.WithField("module", "perses_controller")
@@ -97,6 +98,13 @@ func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if r.ReconciliationTracker != nil {
 				r.ReconciliationTracker.ForgetObject(objKey)
 			}
+			if r.Metrics != nil {
+				r.Metrics.ForgetObject(objKey)
+				r.Metrics.DeletePersesInstance(req.Namespace, req.Name)
+			}
+			if r.ClientCacheInvalidator != nil {
+				r.ClientCacheInvalidator.ForgetInstance(objKey)
+			}
 			return subreconciler.Evaluate(subreconciler.DoNotRequeue())
 		}
 		log.WithError(err).Error("Failed to get perses")
@@ -106,9 +114,9 @@ func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return subreconciler.Evaluate(subreconciler.RequeueWithError(err))
 	}
 
-	// Update Perses instance count
-	if r.Metrics != nil {
-		r.Metrics.PersesInstances(perses.Namespace).Set(1)
+	// Update Perses instance count (skip for objects being deleted)
+	if r.Metrics != nil && perses.GetDeletionTimestamp() == nil {
+		r.Metrics.PersesInstances(perses.Namespace, perses.Name).Set(1)
 	}
 
 	// Store perses in context for all sub-reconcilers

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -186,7 +186,11 @@ func (r *PersesReconciler) updatePersesStatus(
 		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
+		before := fresh.Status.DeepCopy()
 		updateFn(fresh)
+		if equality.Semantic.DeepEqual(*before, fresh.Status) {
+			return nil
+		}
 		return r.Status().Update(ctx, fresh)
 	})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -94,9 +94,7 @@ var _ = BeforeSuite(func() {
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
-		Cache: cache.Options{
-			ByObject: internalcache.BuildCacheByObject(nil, false, false),
-		},
+		Cache: internalcache.BuildCacheOptions(nil, false, false),
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -15,6 +15,7 @@ package cache
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses-operator/internal/perses/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,17 +34,30 @@ func ParseSecretLabelSelector(raw string) (labels.Selector, error) {
 	return labels.Parse(raw)
 }
 
-// BuildCacheByObject builds the cache.ByObject map for the manager's cache configuration.
+// BuildCacheOptions builds the cache configuration for the manager.
+//
+// ManagedFields are stripped from all cached objects via DefaultTransform to reduce
+// memory usage. Per-object Transforms override DefaultTransform, so they also strip
+// ManagedFields explicitly.
 //
 // Operator-created resources (Deployment, StatefulSet, ConfigMap, Service) are filtered
 // by the fixed label app.kubernetes.io/managed-by=perses-operator.
 //
+// CRD resources (PersesDashboard, PersesDatasource, PersesGlobalDatasource) have their
+// Spec stripped from the cache. Controllers use APIReader for the full object.
+//
 // Secrets are filtered by secretSelector. If secretSelector is nil (no flag provided),
 // the default label perses.dev/watch=true is used. If watchAllSecrets is true, no label
 // filter is applied to secrets (preserving pre-change behavior).
-//
 // Secret data is always stripped from the cache via Transform regardless of label filtering.
-func BuildCacheByObject(secretSelector labels.Selector, watchAllSecrets bool, tlsClusterProfile bool) map[client.Object]cache.ByObject {
+func BuildCacheOptions(secretSelector labels.Selector, watchAllSecrets bool, tlsClusterProfile bool) cache.Options {
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject:         buildCacheByObject(secretSelector, watchAllSecrets, tlsClusterProfile),
+	}
+}
+
+func buildCacheByObject(secretSelector labels.Selector, watchAllSecrets bool, tlsClusterProfile bool) map[client.Object]cache.ByObject {
 	managedBySelector := labels.SelectorFromSet(labels.Set{
 		common.PersesManagedByLabel: common.PersesManagedByValue,
 	})
@@ -61,14 +75,44 @@ func BuildCacheByObject(secretSelector labels.Selector, watchAllSecrets bool, tl
 		&corev1.Service{}: {
 			Label: managedBySelector,
 		},
+		&persesv1alpha2.PersesDashboard{}: {
+			Transform: func(obj any) (any, error) {
+				if d, ok := obj.(*persesv1alpha2.PersesDashboard); ok {
+					d.ManagedFields = nil
+					d.Spec.Config = persesv1alpha2.Dashboard{}
+					d.Spec.InstanceSelector = nil
+				}
+				return obj, nil
+			},
+		},
+		&persesv1alpha2.PersesDatasource{}: {
+			Transform: func(obj any) (any, error) {
+				if d, ok := obj.(*persesv1alpha2.PersesDatasource); ok {
+					d.ManagedFields = nil
+					d.Spec.Config = persesv1alpha2.Datasource{}
+					d.Spec.Client = nil
+					d.Spec.InstanceSelector = nil
+				}
+				return obj, nil
+			},
+		},
+		&persesv1alpha2.PersesGlobalDatasource{}: {
+			Transform: func(obj any) (any, error) {
+				if d, ok := obj.(*persesv1alpha2.PersesGlobalDatasource); ok {
+					d.ManagedFields = nil
+					d.Spec.Config = persesv1alpha2.Datasource{}
+					d.Spec.Client = nil
+					d.Spec.InstanceSelector = nil
+				}
+				return obj, nil
+			},
+		},
 	}
 
 	secretEntry := cache.ByObject{
-		// Strip secret data from the cache to reduce memory usage.
-		// All controllers watch or read secrets but only need metadata for change detection.
-		// Controllers that need actual secret data use the APIReader instead.
 		Transform: func(obj any) (any, error) {
 			if secret, ok := obj.(*corev1.Secret); ok {
+				secret.ManagedFields = nil
 				secret.Data = nil
 				secret.StringData = nil
 			}

--- a/internal/cache/options_test.go
+++ b/internal/cache/options_test.go
@@ -18,9 +18,13 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses-operator/internal/perses/common"
+	persesv1 "github.com/perses/perses/pkg/model/api/v1"
+	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,7 +136,7 @@ func findByObjectEntry(byObject map[client.Object]ctrlcache.ByObject, target cli
 }
 
 func TestBuildCacheByObject_DefaultLabels(t *testing.T) {
-	byObject := BuildCacheByObject(nil, false, false)
+	byObject := buildCacheByObject(nil, false, false)
 
 	managedBySelector := labels.SelectorFromSet(labels.Set{
 		common.PersesManagedByLabel: common.PersesManagedByValue,
@@ -180,7 +184,7 @@ func TestBuildCacheByObject_CustomSecretSelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse selector: %v", err)
 	}
-	byObject := BuildCacheByObject(customSelector, false, false)
+	byObject := buildCacheByObject(customSelector, false, false)
 
 	secretEntry := findByObjectEntry(byObject, &corev1.Secret{})
 	if secretEntry == nil {
@@ -197,7 +201,7 @@ func TestBuildCacheByObject_CustomSecretSelector(t *testing.T) {
 }
 
 func TestBuildCacheByObject_WatchAllSecrets(t *testing.T) {
-	byObject := BuildCacheByObject(nil, true, false)
+	byObject := buildCacheByObject(nil, true, false)
 
 	secretEntry := findByObjectEntry(byObject, &corev1.Secret{})
 	if secretEntry == nil {
@@ -218,7 +222,7 @@ func TestBuildCacheByObject_WatchAllSecretsOverridesSelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse selector: %v", err)
 	}
-	byObject := BuildCacheByObject(customSelector, true, false)
+	byObject := buildCacheByObject(customSelector, true, false)
 
 	secretEntry := findByObjectEntry(byObject, &corev1.Secret{})
 	if secretEntry == nil {
@@ -232,7 +236,7 @@ func TestBuildCacheByObject_WatchAllSecretsOverridesSelector(t *testing.T) {
 
 func getSecretTransform(t *testing.T) func(obj any) (any, error) {
 	t.Helper()
-	byObject := BuildCacheByObject(nil, false, false)
+	byObject := buildCacheByObject(nil, false, false)
 	secretEntry := findByObjectEntry(byObject, &corev1.Secret{})
 	if secretEntry == nil {
 		t.Fatal("expected ByObject entry for Secret")
@@ -333,7 +337,7 @@ func TestBuildCacheByObject_SecretTransformEmptySecret(t *testing.T) {
 }
 
 func TestBuildCacheByObject_TLSClusterProfile(t *testing.T) {
-	byObject := BuildCacheByObject(nil, false, true)
+	byObject := buildCacheByObject(nil, false, true)
 
 	apiServerEntry := findByObjectEntry(byObject, &configv1.APIServer{})
 	if apiServerEntry == nil {
@@ -346,10 +350,283 @@ func TestBuildCacheByObject_TLSClusterProfile(t *testing.T) {
 }
 
 func TestBuildCacheByObject_NoTLSClusterProfile(t *testing.T) {
-	byObject := BuildCacheByObject(nil, false, false)
+	byObject := buildCacheByObject(nil, false, false)
 
 	apiServerEntry := findByObjectEntry(byObject, &configv1.APIServer{})
 	if apiServerEntry != nil {
 		t.Error("expected no ByObject entry for APIServer when tlsClusterProfile is false")
+	}
+}
+
+func getCRDTransform(t *testing.T, target client.Object) func(obj any) (any, error) {
+	t.Helper()
+	byObject := buildCacheByObject(nil, false, false)
+	entry := findByObjectEntry(byObject, target)
+	if entry == nil {
+		t.Fatalf("expected ByObject entry for %T", target)
+	}
+	if entry.Transform == nil {
+		t.Fatalf("expected Transform on %T entry", target)
+	}
+	return entry.Transform
+}
+
+func TestBuildCacheOptions_SetsDefaultTransform(t *testing.T) {
+	opts := BuildCacheOptions(nil, false, false)
+	if opts.DefaultTransform == nil {
+		t.Fatal("expected DefaultTransform to be set")
+	}
+
+	// Verify it strips ManagedFields from an arbitrary object
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+			},
+		},
+	}
+	result, err := opts.DefaultTransform(cm)
+	if err != nil {
+		t.Fatalf("DefaultTransform returned error: %v", err)
+	}
+	if len(result.(*corev1.ConfigMap).ManagedFields) != 0 {
+		t.Error("expected ManagedFields to be stripped by DefaultTransform")
+	}
+}
+
+func TestBuildCacheOptions_ContainsByObject(t *testing.T) {
+	opts := BuildCacheOptions(nil, false, false)
+	if opts.ByObject == nil {
+		t.Fatal("expected ByObject to be set")
+	}
+	entry := findByObjectEntry(opts.ByObject, &corev1.Secret{})
+	if entry == nil {
+		t.Fatal("expected Secret entry in ByObject")
+	}
+}
+
+func TestBuildCacheByObject_DashboardTransformStripsManagedFields(t *testing.T) {
+	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
+
+	dashboard := &persesv1alpha2.PersesDashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-dash",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+			},
+		},
+	}
+
+	result, err := transform(dashboard)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	if result.(*persesv1alpha2.PersesDashboard).ManagedFields != nil {
+		t.Error("expected ManagedFields to be nil after Transform")
+	}
+}
+
+func TestBuildCacheByObject_SecretTransformStripsManagedFields(t *testing.T) {
+	transform := getSecretTransform(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-secret",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
+			},
+		},
+	}
+
+	result, err := transform(secret)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	if result.(*corev1.Secret).ManagedFields != nil {
+		t.Error("expected ManagedFields to be nil after Transform")
+	}
+}
+
+func TestBuildCacheByObject_DashboardTransformStripsSpec(t *testing.T) {
+	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
+
+	dashboard := &persesv1alpha2.PersesDashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-dash",
+			Namespace:       "test-ns",
+			ResourceVersion: "12345",
+			Labels:          map[string]string{"app": "test"},
+			Annotations:     map[string]string{"perses.dev/tags": "oncall"},
+		},
+		Spec: persesv1alpha2.PersesDashboardSpec{
+			Config: persesv1alpha2.Dashboard{
+				DashboardSpec: persesv1.DashboardSpec{
+					Display:  &persesv1Common.Display{Name: "My Dashboard"},
+					Duration: "5m",
+				},
+			},
+			InstanceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+		Status: persesv1alpha2.PersesDashboardStatus{
+			Conditions: []metav1.Condition{{
+				Type:   common.TypeAvailablePerses,
+				Status: metav1.ConditionTrue,
+				Reason: "Reconciled",
+			}},
+		},
+	}
+
+	result, err := transform(dashboard)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	d := result.(*persesv1alpha2.PersesDashboard)
+
+	if d.Spec.Config.Display != nil || d.Spec.Config.Duration != "" {
+		t.Error("expected Spec.Config to be zeroed")
+	}
+	if d.Spec.InstanceSelector != nil {
+		t.Error("expected Spec.InstanceSelector to be nil")
+	}
+
+	if d.Name != "test-dash" || d.Namespace != "test-ns" || d.ResourceVersion != "12345" {
+		t.Error("expected ObjectMeta to be preserved")
+	}
+	if d.Labels["app"] != "test" || d.Annotations["perses.dev/tags"] != "oncall" {
+		t.Error("expected Labels and Annotations to be preserved")
+	}
+	if len(d.Status.Conditions) != 1 || d.Status.Conditions[0].Type != common.TypeAvailablePerses {
+		t.Error("expected Status.Conditions to be preserved")
+	}
+}
+
+func TestBuildCacheByObject_DashboardTransformEmptyObject(t *testing.T) {
+	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
+
+	dashboard := &persesv1alpha2.PersesDashboard{}
+	result, err := transform(dashboard)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	if result.(*persesv1alpha2.PersesDashboard) == nil {
+		t.Error("expected non-nil result")
+	}
+}
+
+func TestBuildCacheByObject_DatasourceTransformStripsSpec(t *testing.T) {
+	transform := getCRDTransform(t, &persesv1alpha2.PersesDatasource{})
+
+	datasource := &persesv1alpha2.PersesDatasource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-ds",
+			Namespace:       "test-ns",
+			ResourceVersion: "67890",
+		},
+		Spec: persesv1alpha2.DatasourceSpec{
+			Config: persesv1alpha2.Datasource{
+				DatasourceSpec: persesv1.DatasourceSpec{
+					Default: true,
+					Plugin:  persesv1Common.Plugin{Kind: "PrometheusDatasource"},
+				},
+			},
+			Client: &persesv1alpha2.Client{
+				BasicAuth: &persesv1alpha2.BasicAuth{Username: "admin"},
+			},
+			InstanceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+		Status: persesv1alpha2.PersesDatasourceStatus{
+			Conditions: []metav1.Condition{{
+				Type:   common.TypeAvailablePerses,
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+
+	result, err := transform(datasource)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	d := result.(*persesv1alpha2.PersesDatasource)
+
+	if d.Spec.Config.Default || d.Spec.Config.Plugin.Kind != "" {
+		t.Error("expected Spec.Config to be zeroed")
+	}
+	if d.Spec.Client != nil {
+		t.Error("expected Spec.Client to be nil")
+	}
+	if d.Spec.InstanceSelector != nil {
+		t.Error("expected Spec.InstanceSelector to be nil")
+	}
+
+	if d.Name != "test-ds" || d.ResourceVersion != "67890" {
+		t.Error("expected ObjectMeta to be preserved")
+	}
+	if len(d.Status.Conditions) != 1 {
+		t.Error("expected Status.Conditions to be preserved")
+	}
+}
+
+func TestBuildCacheByObject_GlobalDatasourceTransformStripsSpec(t *testing.T) {
+	transform := getCRDTransform(t, &persesv1alpha2.PersesGlobalDatasource{})
+
+	gds := &persesv1alpha2.PersesGlobalDatasource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-gds",
+			ResourceVersion: "11111",
+		},
+		Spec: persesv1alpha2.DatasourceSpec{
+			Config: persesv1alpha2.Datasource{
+				DatasourceSpec: persesv1.DatasourceSpec{
+					Default: true,
+					Plugin:  persesv1Common.Plugin{Kind: "PrometheusDatasource"},
+				},
+			},
+			Client: &persesv1alpha2.Client{
+				BasicAuth: &persesv1alpha2.BasicAuth{Username: "admin"},
+			},
+			InstanceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "prod"},
+			},
+		},
+		Status: persesv1alpha2.PersesGlobalDatasourceStatus{
+			Conditions: []metav1.Condition{{
+				Type:   common.TypeAvailablePerses,
+				Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+
+	result, err := transform(gds)
+	if err != nil {
+		t.Fatalf("Transform returned error: %v", err)
+	}
+
+	d := result.(*persesv1alpha2.PersesGlobalDatasource)
+
+	if d.Spec.Config.Default || d.Spec.Config.Plugin.Kind != "" {
+		t.Error("expected Spec.Config to be zeroed")
+	}
+	if d.Spec.Client != nil {
+		t.Error("expected Spec.Client to be nil")
+	}
+	if d.Spec.InstanceSelector != nil {
+		t.Error("expected Spec.InstanceSelector to be nil")
+	}
+
+	if d.Name != "test-gds" || d.ResourceVersion != "11111" {
+		t.Error("expected ObjectMeta to be preserved")
+	}
+	if len(d.Status.Conditions) != 1 {
+		t.Error("expected Status.Conditions to be preserved")
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -90,7 +90,7 @@ func NewMetrics() *Metrics {
 				Name: "perses_operator_managed_perses_instances",
 				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"resource_namespace"},
+			[]string{"resource_namespace", "resource_name"},
 		),
 		ready: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -124,9 +124,15 @@ func (m *Metrics) ReconcileErrors(controller, reason string) prometheus.Counter 
 	return m.reconcileErrors.With(prometheus.Labels{"controller": controller, "reason": reason})
 }
 
-// PersesInstances returns a gauge to track Perses instance count.
-func (m *Metrics) PersesInstances(namespace string) prometheus.Gauge {
-	return m.persesInstances.With(prometheus.Labels{"resource_namespace": namespace})
+// PersesInstances returns a gauge to track a specific Perses instance.
+func (m *Metrics) PersesInstances(namespace, name string) prometheus.Gauge {
+	return m.persesInstances.With(prometheus.Labels{"resource_namespace": namespace, "resource_name": name})
+}
+
+// DeletePersesInstance removes the gauge entry for the given Perses instance.
+// It should be called when a Perses instance is deleted to clean up stale label sets.
+func (m *Metrics) DeletePersesInstance(namespace, name string) {
+	m.persesInstances.DeleteLabelValues(namespace, name)
 }
 
 // Ready returns a gauge to track operator readiness for the given controller.
@@ -144,13 +150,26 @@ func (m *Metrics) SetFailedResources(objKey, resource string, v int) {
 	m.setResources(objKey, resourceKey{resource: resource, state: failed}, v)
 }
 
+// ForgetObject removes all resource entries for the given object key.
+// It should be called when a controller detects that the object has been deleted.
+func (m *Metrics) ForgetObject(objKey string) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	for rKey := range m.resources {
+		delete(m.resources[rKey], objKey)
+		if len(m.resources[rKey]) == 0 {
+			delete(m.resources, rKey)
+		}
+	}
+}
+
 func (m *Metrics) setResources(objKey string, resKey resourceKey, v int) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
 	if _, found := m.resources[resKey]; !found {
-		m.resources[resourceKey{resource: resKey.resource, state: synced}] = make(map[string]int)
-		m.resources[resourceKey{resource: resKey.resource, state: failed}] = make(map[string]int)
+		m.resources[resKey] = make(map[string]int)
 	}
 
 	m.resources[resKey][objKey] = v

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -47,7 +47,7 @@ func TestNewMetrics(t *testing.T) {
 				Name: "perses_operator_managed_perses_instances",
 				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"resource_namespace"},
+			[]string{"resource_namespace", "resource_name"},
 		),
 		ready: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -64,7 +64,7 @@ func TestNewMetrics(t *testing.T) {
 	// Set some values so metrics appear in output
 	m.reconcileOperations.WithLabelValues("test").Add(1)
 	m.reconcileErrors.WithLabelValues("test", "test_reason").Add(0)
-	m.persesInstances.WithLabelValues("test-ns").Set(1)
+	m.persesInstances.WithLabelValues("test-ns", "test-perses").Set(1)
 	m.Ready("test").Set(1)
 
 	// Verify metrics are registered
@@ -159,22 +159,22 @@ func TestPersesInstancesGauge(t *testing.T) {
 				Name: "perses_operator_managed_perses_instances",
 				Help: "Number of Perses instances managed by the operator",
 			},
-			[]string{"resource_namespace"},
+			[]string{"resource_namespace", "resource_name"},
 		),
 		resources: make(map[resourceKey]map[string]int),
 	}
 	reg.MustRegister(m.persesInstances)
 
 	// Set instance counts
-	m.PersesInstances("perses-dev").Set(1)
-	m.PersesInstances("production").Set(3)
+	m.PersesInstances("perses-dev", "perses-1").Set(1)
+	m.PersesInstances("production", "perses-prod").Set(1)
 
 	// Verify values
 	expected := `
 		# HELP perses_operator_managed_perses_instances Number of Perses instances managed by the operator
 		# TYPE perses_operator_managed_perses_instances gauge
-		perses_operator_managed_perses_instances{resource_namespace="perses-dev"} 1
-		perses_operator_managed_perses_instances{resource_namespace="production"} 3
+		perses_operator_managed_perses_instances{resource_name="perses-1",resource_namespace="perses-dev"} 1
+		perses_operator_managed_perses_instances{resource_name="perses-prod",resource_namespace="production"} 1
 	`
 	err := testutil.CollectAndCompare(m.persesInstances, strings.NewReader(expected))
 	assert.NoError(t, err)
@@ -268,6 +268,127 @@ func TestResourceStateString(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.state.String())
 		})
 	}
+}
+
+func TestDeletePersesInstance(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		persesInstances: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "perses_operator_managed_perses_instances",
+				Help: "Number of Perses instances managed by the operator",
+			},
+			[]string{"resource_namespace", "resource_name"},
+		),
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m.persesInstances)
+
+	// Set instances for two namespaces
+	m.PersesInstances("perses-dev", "perses-1").Set(1)
+	m.PersesInstances("production", "perses-prod").Set(1)
+
+	// Delete one instance
+	m.DeletePersesInstance("perses-dev", "perses-1")
+
+	// Verify only production remains
+	expected := `
+		# HELP perses_operator_managed_perses_instances Number of Perses instances managed by the operator
+		# TYPE perses_operator_managed_perses_instances gauge
+		perses_operator_managed_perses_instances{resource_name="perses-prod",resource_namespace="production"} 1
+	`
+	err := testutil.CollectAndCompare(m.persesInstances, strings.NewReader(expected))
+	assert.NoError(t, err)
+
+	// Deleting a non-existent instance should not panic
+	m.DeletePersesInstance("nonexistent", "nonexistent")
+}
+
+func TestForgetObject(t *testing.T) {
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	// Set synced and failed entries for multiple objects
+	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
+	m.SetFailedResources("ns1/resource1", "dashboard", 1)
+	m.SetSyncedResources("ns2/resource3", "datasource", 1)
+
+	// Forget resource1
+	m.ForgetObject("ns1/resource1")
+
+	// Verify resource1 is removed from both synced and failed maps
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	syncedDashboard := resourceKey{resource: "dashboard", state: synced}
+	failedDashboard := resourceKey{resource: "dashboard", state: failed}
+	syncedDatasource := resourceKey{resource: "datasource", state: synced}
+
+	assert.Equal(t, 1, len(m.resources[syncedDashboard]), "Should have 1 synced dashboard after forget")
+	assert.Equal(t, 1, len(m.resources[syncedDatasource]), "Datasource should be unaffected")
+
+	// Empty outer map entries should be removed
+	_, outerExists := m.resources[failedDashboard]
+	assert.False(t, outerExists, "Empty outer map entry should be removed")
+
+	// resource2 should still exist
+	assert.Equal(t, 1, m.resources[syncedDashboard]["ns1/resource2"])
+	// resource1 should be gone
+	_, exists := m.resources[syncedDashboard]["ns1/resource1"]
+	assert.False(t, exists, "resource1 should be removed from synced map")
+}
+
+func TestForgetObjectCollectOutput(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+	reg.MustRegister(m)
+
+	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
+	m.SetFailedResources("ns1/resource3", "dashboard", 1)
+
+	// Forget resource1 and resource3
+	m.ForgetObject("ns1/resource1")
+	m.ForgetObject("ns1/resource3")
+
+	// Collect and verify totals — the failed entry should disappear entirely
+	// since no objects remain in that category
+	expected := `
+		# HELP perses_operator_managed_resources Number of resources managed by the operator per state (synced/failed)
+		# TYPE perses_operator_managed_resources gauge
+		perses_operator_managed_resources{resource="dashboard",state="synced"} 1
+	`
+	err := testutil.CollectAndCompare(m, strings.NewReader(expected))
+	assert.NoError(t, err)
+}
+
+func TestForgetObjectConcurrency(t *testing.T) {
+	m := &Metrics{
+		resources: make(map[resourceKey]map[string]int),
+	}
+
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			key := "test/resource"
+			m.SetSyncedResources(key, "dashboard", id)
+			m.SetFailedResources(key, "datasource", id)
+			m.ForgetObject(key)
+			done <- true
+		}(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	assert.NotNil(t, m.resources)
 }
 
 func TestMetricsConcurrency(t *testing.T) {

--- a/internal/perses/common/perses_client_factory.go
+++ b/internal/perses/common/perses_client_factory.go
@@ -18,6 +18,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
+	"sync"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,13 +38,144 @@ type PersesClientFactory interface {
 	CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error)
 }
 
-type PersesClientFactoryWithConfig struct{}
+type PersesClientCacheInvalidator interface {
+	ForgetInstance(key string)
+}
 
-func NewWithConfig() PersesClientFactory {
-	return &PersesClientFactoryWithConfig{}
+const defaultClientCacheTTL = 5 * time.Minute
+
+type clientCacheEntry struct {
+	client      v1.ClientInterface
+	fingerprint string
+	createdAt   time.Time
+}
+
+type PersesClientFactoryWithConfig struct {
+	mtx       sync.RWMutex
+	cache     map[string]clientCacheEntry
+	ttl       time.Duration
+	lastSweep time.Time
+}
+
+func NewWithConfig() *PersesClientFactoryWithConfig {
+	return &PersesClientFactoryWithConfig{
+		cache: make(map[string]clientCacheEntry),
+		ttl:   defaultClientCacheTTL,
+	}
+}
+
+// ForgetInstance removes the cached client for the given Perses instance key.
+// The key format is "namespace/name".
+func (f *PersesClientFactoryWithConfig) ForgetInstance(key string) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	if entry, exists := f.cache[key]; exists {
+		closeClientConnections(entry.client)
+	}
+	delete(f.cache, key)
+}
+
+// sweepExpiredLocked removes cache entries whose TTL has elapsed.
+// It runs at most once per TTL interval to amortise the iteration cost.
+// Caller must hold f.mtx write lock.
+func (f *PersesClientFactoryWithConfig) sweepExpiredLocked() {
+	now := time.Now()
+	if now.Sub(f.lastSweep) < f.ttl {
+		return
+	}
+	for key, entry := range f.cache {
+		if now.Sub(entry.createdAt) >= f.ttl {
+			closeClientConnections(entry.client)
+			delete(f.cache, key)
+		}
+	}
+	f.lastSweep = now
+}
+
+func closeClientConnections(c v1.ClientInterface) {
+	if c == nil {
+		return
+	}
+	if rest := c.RESTClient(); rest != nil && rest.Client != nil {
+		rest.Client.CloseIdleConnections()
+	}
+}
+
+func configFingerprint(perses persesv1alpha2.Perses) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "ns=%s,name=%s,gen=%d,", perses.Namespace, perses.Name, perses.Generation)
+	if perses.Spec.ContainerPort != nil {
+		fmt.Fprintf(&b, "port=%d,", *perses.Spec.ContainerPort)
+	}
+	fmt.Fprintf(&b, "apiPrefix=%s,", perses.Spec.Config.APIPrefix)
+	fmt.Fprintf(&b, "tls=%v,", isTLSEnabled(&perses))
+	fmt.Fprintf(&b, "k8sAuth=%v,", isKubernetesAuthEnabled(&perses))
+	fmt.Fprintf(&b, "clientTLS=%v,", isClientTLSEnabled(&perses))
+	serverURLFlag := flag.Lookup(PersesServerURLFlag)
+	if serverURLFlag != nil {
+		fmt.Fprintf(&b, "serverURL=%s,", serverURLFlag.Value.String())
+	}
+	return b.String()
+}
+
+// cacheHit returns the cached client if it exists, has the matching fingerprint,
+// and has not expired. Caller must hold at least RLock.
+func (f *PersesClientFactoryWithConfig) cacheHit(instanceKey, fingerprint string) (v1.ClientInterface, bool) {
+	entry, ok := f.cache[instanceKey]
+	if !ok {
+		return nil, false
+	}
+	if entry.fingerprint != fingerprint {
+		return nil, false
+	}
+	if time.Since(entry.createdAt) >= f.ttl {
+		return nil, false
+	}
+	return entry.client, true
 }
 
 func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
+	instanceKey := fmt.Sprintf("%s/%s", perses.Namespace, perses.Name)
+	fingerprint := configFingerprint(perses)
+
+	// Check cache under read lock — no file I/O needed.
+	// The TTL bounds credential staleness (SA token, TLS certs) so the
+	// fingerprint only tracks config shape (Generation, port, TLS flags).
+	f.mtx.RLock()
+	if cached, ok := f.cacheHit(instanceKey, fingerprint); ok {
+		f.mtx.RUnlock()
+		return cached, nil
+	}
+	f.mtx.RUnlock()
+
+	// Build the client without holding any lock to avoid blocking other
+	// controllers during slow operations (TLS cert fetches from API server).
+	newClient, err := f.buildClient(ctx, client, perses)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store in cache under write lock. Re-check in case another goroutine raced.
+	f.mtx.Lock()
+	if cached, ok := f.cacheHit(instanceKey, fingerprint); ok {
+		f.mtx.Unlock()
+		return cached, nil
+	}
+	if old, exists := f.cache[instanceKey]; exists {
+		closeClientConnections(old.client)
+	}
+	f.cache[instanceKey] = clientCacheEntry{
+		client:      newClient,
+		fingerprint: fingerprint,
+		createdAt:   time.Now(),
+	}
+	f.sweepExpiredLocked()
+	f.mtx.Unlock()
+
+	return newClient, nil
+}
+
+func (f *PersesClientFactoryWithConfig) buildClient(ctx context.Context, client client.Reader, perses persesv1alpha2.Perses) (v1.ClientInterface, error) {
 	var urlStr string
 
 	var httpProtocol = "http"
@@ -74,11 +208,9 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 			return nil, fmt.Errorf("failed to read service account token from %s: %w", tokenPath, err)
 		}
 		saToken := string(tokenBytes)
-
 		if saToken == "" {
 			return nil, fmt.Errorf("service account token is empty, ensure the Perses operator has the correct permissions")
 		}
-
 		config.Headers = map[string]string{
 			"Authorization": "Bearer " + saToken,
 		}
@@ -135,9 +267,7 @@ func (f *PersesClientFactoryWithConfig) CreateClient(ctx context.Context, client
 		return nil, err
 	}
 
-	persesClient := v1.NewWithClient(restClient)
-
-	return persesClient, nil
+	return v1.NewWithClient(restClient), nil
 }
 
 type PersesClientFactoryWithClient struct {

--- a/internal/perses/common/perses_client_factory_test.go
+++ b/internal/perses/common/perses_client_factory_test.go
@@ -1,0 +1,213 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
+)
+
+func TestConfigFingerprint(t *testing.T) {
+	base := persesv1alpha2.Perses{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "perses-1",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: persesv1alpha2.PersesSpec{
+			ContainerPort: ptr.To(int32(8080)),
+		},
+	}
+
+	fp1 := configFingerprint(base)
+
+	// Same config produces same fingerprint
+	fp2 := configFingerprint(base)
+	assert.Equal(t, fp1, fp2, "Same config should produce same fingerprint")
+
+	// Different Generation changes fingerprint
+	modified := base.DeepCopy()
+	modified.Generation = 2
+	fp3 := configFingerprint(*modified)
+	assert.NotEqual(t, fp1, fp3, "Different Generation should change fingerprint")
+
+	// Different port changes fingerprint
+	modified = base.DeepCopy()
+	modified.Spec.ContainerPort = ptr.To(int32(9090))
+	fp4 := configFingerprint(*modified)
+	assert.NotEqual(t, fp1, fp4, "Different port should change fingerprint")
+
+	// Different namespace changes fingerprint
+	modified = base.DeepCopy()
+	modified.Namespace = "production"
+	fp5 := configFingerprint(*modified)
+	assert.NotEqual(t, fp1, fp5, "Different namespace should change fingerprint")
+
+	// Enabling client TLS changes fingerprint
+	modified = base.DeepCopy()
+	modified.Spec.Client = &persesv1alpha2.Client{
+		TLS: &persesv1alpha2.TLS{
+			Enable: ptr.To(true),
+		},
+	}
+	fp6 := configFingerprint(*modified)
+	assert.NotEqual(t, fp1, fp6, "Enabling client TLS should change fingerprint")
+
+	// Same ResourceVersion but different Generation produces different fingerprint
+	modified = base.DeepCopy()
+	modified.ResourceVersion = "999"
+	fpSameGen := configFingerprint(*modified)
+	assert.Equal(t, fp1, fpSameGen, "ResourceVersion changes should not affect fingerprint")
+}
+
+func TestForgetInstance(t *testing.T) {
+	factory := NewWithConfig()
+
+	// Manually populate cache
+	factory.cache["default/perses-1"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "test-fp",
+	}
+	factory.cache["prod/perses-2"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "test-fp-2",
+	}
+
+	assert.Len(t, factory.cache, 2)
+
+	factory.ForgetInstance("default/perses-1")
+	assert.Len(t, factory.cache, 1)
+
+	_, exists := factory.cache["default/perses-1"]
+	assert.False(t, exists, "Entry should be removed")
+
+	_, exists = factory.cache["prod/perses-2"]
+	assert.True(t, exists, "Other entry should remain")
+
+	// Forgetting a non-existent key should not panic
+	factory.ForgetInstance("nonexistent/key")
+	assert.Len(t, factory.cache, 1)
+}
+
+func TestCacheHitTTLExpiry(t *testing.T) {
+	factory := NewWithConfig()
+	factory.ttl = 100 * time.Millisecond
+
+	factory.cache["default/perses-1"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "fp-1",
+		createdAt:   time.Now(),
+	}
+
+	// Fresh entry should be a hit
+	cached, ok := factory.cacheHit("default/perses-1", "fp-1")
+	assert.True(t, ok, "Fresh entry should be a cache hit")
+	assert.Nil(t, cached)
+
+	// Wrong fingerprint should miss
+	_, ok = factory.cacheHit("default/perses-1", "fp-different")
+	assert.False(t, ok, "Wrong fingerprint should be a cache miss")
+
+	// Wait for TTL to expire
+	time.Sleep(150 * time.Millisecond)
+	_, ok = factory.cacheHit("default/perses-1", "fp-1")
+	assert.False(t, ok, "Expired entry should be a cache miss")
+}
+
+func TestSweepExpiredEntries(t *testing.T) {
+	factory := NewWithConfig()
+	factory.ttl = 50 * time.Millisecond
+
+	factory.cache["default/perses-1"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "fp-1",
+		createdAt:   time.Now(),
+	}
+	factory.cache["default/perses-2"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "fp-2",
+		createdAt:   time.Now(),
+	}
+
+	assert.Len(t, factory.cache, 2)
+
+	// Wait for entries to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Add a fresh entry that should survive the sweep
+	factory.cache["default/perses-3"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "fp-3",
+		createdAt:   time.Now(),
+	}
+
+	factory.mtx.Lock()
+	factory.sweepExpiredLocked()
+	factory.mtx.Unlock()
+
+	assert.Len(t, factory.cache, 1, "Only the fresh entry should remain")
+	_, exists := factory.cache["default/perses-3"]
+	assert.True(t, exists, "Fresh entry should survive sweep")
+}
+
+func TestSweepSkipsBeforeInterval(t *testing.T) {
+	factory := NewWithConfig()
+	factory.ttl = 50 * time.Millisecond
+	factory.lastSweep = time.Now()
+
+	// Add an expired entry
+	factory.cache["default/perses-1"] = clientCacheEntry{
+		client:      nil,
+		fingerprint: "fp-1",
+		createdAt:   time.Now().Add(-time.Minute),
+	}
+
+	// Sweep should be skipped because lastSweep is recent
+	factory.mtx.Lock()
+	factory.sweepExpiredLocked()
+	factory.mtx.Unlock()
+
+	assert.Len(t, factory.cache, 1, "Expired entry should still exist because sweep was skipped")
+}
+
+func TestClientCacheConcurrency(t *testing.T) {
+	factory := NewWithConfig()
+
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := "default/perses-1"
+			factory.mtx.Lock()
+			factory.cache[key] = clientCacheEntry{
+				client:      nil,
+				fingerprint: "fp",
+				createdAt:   time.Now(),
+			}
+			factory.mtx.Unlock()
+			factory.ForgetInstance(key)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.NotNil(t, factory.cache)
+}

--- a/internal/perses/common/status.go
+++ b/internal/perses/common/status.go
@@ -1,0 +1,34 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SnapshotConditions returns a shallow copy of the conditions slice.
+// Use before applying mutations so the original values are preserved
+// for comparison with ConditionsChanged.
+func SnapshotConditions(conditions []metav1.Condition) []metav1.Condition {
+	snapshot := make([]metav1.Condition, len(conditions))
+	copy(snapshot, conditions)
+	return snapshot
+}
+
+// ConditionsChanged reports whether the conditions slice differs from
+// a previously taken snapshot. It is safe to call with nil or empty slices.
+func ConditionsChanged(before, after []metav1.Condition) bool {
+	return !equality.Semantic.DeepEqual(before, after)
+}

--- a/internal/perses/common/status_test.go
+++ b/internal/perses/common/status_test.go
@@ -1,0 +1,154 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+func makeCondition(typ string, status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               typ,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+}
+
+func TestConditionsChanged(t *testing.T) {
+	tests := []struct {
+		name    string
+		before  []metav1.Condition
+		after   []metav1.Condition
+		changed bool
+	}{
+		{
+			name:    "both empty",
+			before:  []metav1.Condition{},
+			after:   []metav1.Condition{},
+			changed: false,
+		},
+		{
+			name:    "both nil",
+			before:  nil,
+			after:   nil,
+			changed: false,
+		},
+		{
+			name:    "identical single condition",
+			before:  []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok")},
+			after:   []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok")},
+			changed: false,
+		},
+		{
+			name:    "different status",
+			before:  []metav1.Condition{makeCondition("Available", metav1.ConditionFalse, "Reconciled", "ok")},
+			after:   []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok")},
+			changed: true,
+		},
+		{
+			name:    "different reason",
+			before:  []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciling", "ok")},
+			after:   []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok")},
+			changed: true,
+		},
+		{
+			name:    "different message",
+			before:  []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "starting")},
+			after:   []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "done")},
+			changed: true,
+		},
+		{
+			name:   "condition added",
+			before: []metav1.Condition{makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok")},
+			after: []metav1.Condition{
+				makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok"),
+				makeCondition("Degraded", metav1.ConditionFalse, "Reconciled", "ok"),
+			},
+			changed: true,
+		},
+		{
+			name:    "empty to non-empty",
+			before:  []metav1.Condition{},
+			after:   []metav1.Condition{makeCondition("Available", metav1.ConditionUnknown, "Reconciling", "starting")},
+			changed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.changed, ConditionsChanged(tt.before, tt.after))
+		})
+	}
+}
+
+func TestSnapshotConditions(t *testing.T) {
+	original := []metav1.Condition{
+		makeCondition("Available", metav1.ConditionTrue, "Reconciled", "ok"),
+		makeCondition("Degraded", metav1.ConditionFalse, "Reconciled", "ok"),
+	}
+
+	snapshot := SnapshotConditions(original)
+
+	assert.Equal(t, original, snapshot)
+	assert.False(t, ConditionsChanged(snapshot, original))
+
+	// Mutating the original via SetStatusCondition should not affect the snapshot
+	meta.SetStatusCondition(&original, metav1.Condition{
+		Type:   "Available",
+		Status: metav1.ConditionFalse,
+		Reason: "Error",
+	})
+
+	assert.True(t, ConditionsChanged(snapshot, original),
+		"snapshot should differ after mutating original")
+}
+
+func TestSnapshotConditionsEmpty(t *testing.T) {
+	snapshot := SnapshotConditions(nil)
+	assert.NotNil(t, snapshot)
+	assert.Empty(t, snapshot)
+}
+
+func TestSetStatusConditionIdempotency(t *testing.T) {
+	conditions := []metav1.Condition{}
+
+	// First call: sets the condition
+	meta.SetStatusCondition(&conditions, metav1.Condition{
+		Type:    "Available",
+		Status:  metav1.ConditionTrue,
+		Reason:  "Reconciled",
+		Message: "Dashboard reconciled successfully",
+	})
+
+	snapshot := SnapshotConditions(conditions)
+
+	// Second call with identical values: meta.SetStatusCondition is a no-op
+	// (doesn't update LastTransitionTime when Status unchanged)
+	meta.SetStatusCondition(&conditions, metav1.Condition{
+		Type:    "Available",
+		Status:  metav1.ConditionTrue,
+		Reason:  "Reconciled",
+		Message: "Dashboard reconciled successfully",
+	})
+
+	assert.False(t, ConditionsChanged(snapshot, conditions),
+		"re-applying identical condition should not register as changed")
+}

--- a/internal/perses/common/sync.go
+++ b/internal/perses/common/sync.go
@@ -1,0 +1,42 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"maps"
+
+	persesv1 "github.com/perses/perses/pkg/model/api/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// DashboardInSync returns true if the existing dashboard in Perses
+// matches the desired state (tags and spec).
+func DashboardInSync(existing, desired *persesv1.Dashboard) bool {
+	return maps.Equal(existing.Metadata.Tags, desired.Metadata.Tags) &&
+		equality.Semantic.DeepEqual(existing.Spec, desired.Spec)
+}
+
+// DatasourceInSync returns true if the existing datasource in Perses
+// matches the desired state (tags and spec).
+func DatasourceInSync(existing, desired *persesv1.Datasource) bool {
+	return maps.Equal(existing.Metadata.Tags, desired.Metadata.Tags) &&
+		equality.Semantic.DeepEqual(existing.Spec, desired.Spec)
+}
+
+// GlobalDatasourceInSync returns true if the existing global datasource
+// in Perses matches the desired state (tags and spec).
+func GlobalDatasourceInSync(existing, desired *persesv1.GlobalDatasource) bool {
+	return maps.Equal(existing.Metadata.Tags, desired.Metadata.Tags) &&
+		equality.Semantic.DeepEqual(existing.Spec, desired.Spec)
+}

--- a/internal/perses/common/sync_test.go
+++ b/internal/perses/common/sync_test.go
@@ -1,0 +1,172 @@
+// Copyright The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/perses/common/set"
+	persesv1 "github.com/perses/perses/pkg/model/api/v1"
+	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDashboardInSync(t *testing.T) {
+	baseDashboard := func() *persesv1.Dashboard {
+		return &persesv1.Dashboard{
+			Kind: persesv1.KindDashboard,
+			Metadata: persesv1.ProjectMetadata{
+				Metadata: persesv1.Metadata{
+					Name: "test-dashboard",
+					Tags: set.New("tag1", "tag2"),
+				},
+			},
+			Spec: persesv1.DashboardSpec{
+				Duration: "1h",
+				Display:  &persesv1Common.Display{Name: "Test"},
+			},
+		}
+	}
+
+	t.Run("identical dashboards", func(t *testing.T) {
+		assert.True(t, DashboardInSync(baseDashboard(), baseDashboard()))
+	})
+
+	t.Run("different tags", func(t *testing.T) {
+		existing := baseDashboard()
+		desired := baseDashboard()
+		desired.Metadata.Tags = set.New("tag3")
+		assert.False(t, DashboardInSync(existing, desired))
+	})
+
+	t.Run("different spec", func(t *testing.T) {
+		existing := baseDashboard()
+		desired := baseDashboard()
+		desired.Spec.Duration = "2h"
+		assert.False(t, DashboardInSync(existing, desired))
+	})
+
+	t.Run("extra metadata on existing does not affect comparison", func(t *testing.T) {
+		existing := baseDashboard()
+		existing.Metadata.Version = 5
+		existing.Metadata.CreatedAt = time.Now()
+		existing.Metadata.UpdatedAt = time.Now()
+		assert.True(t, DashboardInSync(existing, baseDashboard()))
+	})
+
+	t.Run("nil tags on both", func(t *testing.T) {
+		existing := baseDashboard()
+		desired := baseDashboard()
+		existing.Metadata.Tags = nil
+		desired.Metadata.Tags = nil
+		assert.True(t, DashboardInSync(existing, desired))
+	})
+
+	t.Run("empty tags on both", func(t *testing.T) {
+		existing := baseDashboard()
+		desired := baseDashboard()
+		existing.Metadata.Tags = set.Set[string]{}
+		desired.Metadata.Tags = set.Set[string]{}
+		assert.True(t, DashboardInSync(existing, desired))
+	})
+}
+
+func TestDatasourceInSync(t *testing.T) {
+	baseDatasource := func() *persesv1.Datasource {
+		return &persesv1.Datasource{
+			Kind: persesv1.KindDatasource,
+			Metadata: persesv1.ProjectMetadata{
+				Metadata: persesv1.Metadata{
+					Name: "test-ds",
+					Tags: set.New("ds-tag"),
+				},
+			},
+			Spec: persesv1.DatasourceSpec{
+				Default: true,
+				Plugin: persesv1Common.Plugin{
+					Kind: "PrometheusDatasource",
+				},
+			},
+		}
+	}
+
+	t.Run("identical datasources", func(t *testing.T) {
+		assert.True(t, DatasourceInSync(baseDatasource(), baseDatasource()))
+	})
+
+	t.Run("different tags", func(t *testing.T) {
+		existing := baseDatasource()
+		desired := baseDatasource()
+		desired.Metadata.Tags = set.New("other-tag")
+		assert.False(t, DatasourceInSync(existing, desired))
+	})
+
+	t.Run("different spec", func(t *testing.T) {
+		existing := baseDatasource()
+		desired := baseDatasource()
+		desired.Spec.Default = false
+		assert.False(t, DatasourceInSync(existing, desired))
+	})
+
+	t.Run("extra metadata on existing", func(t *testing.T) {
+		existing := baseDatasource()
+		existing.Metadata.Version = 3
+		existing.Metadata.CreatedAt = time.Now()
+		assert.True(t, DatasourceInSync(existing, baseDatasource()))
+	})
+}
+
+func TestGlobalDatasourceInSync(t *testing.T) {
+	baseGlobalDS := func() *persesv1.GlobalDatasource {
+		return &persesv1.GlobalDatasource{
+			Kind: persesv1.KindGlobalDatasource,
+			Metadata: persesv1.Metadata{
+				Name: "test-gds",
+				Tags: set.New("gds-tag"),
+			},
+			Spec: persesv1.DatasourceSpec{
+				Default: true,
+				Plugin: persesv1Common.Plugin{
+					Kind: "PrometheusDatasource",
+				},
+			},
+		}
+	}
+
+	t.Run("identical global datasources", func(t *testing.T) {
+		assert.True(t, GlobalDatasourceInSync(baseGlobalDS(), baseGlobalDS()))
+	})
+
+	t.Run("different tags", func(t *testing.T) {
+		existing := baseGlobalDS()
+		desired := baseGlobalDS()
+		desired.Metadata.Tags = set.New("other-tag")
+		assert.False(t, GlobalDatasourceInSync(existing, desired))
+	})
+
+	t.Run("different spec", func(t *testing.T) {
+		existing := baseGlobalDS()
+		desired := baseGlobalDS()
+		desired.Spec.Default = false
+		assert.False(t, GlobalDatasourceInSync(existing, desired))
+	})
+
+	t.Run("extra metadata on existing", func(t *testing.T) {
+		existing := baseGlobalDS()
+		existing.Metadata.Version = 10
+		existing.Metadata.CreatedAt = time.Now()
+		assert.True(t, GlobalDatasourceInSync(existing, baseGlobalDS()))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	k8sapiflag "k8s.io/component-base/cli/flag"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -122,7 +122,7 @@ func main() {
 	if watchAllSecrets && watchSecretLabelsFlag != "" {
 		setupLog.Info("--watch-all-secrets is set, --watch-secret-labels will be ignored")
 	}
-	cacheByObject := internalcache.BuildCacheByObject(secretSelector, watchAllSecrets, tlsClusterProfile)
+	cacheOpts := internalcache.BuildCacheOptions(secretSelector, watchAllSecrets, tlsClusterProfile)
 
 	// Parse and validate TLS settings
 	parsedTLSMinVersion, err := operatortls.ParseTLSVersion(tlsMinVersion)
@@ -215,9 +215,7 @@ func main() {
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 		PprofBindAddress: "127.0.0.1:8083",
-		Cache: cache.Options{
-			ByObject: cacheByObject,
-		},
+		Cache: cacheOpts,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -236,12 +236,15 @@ func main() {
 	opMetrics := operatormetrics.NewMetrics()
 	reconciliationTracker := operatormetrics.NewReconciliationTracker(ctrlmetrics.Registry)
 
+	persesClientFactory := common.NewWithConfig()
+
 	if err = (&persescontroller.PersesReconciler{
-		Client:                mgr.GetClient(),
-		APIReader:             mgr.GetAPIReader(),
-		Scheme:                mgr.GetScheme(),
-		Metrics:               opMetrics,
-		ReconciliationTracker: reconciliationTracker,
+		Client:                 mgr.GetClient(),
+		APIReader:              mgr.GetAPIReader(),
+		Scheme:                 mgr.GetScheme(),
+		Metrics:                opMetrics,
+		ReconciliationTracker:  reconciliationTracker,
+		ClientCacheInvalidator: persesClientFactory,
 		Config: persescontroller.Config{
 			PersesImage:          persesImage,
 			TLSMinVersion:        tlsMinVersion,
@@ -259,7 +262,7 @@ func main() {
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
-		ClientFactory:         common.NewWithConfig(),
+		ClientFactory:         persesClientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PersesDashboard")
 		os.Exit(1)
@@ -271,7 +274,7 @@ func main() {
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
-		ClientFactory:         common.NewWithConfig(),
+		ClientFactory:         persesClientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PersesDatasource")
 		os.Exit(1)
@@ -283,7 +286,7 @@ func main() {
 		Scheme:                mgr.GetScheme(),
 		Metrics:               opMetrics,
 		ReconciliationTracker: reconciliationTracker,
-		ClientFactory:         common.NewWithConfig(),
+		ClientFactory:         persesClientFactory,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PersesGlobalDatasource")
 		os.Exit(1)


### PR DESCRIPTION
# Description

This PR:
- Fixes a memory leak with the metrics when resources are deleted
- Caches the Perses clients created by the client factory to improve memory consumption and avoid creating a client for each reconcile request
- Updates status only when they change
- Removes managed fields and specs from the tracking cache payloads

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
