### PR TITLE
[ENHANCEMENT] use only metadata to watch for resources to optimize memory consumption

### DIFF
--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -22,7 +22,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,7 +54,7 @@ func dashboardFromContext(ctx context.Context) (*persesv1alpha2.PersesDashboard,
 // PersesDashboardReconciler reconciles a PersesDashboard object
 type PersesDashboardReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
+	APIReader             client.Reader // uncached reader — OnlyMetadata watch caches metadata only
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -153,7 +152,7 @@ func (r *PersesDashboardReconciler) updateDashboardStatus(
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fresh := &persesv1alpha2.PersesDashboard{}
-		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
+		if err := r.APIReader.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
 		before := common.SnapshotConditions(fresh.Status.Conditions)
@@ -230,22 +229,7 @@ func (r *PersesDashboardReconciler) setStatusToDegraded(
 // Each dashboard's instanceSelector labels determine which Perses instances it syncs to.
 // If no instanceSelector is set, the dashboard syncs to all Perses instances.
 func (r *PersesDashboardReconciler) findDashboardsForPerses(ctx context.Context, _ client.Object) []reconcile.Request {
-	dashboards := &persesv1alpha2.PersesDashboardList{}
-	if err := r.List(ctx, dashboards); err != nil {
-		log.WithError(err).Error("Failed to list dashboards for Perses instance change")
-		return nil
-	}
-
-	requests := make([]reconcile.Request, len(dashboards.Items))
-	for i, d := range dashboards.Items {
-		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      d.Name,
-				Namespace: d.Namespace,
-			},
-		}
-	}
-	return requests
+	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesDashboardList"))
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -257,7 +241,7 @@ func (r *PersesDashboardReconciler) findDashboardsForPerses(ctx context.Context,
 // own reconciliation loop.
 func (r *PersesDashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&persesv1alpha2.PersesDashboard{}).
+		For(&persesv1alpha2.PersesDashboard{}, builder.OnlyMetadata).
 		Watches(
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findDashboardsForPerses),

--- a/controllers/dashboards/persesdashboard_controller_test.go
+++ b/controllers/dashboards/persesdashboard_controller_test.go
@@ -46,9 +46,11 @@ func newTestDashboardReconciler(objects ...runtime.Object) *PersesDashboardRecon
 	}
 	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesDashboard{})
 
+	c := clientBuilder.Build()
 	return &PersesDashboardReconciler{
-		Client: clientBuilder.Build(),
-		Scheme: scheme,
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
 	}
 }
 

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +53,7 @@ func datasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesDatasourc
 // PersesDatasourceReconciler reconciles a PersesDatasource object
 type PersesDatasourceReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
+	APIReader             client.Reader // uncached reader — OnlyMetadata watch caches metadata only
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -153,7 +152,7 @@ func (r *PersesDatasourceReconciler) updateDatasourceStatus(
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fresh := &persesv1alpha2.PersesDatasource{}
-		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
+		if err := r.APIReader.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
 		before := common.SnapshotConditions(fresh.Status.Conditions)
@@ -230,22 +229,7 @@ func (r *PersesDatasourceReconciler) setStatusToDegraded(
 // Each datasource's instanceSelector labels determine which Perses instances it syncs to.
 // If no instanceSelector is set, the datasource syncs to all Perses instances.
 func (r *PersesDatasourceReconciler) findDatasourcesForPerses(ctx context.Context, _ client.Object) []reconcile.Request {
-	datasources := &persesv1alpha2.PersesDatasourceList{}
-	if err := r.List(ctx, datasources); err != nil {
-		log.WithError(err).Error("Failed to list datasources for Perses instance change")
-		return nil
-	}
-
-	requests := make([]reconcile.Request, len(datasources.Items))
-	for i, d := range datasources.Items {
-		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      d.Name,
-				Namespace: d.Namespace,
-			},
-		}
-	}
-	return requests
+	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesDatasourceList"))
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -257,7 +241,7 @@ func (r *PersesDatasourceReconciler) findDatasourcesForPerses(ctx context.Contex
 // own reconciliation loop.
 func (r *PersesDatasourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&persesv1alpha2.PersesDatasource{}).
+		For(&persesv1alpha2.PersesDatasource{}, builder.OnlyMetadata).
 		Watches(
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findDatasourcesForPerses),

--- a/controllers/datasources/persesdatasource_controller_test.go
+++ b/controllers/datasources/persesdatasource_controller_test.go
@@ -46,9 +46,11 @@ func newTestDatasourceReconciler(objects ...runtime.Object) *PersesDatasourceRec
 	}
 	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesDatasource{})
 
+	c := clientBuilder.Build()
 	return &PersesDatasourceReconciler{
-		Client: clientBuilder.Build(),
-		Scheme: scheme,
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
 	}
 }
 

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +53,7 @@ func globalDatasourceFromContext(ctx context.Context) (*persesv1alpha2.PersesGlo
 // PersesGlobalDatasourceReconciler reconciles a PersesDatasource object
 type PersesGlobalDatasourceReconciler struct {
 	client.Client
-	APIReader             client.Reader // uncached reader — cached client strips Spec via Transform
+	APIReader             client.Reader // uncached reader — OnlyMetadata watch caches metadata only
 	Scheme                *runtime.Scheme
 	Recorder              record.EventRecorder
 	ClientFactory         common.PersesClientFactory
@@ -153,7 +152,7 @@ func (r *PersesGlobalDatasourceReconciler) updateGlobalDatasourceStatus(
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		fresh := &persesv1alpha2.PersesGlobalDatasource{}
-		if err := r.Get(ctx, req.NamespacedName, fresh); err != nil {
+		if err := r.APIReader.Get(ctx, req.NamespacedName, fresh); err != nil {
 			return err
 		}
 		before := common.SnapshotConditions(fresh.Status.Conditions)
@@ -230,22 +229,7 @@ func (r *PersesGlobalDatasourceReconciler) setStatusToDegraded(
 // Global datasources are cluster-scoped and their instanceSelector labels determine
 // which Perses instances they sync to. If no instanceSelector is set, they sync to all instances.
 func (r *PersesGlobalDatasourceReconciler) findGlobalDatasourcesForPerses(ctx context.Context, _ client.Object) []reconcile.Request {
-	datasources := &persesv1alpha2.PersesGlobalDatasourceList{}
-	if err := r.List(ctx, datasources); err != nil {
-		log.WithError(err).Error("Failed to list globaldatasources for Perses instance change")
-		return nil
-	}
-
-	requests := make([]reconcile.Request, len(datasources.Items))
-	for i, d := range datasources.Items {
-		requests[i] = reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      d.Name,
-				Namespace: d.Namespace,
-			},
-		}
-	}
-	return requests
+	return common.MetadataListToRequests(ctx, r.Client, persesv1alpha2.GroupVersion.WithKind("PersesGlobalDatasourceList"))
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -256,7 +240,7 @@ func (r *PersesGlobalDatasourceReconciler) findGlobalDatasourcesForPerses(ctx co
 // ready at creation, and deletion is handled by the global datasource's own reconciliation loop.
 func (r *PersesGlobalDatasourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&persesv1alpha2.PersesGlobalDatasource{}).
+		For(&persesv1alpha2.PersesGlobalDatasource{}, builder.OnlyMetadata).
 		Watches(
 			&persesv1alpha2.Perses{},
 			handler.EnqueueRequestsFromMapFunc(r.findGlobalDatasourcesForPerses),

--- a/controllers/globaldatasources/persesglobaldatasource_controller_test.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller_test.go
@@ -46,9 +46,11 @@ func newTestGlobalDatasourceReconciler(objects ...runtime.Object) *PersesGlobalD
 	}
 	clientBuilder = clientBuilder.WithStatusSubresource(&persesv1alpha2.PersesGlobalDatasource{})
 
+	c := clientBuilder.Build()
 	return &PersesGlobalDatasourceReconciler{
-		Client: clientBuilder.Build(),
-		Scheme: scheme,
+		Client:    c,
+		APIReader: c,
+		Scheme:    scheme,
 	}
 }
 

--- a/internal/cache/options.go
+++ b/internal/cache/options.go
@@ -15,7 +15,6 @@ package cache
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
-	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses-operator/internal/perses/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,8 +42,8 @@ func ParseSecretLabelSelector(raw string) (labels.Selector, error) {
 // Operator-created resources (Deployment, StatefulSet, ConfigMap, Service) are filtered
 // by the fixed label app.kubernetes.io/managed-by=perses-operator.
 //
-// CRD resources (PersesDashboard, PersesDatasource, PersesGlobalDatasource) have their
-// Spec stripped from the cache. Controllers use APIReader for the full object.
+// CRD resources (PersesDashboard, PersesDatasource, PersesGlobalDatasource) are not
+// cached here — their controllers use builder.OnlyMetadata and APIReader instead.
 //
 // Secrets are filtered by secretSelector. If secretSelector is nil (no flag provided),
 // the default label perses.dev/watch=true is used. If watchAllSecrets is true, no label
@@ -74,38 +73,6 @@ func buildCacheByObject(secretSelector labels.Selector, watchAllSecrets bool, tl
 		},
 		&corev1.Service{}: {
 			Label: managedBySelector,
-		},
-		&persesv1alpha2.PersesDashboard{}: {
-			Transform: func(obj any) (any, error) {
-				if d, ok := obj.(*persesv1alpha2.PersesDashboard); ok {
-					d.ManagedFields = nil
-					d.Spec.Config = persesv1alpha2.Dashboard{}
-					d.Spec.InstanceSelector = nil
-				}
-				return obj, nil
-			},
-		},
-		&persesv1alpha2.PersesDatasource{}: {
-			Transform: func(obj any) (any, error) {
-				if d, ok := obj.(*persesv1alpha2.PersesDatasource); ok {
-					d.ManagedFields = nil
-					d.Spec.Config = persesv1alpha2.Datasource{}
-					d.Spec.Client = nil
-					d.Spec.InstanceSelector = nil
-				}
-				return obj, nil
-			},
-		},
-		&persesv1alpha2.PersesGlobalDatasource{}: {
-			Transform: func(obj any) (any, error) {
-				if d, ok := obj.(*persesv1alpha2.PersesGlobalDatasource); ok {
-					d.ManagedFields = nil
-					d.Spec.Config = persesv1alpha2.Datasource{}
-					d.Spec.Client = nil
-					d.Spec.InstanceSelector = nil
-				}
-				return obj, nil
-			},
 		},
 	}
 

--- a/internal/cache/options_test.go
+++ b/internal/cache/options_test.go
@@ -20,8 +20,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	persesv1alpha2 "github.com/perses/perses-operator/api/v1alpha2"
 	"github.com/perses/perses-operator/internal/perses/common"
-	persesv1 "github.com/perses/perses/pkg/model/api/v1"
-	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -358,17 +356,21 @@ func TestBuildCacheByObject_NoTLSClusterProfile(t *testing.T) {
 	}
 }
 
-func getCRDTransform(t *testing.T, target client.Object) func(obj any) (any, error) {
-	t.Helper()
+func TestBuildCacheByObject_NoCRDEntries(t *testing.T) {
 	byObject := buildCacheByObject(nil, false, false)
-	entry := findByObjectEntry(byObject, target)
-	if entry == nil {
-		t.Fatalf("expected ByObject entry for %T", target)
+
+	crdTypes := []client.Object{
+		&persesv1alpha2.PersesDashboard{},
+		&persesv1alpha2.PersesDatasource{},
+		&persesv1alpha2.PersesGlobalDatasource{},
 	}
-	if entry.Transform == nil {
-		t.Fatalf("expected Transform on %T entry", target)
+
+	for _, obj := range crdTypes {
+		entry := findByObjectEntry(byObject, obj)
+		if entry != nil {
+			t.Errorf("expected no ByObject entry for %T (controllers use builder.OnlyMetadata instead)", obj)
+		}
 	}
-	return entry.Transform
 }
 
 func TestBuildCacheOptions_SetsDefaultTransform(t *testing.T) {
@@ -406,28 +408,6 @@ func TestBuildCacheOptions_ContainsByObject(t *testing.T) {
 	}
 }
 
-func TestBuildCacheByObject_DashboardTransformStripsManagedFields(t *testing.T) {
-	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
-
-	dashboard := &persesv1alpha2.PersesDashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-dash",
-			ManagedFields: []metav1.ManagedFieldsEntry{
-				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationApply},
-			},
-		},
-	}
-
-	result, err := transform(dashboard)
-	if err != nil {
-		t.Fatalf("Transform returned error: %v", err)
-	}
-
-	if result.(*persesv1alpha2.PersesDashboard).ManagedFields != nil {
-		t.Error("expected ManagedFields to be nil after Transform")
-	}
-}
-
 func TestBuildCacheByObject_SecretTransformStripsManagedFields(t *testing.T) {
 	transform := getSecretTransform(t)
 
@@ -447,186 +427,5 @@ func TestBuildCacheByObject_SecretTransformStripsManagedFields(t *testing.T) {
 
 	if result.(*corev1.Secret).ManagedFields != nil {
 		t.Error("expected ManagedFields to be nil after Transform")
-	}
-}
-
-func TestBuildCacheByObject_DashboardTransformStripsSpec(t *testing.T) {
-	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
-
-	dashboard := &persesv1alpha2.PersesDashboard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-dash",
-			Namespace:       "test-ns",
-			ResourceVersion: "12345",
-			Labels:          map[string]string{"app": "test"},
-			Annotations:     map[string]string{"perses.dev/tags": "oncall"},
-		},
-		Spec: persesv1alpha2.PersesDashboardSpec{
-			Config: persesv1alpha2.Dashboard{
-				DashboardSpec: persesv1.DashboardSpec{
-					Display:  &persesv1Common.Display{Name: "My Dashboard"},
-					Duration: "5m",
-				},
-			},
-			InstanceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "prod"},
-			},
-		},
-		Status: persesv1alpha2.PersesDashboardStatus{
-			Conditions: []metav1.Condition{{
-				Type:   common.TypeAvailablePerses,
-				Status: metav1.ConditionTrue,
-				Reason: "Reconciled",
-			}},
-		},
-	}
-
-	result, err := transform(dashboard)
-	if err != nil {
-		t.Fatalf("Transform returned error: %v", err)
-	}
-
-	d := result.(*persesv1alpha2.PersesDashboard)
-
-	if d.Spec.Config.Display != nil || d.Spec.Config.Duration != "" {
-		t.Error("expected Spec.Config to be zeroed")
-	}
-	if d.Spec.InstanceSelector != nil {
-		t.Error("expected Spec.InstanceSelector to be nil")
-	}
-
-	if d.Name != "test-dash" || d.Namespace != "test-ns" || d.ResourceVersion != "12345" {
-		t.Error("expected ObjectMeta to be preserved")
-	}
-	if d.Labels["app"] != "test" || d.Annotations["perses.dev/tags"] != "oncall" {
-		t.Error("expected Labels and Annotations to be preserved")
-	}
-	if len(d.Status.Conditions) != 1 || d.Status.Conditions[0].Type != common.TypeAvailablePerses {
-		t.Error("expected Status.Conditions to be preserved")
-	}
-}
-
-func TestBuildCacheByObject_DashboardTransformEmptyObject(t *testing.T) {
-	transform := getCRDTransform(t, &persesv1alpha2.PersesDashboard{})
-
-	dashboard := &persesv1alpha2.PersesDashboard{}
-	result, err := transform(dashboard)
-	if err != nil {
-		t.Fatalf("Transform returned error: %v", err)
-	}
-
-	if result.(*persesv1alpha2.PersesDashboard) == nil {
-		t.Error("expected non-nil result")
-	}
-}
-
-func TestBuildCacheByObject_DatasourceTransformStripsSpec(t *testing.T) {
-	transform := getCRDTransform(t, &persesv1alpha2.PersesDatasource{})
-
-	datasource := &persesv1alpha2.PersesDatasource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-ds",
-			Namespace:       "test-ns",
-			ResourceVersion: "67890",
-		},
-		Spec: persesv1alpha2.DatasourceSpec{
-			Config: persesv1alpha2.Datasource{
-				DatasourceSpec: persesv1.DatasourceSpec{
-					Default: true,
-					Plugin:  persesv1Common.Plugin{Kind: "PrometheusDatasource"},
-				},
-			},
-			Client: &persesv1alpha2.Client{
-				BasicAuth: &persesv1alpha2.BasicAuth{Username: "admin"},
-			},
-			InstanceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "prod"},
-			},
-		},
-		Status: persesv1alpha2.PersesDatasourceStatus{
-			Conditions: []metav1.Condition{{
-				Type:   common.TypeAvailablePerses,
-				Status: metav1.ConditionTrue,
-			}},
-		},
-	}
-
-	result, err := transform(datasource)
-	if err != nil {
-		t.Fatalf("Transform returned error: %v", err)
-	}
-
-	d := result.(*persesv1alpha2.PersesDatasource)
-
-	if d.Spec.Config.Default || d.Spec.Config.Plugin.Kind != "" {
-		t.Error("expected Spec.Config to be zeroed")
-	}
-	if d.Spec.Client != nil {
-		t.Error("expected Spec.Client to be nil")
-	}
-	if d.Spec.InstanceSelector != nil {
-		t.Error("expected Spec.InstanceSelector to be nil")
-	}
-
-	if d.Name != "test-ds" || d.ResourceVersion != "67890" {
-		t.Error("expected ObjectMeta to be preserved")
-	}
-	if len(d.Status.Conditions) != 1 {
-		t.Error("expected Status.Conditions to be preserved")
-	}
-}
-
-func TestBuildCacheByObject_GlobalDatasourceTransformStripsSpec(t *testing.T) {
-	transform := getCRDTransform(t, &persesv1alpha2.PersesGlobalDatasource{})
-
-	gds := &persesv1alpha2.PersesGlobalDatasource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test-gds",
-			ResourceVersion: "11111",
-		},
-		Spec: persesv1alpha2.DatasourceSpec{
-			Config: persesv1alpha2.Datasource{
-				DatasourceSpec: persesv1.DatasourceSpec{
-					Default: true,
-					Plugin:  persesv1Common.Plugin{Kind: "PrometheusDatasource"},
-				},
-			},
-			Client: &persesv1alpha2.Client{
-				BasicAuth: &persesv1alpha2.BasicAuth{Username: "admin"},
-			},
-			InstanceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"env": "prod"},
-			},
-		},
-		Status: persesv1alpha2.PersesGlobalDatasourceStatus{
-			Conditions: []metav1.Condition{{
-				Type:   common.TypeAvailablePerses,
-				Status: metav1.ConditionTrue,
-			}},
-		},
-	}
-
-	result, err := transform(gds)
-	if err != nil {
-		t.Fatalf("Transform returned error: %v", err)
-	}
-
-	d := result.(*persesv1alpha2.PersesGlobalDatasource)
-
-	if d.Spec.Config.Default || d.Spec.Config.Plugin.Kind != "" {
-		t.Error("expected Spec.Config to be zeroed")
-	}
-	if d.Spec.Client != nil {
-		t.Error("expected Spec.Client to be nil")
-	}
-	if d.Spec.InstanceSelector != nil {
-		t.Error("expected Spec.InstanceSelector to be nil")
-	}
-
-	if d.Name != "test-gds" || d.ResourceVersion != "11111" {
-		t.Error("expected ObjectMeta to be preserved")
-	}
-	if len(d.Status.Conditions) != 1 {
-		t.Error("expected Status.Conditions to be preserved")
 	}
 }

--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -14,12 +14,21 @@
 package common
 
 import (
+	"context"
+
 	"github.com/perses/perses-operator/api/v1alpha2"
+	logger "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+var clog = logger.WithField("module", "constants")
 
 const (
 	PersesNamespaceDomain     = "perses.dev"
@@ -126,6 +135,29 @@ func PersesBecameAvailable(oldObj, newObj client.Object) bool {
 	wasAvailable := meta.IsStatusConditionTrue(oldPerses.Status.Conditions, TypeAvailablePerses)
 	isAvailable := meta.IsStatusConditionTrue(newPerses.Status.Conditions, TypeAvailablePerses)
 	return !wasAvailable && isAvailable
+}
+
+// MetadataListToRequests lists all objects of the given GVK from the metadata-only
+// cache and returns a reconcile.Request for each one. It is intended for use in
+// mapper functions passed to handler.EnqueueRequestsFromMapFunc.
+func MetadataListToRequests(ctx context.Context, r client.Reader, gvk schema.GroupVersionKind) []reconcile.Request {
+	list := &metav1.PartialObjectMetadataList{}
+	list.SetGroupVersionKind(gvk)
+	if err := r.List(ctx, list); err != nil {
+		clog.WithError(err).Errorf("Failed to list %s for Perses instance change", gvk.Kind)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, len(list.Items))
+	for i, obj := range list.Items {
+		requests[i] = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      obj.Name,
+				Namespace: obj.Namespace,
+			},
+		}
+	}
+	return requests
 }
 
 // PersesAvailabilityPredicate returns a predicate that triggers reconciliation


### PR DESCRIPTION
# Description

Use only the metadata to watch dashboards, datasources and perses resources to avoid bloating the memory with large specs.

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
