### PR TITLE
[FEATURE] Add reconcile-time validation using Perses validate API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Dockerfile.cross
 .vscode
 
 /dist
+tmp/
 
 .goreleaser.yaml
 

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -591,6 +591,7 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
+			mockDashboard.On("Get", DashboardName).Return(&persesv1.Dashboard{}, perseshttp.RequestNotFoundError)
 
 			By("Reconciling the custom resource - validation should fail before Create is called")
 			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
@@ -609,7 +610,6 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 
 			By("Checking that Create was never called on the Perses API")
 			mockDashboard.AssertNotCalled(GinkgoT(), "Create")
-			mockDashboard.AssertNotCalled(GinkgoT(), "Get")
 
 			By("Checking the Status Conditions show ValidationFailed")
 			Eventually(func() error {

--- a/controllers/dashboard_controller_test.go
+++ b/controllers/dashboard_controller_test.go
@@ -16,6 +16,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -166,7 +167,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new dashboard when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
@@ -284,7 +286,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("Initial reconciliation - creates the dashboard in Perses")
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
 			mockDashboard.On("Get", DashboardName).Return(&persesv1.Dashboard{}, perseshttp.RequestNotFoundError)
@@ -314,7 +317,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Second*10, time.Millisecond*250).Should(Succeed())
 
 			By("Re-reconciling with the updated spec")
-			mockPersesClient2 := new(internal.MockClient)
+			mockPersesClient2, validateServer2 := internal.NewMockClientWithValidation()
+			defer validateServer2.Close()
 			mockDashboard2 := new(internal.MockDashboard)
 			mockPersesClient2.On("Dashboard", PersesNamespace).Return(mockDashboard2)
 
@@ -415,7 +419,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new dashboard when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
@@ -524,7 +529,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 				Expect(err).To(Not(HaveOccurred()))
 			}
 
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
@@ -551,6 +557,103 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			})
 			Expect(err).To(HaveOccurred())
 			mockDashboard.AssertCalled(GinkgoT(), "Delete", DashboardName)
+		})
+
+		It("should set degraded status with ValidationFailed reason when server-side validation fails", func() {
+			By("Creating the custom resource for the Kind PersesDashboard")
+			dashboard := &persesv1alpha2.PersesDashboard{}
+			err := k8sClient.Get(ctx, dashboardNamespaceName, dashboard)
+			if err != nil && errors.IsNotFound(err) {
+				perses := &persesv1alpha2.PersesDashboard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DashboardName,
+						Namespace: PersesNamespace,
+					},
+					Spec: persesv1alpha2.PersesDashboardSpec{
+						Config: persesv1alpha2.Dashboard{
+							DashboardSpec: newDashboard.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, perses)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Checking if the custom resource was successfully created")
+			Eventually(func() error {
+				found := &persesv1alpha2.PersesDashboard{}
+				return k8sClient.Get(ctx, dashboardNamespaceName, found)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			mockPersesClient, validateServer := internal.NewMockClientWithValidationError("invalid panel plugin kind")
+			defer validateServer.Close()
+			mockDashboard := new(internal.MockDashboard)
+
+			mockPersesClient.On("Dashboard", PersesNamespace).Return(mockDashboard)
+
+			By("Reconciling the custom resource - validation should fail before Create is called")
+			dashboardReconciler := &dashboardcontroller.PersesDashboardReconciler{
+				Client:        k8sClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			_, err = dashboardReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: dashboardNamespaceName,
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed server-side validation"))
+
+			By("Checking that Create was never called on the Perses API")
+			mockDashboard.AssertNotCalled(GinkgoT(), "Create")
+			mockDashboard.AssertNotCalled(GinkgoT(), "Get")
+
+			By("Checking the Status Conditions show ValidationFailed")
+			Eventually(func() error {
+				dashboardWithStatus := &persesv1alpha2.PersesDashboard{}
+				err = k8sClient.Get(ctx, dashboardNamespaceName, dashboardWithStatus)
+
+				if len(dashboardWithStatus.Status.Conditions) == 0 {
+					return fmt.Errorf("No status condition was added to the perses dashboard instance")
+				}
+
+				degradedCond := apimeta.FindStatusCondition(dashboardWithStatus.Status.Conditions, common.TypeDegradedPerses)
+				if degradedCond == nil {
+					return fmt.Errorf("Degraded condition not found on the perses dashboard instance")
+				}
+				if degradedCond.Status != metav1.ConditionTrue {
+					return fmt.Errorf("Expected Degraded=True but got %s", degradedCond.Status)
+				}
+				if degradedCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, degradedCond.Reason)
+				}
+				if !strings.Contains(degradedCond.Message, "failed server-side validation") {
+					return fmt.Errorf("Expected message to contain 'failed server-side validation' but got: %s", degradedCond.Message)
+				}
+
+				availableCond := apimeta.FindStatusCondition(dashboardWithStatus.Status.Conditions, common.TypeAvailablePerses)
+				if availableCond == nil {
+					return fmt.Errorf("Available condition not found on the perses dashboard instance")
+				}
+				if availableCond.Status != metav1.ConditionFalse {
+					return fmt.Errorf("Expected Available=False but got %s", availableCond.Status)
+				}
+				if availableCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, availableCond.Reason)
+				}
+
+				return err
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			dashboardToDelete := &persesv1alpha2.PersesDashboard{}
+			err = k8sClient.Get(ctx, dashboardNamespaceName, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, dashboardToDelete)
+			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
 
@@ -707,7 +810,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API - should only be called once for the matching instance
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", SelectorNamespace).Return(mockDashboard)
@@ -784,7 +888,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API - should be called for all instances
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", SelectorNamespace).Return(mockDashboard)
@@ -939,7 +1044,8 @@ var _ = Describe("Dashboard controller", Ordered, func() {
 				Spec: dashboard.Spec.Config.DashboardSpec,
 			}
 
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDashboard := new(internal.MockDashboard)
 
 			mockPersesClient.On("Dashboard", TagsNamespace).Return(mockDashboard)

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -122,8 +122,6 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 		}
 	}
 
-	existing, err := persesClient.Dashboard(dashboard.Namespace).Get(dashboard.Name)
-
 	persesDashboard := &persesv1.Dashboard{
 		Kind: persesv1.KindDashboard,
 		Metadata: persesv1.ProjectMetadata{
@@ -142,6 +140,8 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 			common.ReasonValidationFailed,
 		)
 	}
+
+	existing, err := persesClient.Dashboard(dashboard.Namespace).Get(dashboard.Name)
 
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/perses/perses/pkg/client/api/validate"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	persesv1Common "github.com/perses/perses/pkg/model/api/v1/common"
@@ -132,6 +133,14 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 			},
 		},
 		Spec: dashboard.Spec.Config.DashboardSpec,
+	}
+
+	if validateErr := validate.New(persesClient.RESTClient()).Dashboard(persesDashboard); validateErr != nil {
+		dlog.WithError(validateErr).Errorf("Dashboard validation failed: %s", dashboard.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr),
+			common.ReasonValidationFailed,
+		)
 	}
 
 	if err != nil {

--- a/controllers/dashboards/dashboard_controller.go
+++ b/controllers/dashboards/dashboard_controller.go
@@ -133,47 +133,49 @@ func (r *PersesDashboardReconciler) syncPersesDashboard(ctx context.Context, per
 		Spec: dashboard.Spec.Config.DashboardSpec,
 	}
 
-	if validateErr := validate.New(persesClient.RESTClient()).Dashboard(persesDashboard); validateErr != nil {
-		dlog.WithError(validateErr).Errorf("Dashboard validation failed: %s", dashboard.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr),
-			common.ReasonValidationFailed,
-		)
-	}
-
 	existing, err := persesClient.Dashboard(dashboard.Namespace).Get(dashboard.Name)
+	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
-	if err != nil {
-		if errors.Is(err, perseshttp.RequestNotFoundError) {
-			_, err = persesClient.Dashboard(dashboard.Namespace).Create(persesDashboard)
-
-			if err != nil {
-				dlog.WithError(err).Errorf("Failed to create dashboard: %s", dashboard.Name)
-				return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
-			}
-
-			dlog.Infof("Dashboard created: %s", dashboard.Name)
-
-			res, err := subreconciler.ContinueReconciling()
-			return res, "", err
-		}
-
+	if err != nil && !notFound {
 		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
 	}
 
-	if common.DashboardInSync(existing, persesDashboard) {
+	if !notFound && common.DashboardInSync(existing, persesDashboard) {
 		dlog.Debugf("Dashboard already in sync: %s", dashboard.Name)
 		res, err := subreconciler.ContinueReconciling()
 		return res, "", err
 	}
 
-	_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
-	if err != nil {
-		dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
-		return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+	if validateErr := validate.New(persesClient.RESTClient()).Dashboard(persesDashboard); validateErr != nil {
+		if common.IsClientError(validateErr) {
+			dlog.WithError(validateErr).Errorf("Dashboard validation failed: %s", dashboard.Name)
+			return subreconciler.RequeueWithErrorAndReason(
+				fmt.Errorf("dashboard %q failed server-side validation: %w", dashboard.Name, validateErr),
+				common.ReasonValidationFailed,
+			)
+		}
+		dlog.WithError(validateErr).Errorf("Dashboard validation request failed: %s", dashboard.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("dashboard %q validation request failed: %w", dashboard.Name, validateErr),
+			common.ReasonBackendError,
+		)
 	}
 
-	dlog.Infof("Dashboard updated: %s", dashboard.Name)
+	if notFound {
+		_, err = persesClient.Dashboard(dashboard.Namespace).Create(persesDashboard)
+		if err != nil {
+			dlog.WithError(err).Errorf("Failed to create dashboard: %s", dashboard.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+		}
+		dlog.Infof("Dashboard created: %s", dashboard.Name)
+	} else {
+		_, err = persesClient.Dashboard(dashboard.Namespace).Update(persesDashboard)
+		if err != nil {
+			dlog.WithError(err).Errorf("Failed to update dashboard: %s", dashboard.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, common.ReasonBackendError)
+		}
+		dlog.Infof("Dashboard updated: %s", dashboard.Name)
+	}
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			mockDatasource := new(internal.MockDatasource)
 
 			mockPersesClient.On("Datasource", PersesNamespace).Return(mockDatasource)
-			mockPersesClient.On("Secret", PersesNamespace).Return(new(internal.MockSecret))
+			mockDatasource.On("Get", DatasourceName).Return(&persesv1.Datasource{}, perseshttp.RequestNotFoundError)
 
 			By("Reconciling the custom resource - validation should fail before Create is called")
 			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
@@ -507,7 +507,6 @@ var _ = Describe("Datasource controller", Ordered, func() {
 
 			By("Checking that Create was never called on the Perses API")
 			mockDatasource.AssertNotCalled(GinkgoT(), "Create")
-			mockDatasource.AssertNotCalled(GinkgoT(), "Get")
 
 			By("Checking the Status Conditions show ValidationFailed")
 			Eventually(func() error {

--- a/controllers/datasource_controller_test.go
+++ b/controllers/datasource_controller_test.go
@@ -187,7 +187,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new datasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 			mockSecret := new(internal.MockSecret)
 
@@ -311,7 +312,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new datasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 			mockSecret := new(internal.MockSecret)
 
@@ -424,7 +426,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 				Expect(err).To(Not(HaveOccurred()))
 			}
 
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 
 			mockPersesClient.On("Datasource", PersesNamespace).Return(mockDatasource)
@@ -451,6 +454,101 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			})
 			Expect(err).To(HaveOccurred())
 			mockDatasource.AssertCalled(GinkgoT(), "Delete", DatasourceName)
+		})
+
+		It("should set degraded status with ValidationFailed reason when server-side validation fails", func() {
+			By("Creating the custom resource for the Kind PersesDatasource")
+			datasource := &persesv1alpha2.PersesDatasource{}
+			err := k8sClient.Get(ctx, datasourceNamespaceName, datasource)
+			if err != nil && errors.IsNotFound(err) {
+				datasource = &persesv1alpha2.PersesDatasource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      DatasourceName,
+						Namespace: PersesNamespace,
+					},
+					Spec: persesv1alpha2.DatasourceSpec{
+						Config: persesv1alpha2.Datasource{
+							DatasourceSpec: newDatasource.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, datasource)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Checking if the custom resource was successfully created")
+			Eventually(func() error {
+				found := &persesv1alpha2.PersesDatasource{}
+				return k8sClient.Get(ctx, datasourceNamespaceName, found)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			mockPersesClient, validateServer := internal.NewMockClientWithValidationError("invalid datasource plugin kind")
+			defer validateServer.Close()
+			mockDatasource := new(internal.MockDatasource)
+
+			mockPersesClient.On("Datasource", PersesNamespace).Return(mockDatasource)
+			mockPersesClient.On("Secret", PersesNamespace).Return(new(internal.MockSecret))
+
+			By("Reconciling the custom resource - validation should fail before Create is called")
+			datasourceReconciler := &datasourcecontroller.PersesDatasourceReconciler{
+				Client:        k8sClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			_, err = datasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: datasourceNamespaceName,
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed server-side validation"))
+
+			By("Checking that Create was never called on the Perses API")
+			mockDatasource.AssertNotCalled(GinkgoT(), "Create")
+			mockDatasource.AssertNotCalled(GinkgoT(), "Get")
+
+			By("Checking the Status Conditions show ValidationFailed")
+			Eventually(func() error {
+				datasourceWithStatus := &persesv1alpha2.PersesDatasource{}
+				err = k8sClient.Get(ctx, datasourceNamespaceName, datasourceWithStatus)
+
+				if len(datasourceWithStatus.Status.Conditions) == 0 {
+					return fmt.Errorf("No status condition was added to the perses datasource instance")
+				}
+
+				degradedCond := apimeta.FindStatusCondition(datasourceWithStatus.Status.Conditions, common.TypeDegradedPerses)
+				if degradedCond == nil {
+					return fmt.Errorf("Degraded condition not found on the perses datasource instance")
+				}
+				if degradedCond.Status != metav1.ConditionTrue {
+					return fmt.Errorf("Expected Degraded=True but got %s", degradedCond.Status)
+				}
+				if degradedCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, degradedCond.Reason)
+				}
+
+				availableCond := apimeta.FindStatusCondition(datasourceWithStatus.Status.Conditions, common.TypeAvailablePerses)
+				if availableCond == nil {
+					return fmt.Errorf("Available condition not found on the perses datasource instance")
+				}
+				if availableCond.Status != metav1.ConditionFalse {
+					return fmt.Errorf("Expected Available=False but got %s", availableCond.Status)
+				}
+				if availableCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, availableCond.Reason)
+				}
+
+				return err
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			datasourceToDelete := &persesv1alpha2.PersesDatasource{}
+			err = k8sClient.Get(ctx, datasourceNamespaceName, datasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, datasourceToDelete)
+			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
 
@@ -588,7 +686,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new datasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 			mockSecret := new(internal.MockSecret)
 
@@ -712,7 +811,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new datasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 			mockSecret := new(internal.MockSecret)
 
@@ -916,7 +1016,8 @@ var _ = Describe("Datasource controller", Ordered, func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			By("Setting up mock Perses API expectations")
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockDatasource := new(internal.MockDatasource)
 			mockSecret := new(internal.MockSecret)
 

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -134,8 +134,6 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		}
 	}
 
-	existing, err := persesClient.Datasource(datasource.Namespace).Get(datasource.Name)
-
 	datasourceWithName := &persesv1.Datasource{
 		Kind: persesv1.KindDatasource,
 		Metadata: persesv1.ProjectMetadata{
@@ -154,6 +152,8 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 			persescommon.ReasonValidationFailed,
 		)
 	}
+
+	existing, err := persesClient.Datasource(datasource.Namespace).Get(datasource.Name)
 
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	"github.com/perses/perses/pkg/client/api/validate"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/common"
@@ -144,6 +145,14 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 			},
 		},
 		Spec: datasource.Spec.Config.DatasourceSpec,
+	}
+
+	if validateErr := validate.New(persesClient.RESTClient()).Datasource(datasourceWithName); validateErr != nil {
+		dlog.WithError(validateErr).Errorf("Datasource validation failed: %s", datasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("datasource %q failed server-side validation: %w", datasource.Name, validateErr),
+			persescommon.ReasonValidationFailed,
+		)
 	}
 
 	if err != nil {

--- a/controllers/datasources/datasource_controller.go
+++ b/controllers/datasources/datasource_controller.go
@@ -125,15 +125,6 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		}
 	}
 
-	// create a secret holding the secret configuration so the datasource can reference it
-	if persescommon.HasSecretConfig(datasource.Spec.Client) {
-		_, reason, err := r.syncPersesSecret(ctx, persesClient, datasource)
-		if err != nil {
-			dlog.WithError(err).Errorf("Failed to create datasource secret: %s", datasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, reason)
-		}
-	}
-
 	datasourceWithName := &persesv1.Datasource{
 		Kind: persesv1.KindDatasource,
 		Metadata: persesv1.ProjectMetadata{
@@ -145,47 +136,58 @@ func (r *PersesDatasourceReconciler) syncPersesDatasource(ctx context.Context, p
 		Spec: datasource.Spec.Config.DatasourceSpec,
 	}
 
-	if validateErr := validate.New(persesClient.RESTClient()).Datasource(datasourceWithName); validateErr != nil {
-		dlog.WithError(validateErr).Errorf("Datasource validation failed: %s", datasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("datasource %q failed server-side validation: %w", datasource.Name, validateErr),
-			persescommon.ReasonValidationFailed,
-		)
-	}
-
 	existing, err := persesClient.Datasource(datasource.Namespace).Get(datasource.Name)
+	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
-	if err != nil {
-		if errors.Is(err, perseshttp.RequestNotFoundError) {
-			_, err = persesClient.Datasource(datasource.Namespace).Create(datasourceWithName)
-
-			if err != nil {
-				dlog.WithError(err).Errorf("Failed to create datasource: %s", datasource.Name)
-				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-			}
-
-			dlog.Infof("Datasource created: %s", datasource.Name)
-
-			res, err := subreconciler.ContinueReconciling()
-			return res, "", err
-		}
-
+	if err != nil && !notFound {
 		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
 	}
 
-	if persescommon.DatasourceInSync(existing, datasourceWithName) {
+	if !notFound && persescommon.DatasourceInSync(existing, datasourceWithName) {
 		dlog.Debugf("Datasource already in sync: %s", datasource.Name)
 		res, err := subreconciler.ContinueReconciling()
 		return res, "", err
 	}
 
-	_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
-	if err != nil {
-		dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+	if validateErr := validate.New(persesClient.RESTClient()).Datasource(datasourceWithName); validateErr != nil {
+		if persescommon.IsClientError(validateErr) {
+			dlog.WithError(validateErr).Errorf("Datasource validation failed: %s", datasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(
+				fmt.Errorf("datasource %q failed server-side validation: %w", datasource.Name, validateErr),
+				persescommon.ReasonValidationFailed,
+			)
+		}
+		dlog.WithError(validateErr).Errorf("Datasource validation request failed: %s", datasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("datasource %q validation request failed: %w", datasource.Name, validateErr),
+			persescommon.ReasonBackendError,
+		)
 	}
 
-	dlog.Infof("Datasource updated: %s", datasource.Name)
+	// Sync secret only after validation passes to avoid orphaned secrets
+	if persescommon.HasSecretConfig(datasource.Spec.Client) {
+		_, reason, err := r.syncPersesSecret(ctx, persesClient, datasource)
+		if err != nil {
+			dlog.WithError(err).Errorf("Failed to create datasource secret: %s", datasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, reason)
+		}
+	}
+
+	if notFound {
+		_, err = persesClient.Datasource(datasource.Namespace).Create(datasourceWithName)
+		if err != nil {
+			dlog.WithError(err).Errorf("Failed to create datasource: %s", datasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+		}
+		dlog.Infof("Datasource created: %s", datasource.Name)
+	} else {
+		_, err = persesClient.Datasource(datasource.Namespace).Update(datasourceWithName)
+		if err != nil {
+			dlog.WithError(err).Errorf("Failed to update datasource: %s", datasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+		}
+		dlog.Infof("Datasource updated: %s", datasource.Name)
+	}
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -460,7 +460,7 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			mockGlobalDatasource := new(internal.MockGlobalDatasource)
 
 			mockPersesClient.On("GlobalDatasource").Return(mockGlobalDatasource)
-			mockPersesClient.On("GlobalSecret").Return(new(internal.MockGlobalSecret))
+			mockGlobalDatasource.On("Get", GlobalDatasourceName).Return(&persesv1.GlobalDatasource{}, perseshttp.RequestNotFoundError)
 
 			By("Reconciling the custom resource - validation should fail before Create is called")
 			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
@@ -479,7 +479,6 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 
 			By("Checking that Create was never called on the Perses API")
 			mockGlobalDatasource.AssertNotCalled(GinkgoT(), "Create")
-			mockGlobalDatasource.AssertNotCalled(GinkgoT(), "Get")
 
 			By("Checking the Status Conditions show ValidationFailed")
 			Eventually(func() error {

--- a/controllers/globaldatasource_controller_test.go
+++ b/controllers/globaldatasource_controller_test.go
@@ -161,7 +161,8 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new globaldatasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockGlobalDatasource := new(internal.MockGlobalDatasource)
 			mockGlobalSecret := new(internal.MockGlobalSecret)
 
@@ -285,7 +286,8 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			// Mock the Perses API to assert that Is creating a new globaldatasource when reconciling
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockGlobalDatasource := new(internal.MockGlobalDatasource)
 			mockGlobalSecret := new(internal.MockGlobalSecret)
 
@@ -397,7 +399,8 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 				Expect(err).To(Not(HaveOccurred()))
 			}
 
-			mockPersesClient := new(internal.MockClient)
+			mockPersesClient, validateServer := internal.NewMockClientWithValidation()
+			defer validateServer.Close()
 			mockGlobalDatasource := new(internal.MockGlobalDatasource)
 
 			mockPersesClient.On("GlobalDatasource").Return(mockGlobalDatasource)
@@ -424,6 +427,100 @@ var _ = Describe("GlobalDatasource controller", Ordered, func() {
 			})
 			Expect(err).To(HaveOccurred())
 			mockGlobalDatasource.AssertCalled(GinkgoT(), "Delete", GlobalDatasourceName)
+		})
+
+		It("should set degraded status with ValidationFailed reason when server-side validation fails", func() {
+			By("Creating the custom resource for the Kind PersesGlobalDatasource")
+			globaldatasource := &persesv1alpha2.PersesGlobalDatasource{}
+			err := k8sClient.Get(ctx, globaldatasourceNamespaceName, globaldatasource)
+			if err != nil && errors.IsNotFound(err) {
+				globaldatasource = &persesv1alpha2.PersesGlobalDatasource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: GlobalDatasourceName,
+					},
+					Spec: persesv1alpha2.DatasourceSpec{
+						Config: persesv1alpha2.Datasource{
+							DatasourceSpec: newGlobalDatasource.Spec,
+						},
+					},
+				}
+
+				err = k8sClient.Create(ctx, globaldatasource)
+				Expect(err).To(Not(HaveOccurred()))
+			}
+
+			By("Checking if the custom resource was successfully created")
+			Eventually(func() error {
+				found := &persesv1alpha2.PersesGlobalDatasource{}
+				return k8sClient.Get(ctx, globaldatasourceNamespaceName, found)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			mockPersesClient, validateServer := internal.NewMockClientWithValidationError("invalid global datasource plugin kind")
+			defer validateServer.Close()
+			mockGlobalDatasource := new(internal.MockGlobalDatasource)
+
+			mockPersesClient.On("GlobalDatasource").Return(mockGlobalDatasource)
+			mockPersesClient.On("GlobalSecret").Return(new(internal.MockGlobalSecret))
+
+			By("Reconciling the custom resource - validation should fail before Create is called")
+			globaldatasourceReconciler := &globaldatasourcecontroller.PersesGlobalDatasourceReconciler{
+				Client:        k8sClient,
+				APIReader:     k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ClientFactory: common.NewWithClient(mockPersesClient),
+			}
+
+			_, err = globaldatasourceReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: globaldatasourceNamespaceName,
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed server-side validation"))
+
+			By("Checking that Create was never called on the Perses API")
+			mockGlobalDatasource.AssertNotCalled(GinkgoT(), "Create")
+			mockGlobalDatasource.AssertNotCalled(GinkgoT(), "Get")
+
+			By("Checking the Status Conditions show ValidationFailed")
+			Eventually(func() error {
+				gdWithStatus := &persesv1alpha2.PersesGlobalDatasource{}
+				err = k8sClient.Get(ctx, globaldatasourceNamespaceName, gdWithStatus)
+
+				if len(gdWithStatus.Status.Conditions) == 0 {
+					return fmt.Errorf("No status condition was added to the perses globaldatasource instance")
+				}
+
+				degradedCond := apimeta.FindStatusCondition(gdWithStatus.Status.Conditions, common.TypeDegradedPerses)
+				if degradedCond == nil {
+					return fmt.Errorf("Degraded condition not found on the perses globaldatasource instance")
+				}
+				if degradedCond.Status != metav1.ConditionTrue {
+					return fmt.Errorf("Expected Degraded=True but got %s", degradedCond.Status)
+				}
+				if degradedCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, degradedCond.Reason)
+				}
+
+				availableCond := apimeta.FindStatusCondition(gdWithStatus.Status.Conditions, common.TypeAvailablePerses)
+				if availableCond == nil {
+					return fmt.Errorf("Available condition not found on the perses globaldatasource instance")
+				}
+				if availableCond.Status != metav1.ConditionFalse {
+					return fmt.Errorf("Expected Available=False but got %s", availableCond.Status)
+				}
+				if availableCond.Reason != string(common.ReasonValidationFailed) {
+					return fmt.Errorf("Expected reason %s but got %s", common.ReasonValidationFailed, availableCond.Reason)
+				}
+
+				return err
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Cleaning up")
+			gdToDelete := &persesv1alpha2.PersesGlobalDatasource{}
+			err = k8sClient.Get(ctx, globaldatasourceNamespaceName, gdToDelete)
+			Expect(err).To(Not(HaveOccurred()))
+			err = k8sClient.Delete(ctx, gdToDelete)
+			Expect(err).To(Not(HaveOccurred()))
 		})
 	})
 })

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	"github.com/perses/perses/pkg/client/api/validate"
 	"github.com/perses/perses/pkg/client/perseshttp"
 	persesv1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/perses/perses/pkg/model/api/v1/secret"
@@ -113,6 +114,14 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 			Tags: persescommon.ParseTags(globaldatasource.Annotations),
 		},
 		Spec: globaldatasource.Spec.Config.DatasourceSpec,
+	}
+
+	if validateErr := validate.New(persesClient.RESTClient()).GlobalDatasource(globalDatasourceWithName); validateErr != nil {
+		gdlog.WithError(validateErr).Errorf("GlobalDatasource validation failed: %s", globaldatasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("global datasource %q failed server-side validation: %w", globaldatasource.Name, validateErr),
+			persescommon.ReasonValidationFailed,
+		)
 	}
 
 	if err != nil {

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -96,15 +96,6 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 
 	}
 
-	// create a secret holding the secret configuration so the globaldatasource can reference it
-	if persescommon.HasSecretConfig(globaldatasource.Spec.Client) {
-		_, reason, err := r.syncPersesGlobalSecret(ctx, persesClient, globaldatasource)
-		if err != nil {
-			gdlog.WithError(err).Errorf("Failed to create globaldatasource secret: %s", globaldatasource.Name)
-			return subreconciler.RequeueWithErrorAndReason(err, reason)
-		}
-	}
-
 	globalDatasourceWithName := &persesv1.GlobalDatasource{
 		Kind: persesv1.KindGlobalDatasource,
 		Metadata: persesv1.Metadata{
@@ -114,48 +105,59 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 		Spec: globaldatasource.Spec.Config.DatasourceSpec,
 	}
 
-	if validateErr := validate.New(persesClient.RESTClient()).GlobalDatasource(globalDatasourceWithName); validateErr != nil {
-		gdlog.WithError(validateErr).Errorf("GlobalDatasource validation failed: %s", globaldatasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(
-			fmt.Errorf("global datasource %q failed server-side validation: %w", globaldatasource.Name, validateErr),
-			persescommon.ReasonValidationFailed,
-		)
-	}
-
 	existing, err := persesClient.GlobalDatasource().Get(globaldatasource.Name)
+	notFound := err != nil && errors.Is(err, perseshttp.RequestNotFoundError)
 
-	if err != nil {
-		if errors.Is(err, perseshttp.RequestNotFoundError) {
-			_, err = persesClient.GlobalDatasource().Create(globalDatasourceWithName)
-
-			if err != nil {
-				gdlog.WithError(err).Errorf("Failed to create globaldatasource: %s", globaldatasource.Name)
-				return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
-			}
-
-			gdlog.Infof("GlobalDatasource created: %s", globaldatasource.Name)
-
-			res, err := subreconciler.ContinueReconciling()
-			return res, "", err
-		}
-
+	if err != nil && !notFound {
 		res, err := subreconciler.RequeueWithError(err)
 		return res, persescommon.ReasonBackendError, err
 	}
 
-	if persescommon.GlobalDatasourceInSync(existing, globalDatasourceWithName) {
+	if !notFound && persescommon.GlobalDatasourceInSync(existing, globalDatasourceWithName) {
 		gdlog.Debugf("GlobalDatasource already in sync: %s", globaldatasource.Name)
 		res, err := subreconciler.ContinueReconciling()
 		return res, "", err
 	}
 
-	_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
-	if err != nil {
-		gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
-		return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+	if validateErr := validate.New(persesClient.RESTClient()).GlobalDatasource(globalDatasourceWithName); validateErr != nil {
+		if persescommon.IsClientError(validateErr) {
+			gdlog.WithError(validateErr).Errorf("GlobalDatasource validation failed: %s", globaldatasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(
+				fmt.Errorf("global datasource %q failed server-side validation: %w", globaldatasource.Name, validateErr),
+				persescommon.ReasonValidationFailed,
+			)
+		}
+		gdlog.WithError(validateErr).Errorf("GlobalDatasource validation request failed: %s", globaldatasource.Name)
+		return subreconciler.RequeueWithErrorAndReason(
+			fmt.Errorf("global datasource %q validation request failed: %w", globaldatasource.Name, validateErr),
+			persescommon.ReasonBackendError,
+		)
 	}
 
-	gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
+	// Sync secret only after validation passes to avoid orphaned secrets
+	if persescommon.HasSecretConfig(globaldatasource.Spec.Client) {
+		_, reason, err := r.syncPersesGlobalSecret(ctx, persesClient, globaldatasource)
+		if err != nil {
+			gdlog.WithError(err).Errorf("Failed to create globaldatasource secret: %s", globaldatasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, reason)
+		}
+	}
+
+	if notFound {
+		_, err = persesClient.GlobalDatasource().Create(globalDatasourceWithName)
+		if err != nil {
+			gdlog.WithError(err).Errorf("Failed to create globaldatasource: %s", globaldatasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+		}
+		gdlog.Infof("GlobalDatasource created: %s", globaldatasource.Name)
+	} else {
+		_, err = persesClient.GlobalDatasource().Update(globalDatasourceWithName)
+		if err != nil {
+			gdlog.WithError(err).Errorf("Failed to update globaldatasource: %s", globaldatasource.Name)
+			return subreconciler.RequeueWithErrorAndReason(err, persescommon.ReasonBackendError)
+		}
+		gdlog.Infof("GlobalDatasource updated: %s", globaldatasource.Name)
+	}
 
 	res, err := subreconciler.ContinueReconciling()
 	return res, "", err

--- a/controllers/globaldatasources/globaldatasource_controller.go
+++ b/controllers/globaldatasources/globaldatasource_controller.go
@@ -105,8 +105,6 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 		}
 	}
 
-	existing, err := persesClient.GlobalDatasource().Get(globaldatasource.Name)
-
 	globalDatasourceWithName := &persesv1.GlobalDatasource{
 		Kind: persesv1.KindGlobalDatasource,
 		Metadata: persesv1.Metadata{
@@ -123,6 +121,8 @@ func (r *PersesGlobalDatasourceReconciler) syncPersesGlobalDatasource(ctx contex
 			persescommon.ReasonValidationFailed,
 		)
 	}
+
+	existing, err := persesClient.GlobalDatasource().Get(globaldatasource.Name)
 
 	if err != nil {
 		if errors.Is(err, perseshttp.RequestNotFoundError) {

--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -15,8 +15,11 @@ package common
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/perses/perses-operator/api/v1alpha2"
+	"github.com/perses/perses/pkg/client/perseshttp"
 	logger "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +91,17 @@ const (
 	// Generic failure for when the reason is due to the backend returning an error
 	ReasonBackendError ConditionStatusReason = "PersesBackendError"
 )
+
+// IsClientError returns true if the error is an HTTP 4xx response from the
+// Perses API, indicating a client-side error such as a validation failure.
+// Returns false for 5xx errors, network errors, or non-HTTP errors.
+func IsClientError(err error) bool {
+	var reqErr *perseshttp.RequestError
+	if errors.As(err, &reqErr) {
+		return reqErr.StatusCode >= http.StatusBadRequest && reqErr.StatusCode < http.StatusInternalServerError
+	}
+	return false
+}
 
 // isTLSEnabled checks if TLS is enabled in the Perses configuration
 func isTLSEnabled(perses *v1alpha2.Perses) bool {

--- a/internal/perses/common/constants.go
+++ b/internal/perses/common/constants.go
@@ -83,6 +83,8 @@ const (
 	ReasonInvalidConfiguration ConditionStatusReason = "InvalidConfiguration"
 	// Failure to be used when resource that started the reconciliation is unable to be found
 	ReasonMissingResource ConditionStatusReason = "MissingResource"
+	// Failure to be used when server-side validation of a resource fails
+	ReasonValidationFailed ConditionStatusReason = "ValidationFailed"
 	// Generic failure for when the reason is due to the backend returning an error
 	ReasonBackendError ConditionStatusReason = "PersesBackendError"
 )

--- a/internal/perses/perses_mock_api.go
+++ b/internal/perses/perses_mock_api.go
@@ -54,7 +54,7 @@ func newMockClientWithValidateServer(validateErr string) (*MockClient, *httptest
 		if strings.HasPrefix(r.URL.Path, "/api/validate/") {
 			if validateErr != "" {
 				w.WriteHeader(http.StatusBadRequest)
-				fmt.Fprint(w, validateErr)
+				_, _ = fmt.Fprint(w, validateErr)
 				return
 			}
 			w.WriteHeader(http.StatusOK)

--- a/internal/perses/perses_mock_api.go
+++ b/internal/perses/perses_mock_api.go
@@ -14,7 +14,15 @@
 package perses
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
 	v1 "github.com/perses/perses/pkg/client/api/v1"
+	clientConfig "github.com/perses/perses/pkg/client/config"
+	"github.com/perses/perses/pkg/client/perseshttp"
+	"github.com/perses/perses/pkg/model/api/v1/common"
 	modelv1 "github.com/perses/perses/pkg/model/api/v1"
 	"github.com/stretchr/testify/mock"
 )
@@ -22,6 +30,45 @@ import (
 type MockClient struct {
 	v1.ClientInterface
 	mock.Mock
+	restClient *perseshttp.RESTClient
+}
+
+func (c *MockClient) RESTClient() *perseshttp.RESTClient {
+	return c.restClient
+}
+
+// NewMockClientWithValidation creates a MockClient wired to a validate server
+// that always returns 200 (valid). Caller must close the returned server.
+func NewMockClientWithValidation() (*MockClient, *httptest.Server) {
+	return newMockClientWithValidateServer("")
+}
+
+// NewMockClientWithValidationError creates a MockClient wired to a validate server
+// that returns 400 with the given error message. Caller must close the returned server.
+func NewMockClientWithValidationError(errMsg string) (*MockClient, *httptest.Server) {
+	return newMockClientWithValidateServer(errMsg)
+}
+
+func newMockClientWithValidateServer(validateErr string) (*MockClient, *httptest.Server) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/validate/") {
+			if validateErr != "" {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, validateErr)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	parsedURL, _ := common.ParseURL(server.URL)
+	restClient, _ := clientConfig.NewRESTClient(clientConfig.RestConfigClient{
+		URL: parsedURL,
+	})
+
+	return &MockClient{restClient: restClient}, server
 }
 
 type project struct {

--- a/internal/perses/perses_mock_api.go
+++ b/internal/perses/perses_mock_api.go
@@ -63,10 +63,18 @@ func newMockClientWithValidateServer(validateErr string) (*MockClient, *httptest
 		w.WriteHeader(http.StatusNotFound)
 	}))
 
-	parsedURL, _ := common.ParseURL(server.URL)
-	restClient, _ := clientConfig.NewRESTClient(clientConfig.RestConfigClient{
+	parsedURL, err := common.ParseURL(server.URL)
+	if err != nil {
+		server.Close()
+		panic(fmt.Sprintf("MockValidateServer: failed to parse test server URL: %v", err))
+	}
+	restClient, err := clientConfig.NewRESTClient(clientConfig.RestConfigClient{
 		URL: parsedURL,
 	})
+	if err != nil {
+		server.Close()
+		panic(fmt.Sprintf("MockValidateServer: failed to create REST client: %v", err))
+	}
 
 	return &MockClient{restClient: restClient}, server
 }

--- a/test/e2e/validation/00-assert.yaml
+++ b/test/e2e/validation/00-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-validation-test
+status:
+  conditions:
+    - type: Available
+      status: "True"
+      reason: Reconciled
+    - type: Degraded
+      status: "False"
+      reason: Reconciled
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-validation-test

--- a/test/e2e/validation/00-install.yaml
+++ b/test/e2e/validation/00-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: perses.dev/v1alpha2
+kind: Perses
+metadata:
+  name: perses-validation-test
+  labels:
+    app.kubernetes.io/instance: perses-validation-test
+spec:
+  metadata:
+    labels:
+      instance: perses-validation-test
+  config:
+    database:
+      file:
+        folder: "/perses"
+        extension: "yaml"
+  containerPort: 8080
+  resources:
+    requests:
+      memory: 128Mi

--- a/test/e2e/validation/01-assert.yaml
+++ b/test/e2e/validation/01-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: perses-validation-test
+status:
+  readyReplicas: 1

--- a/test/e2e/validation/02-assert.yaml
+++ b/test/e2e/validation/02-assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+commands:
+  - script: |
+      REASON=$(kubectl get persesdashboard valid-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].reason}')
+      if [ "$REASON" != "Reconciled" ]; then
+        echo "FAIL: Expected valid-dashboard Available reason 'Reconciled' but got '$REASON'"
+        exit 1
+      fi
+      echo "PASS: valid-dashboard reconciled successfully"
+  - script: |
+      REASON=$(kubectl get persesdashboard invalid-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Degraded")].reason}')
+      if [ "$REASON" != "ValidationFailed" ]; then
+        echo "FAIL: Expected invalid-dashboard Degraded reason 'ValidationFailed' but got '$REASON'"
+        exit 1
+      fi
+      STATUS=$(kubectl get persesdashboard invalid-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Available")].status}')
+      if [ "$STATUS" != "False" ]; then
+        echo "FAIL: Expected invalid-dashboard Available status 'False' but got '$STATUS'"
+        exit 1
+      fi
+      MSG=$(kubectl get persesdashboard invalid-dashboard -n $NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Degraded")].message}')
+      echo "$MSG" | grep -q "failed server-side validation" || {
+        echo "FAIL: Expected message to contain 'failed server-side validation' but got: $MSG"
+        exit 1
+      }
+      echo "PASS: invalid-dashboard correctly shows ValidationFailed"

--- a/test/e2e/validation/02-install.yaml
+++ b/test/e2e/validation/02-install.yaml
@@ -1,0 +1,79 @@
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: valid-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-validation-test
+  config:
+    display:
+      name: Valid Dashboard
+    duration: 5m
+    panels:
+      testPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Test Panel
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    query: up
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/testPanel"
+---
+apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: invalid-dashboard
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: perses-validation-test
+  config:
+    display:
+      name: Invalid Dashboard
+    duration: 5m
+    panels:
+      badPanel:
+        kind: Panel
+        spec:
+          display:
+            name: Bad Panel
+          plugin:
+            kind: NonExistentPluginThatDoesNotExist
+            spec:
+              foo: bar
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: Row 1
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 24
+              height: 6
+              content:
+                "$ref": "#/spec/panels/badPanel"

--- a/test/e2e/validation/03-assert.yaml
+++ b/test/e2e/validation/03-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+commands:
+  - command: kubectl wait --for=delete persesdashboard/valid-dashboard -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete persesdashboard/invalid-dashboard -n $NAMESPACE --timeout=60s
+  - command: kubectl wait --for=delete perses/perses-validation-test -n $NAMESPACE --timeout=60s

--- a/test/e2e/validation/03-delete.yaml
+++ b/test/e2e/validation/03-delete.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDashboard
+    metadata:
+      name: valid-dashboard
+  - apiVersion: perses.dev/v1alpha2
+    kind: PersesDashboard
+    metadata:
+      name: invalid-dashboard
+  - apiVersion: perses.dev/v1alpha2
+    kind: Perses
+    metadata:
+      name: perses-validation-test


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

- Adds server-side validation during reconciliation for `PersesDashboard`, `PersesDatasource`, and `PersesGlobalDatasource` resources by calling the Perses validate API before creating or updating resources
- When validation fails, the reconciler sets the status to Degraded with a `ValidationFailed` reason and does not proceed with the Create/Update call
- Introduces `ReasonValidationFailed` constant and extends `MockClient` with `RESTClient()` support for testing against httptest-based validate servers

Closes: COO-1933

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
