### PR TITLE
[IGNORE]: Fix OperatorHub PR lookup for existing pull requests

### DIFF
--- a/.github/workflows/operator-hub-release.yaml
+++ b/.github/workflows/operator-hub-release.yaml
@@ -203,13 +203,11 @@ jobs:
           git push -f --set-upstream origin "${branch}"
 
           existing_pr="$(
-            gh pr list \
-              --repo "${target_repo}" \
-              --head "${head_branch}" \
-              --base main \
-              --state open \
-              --json url \
-              --jq '.[0].url // empty'
+            gh api -X GET "/repos/${target_repo}/pulls" \
+              -f state=open \
+              -f base=main \
+              -f "head=${head_branch}" \
+              --jq '.[0].html_url // empty'
           )"
 
           if [ -n "${existing_pr}" ]; then


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

Rerunning the OperatorHub release workflow should update the existing branch and skip PR creation when the PR is already open.

This commit uses the pulls REST API instead which lets reruns update the existing branch and exit successfully when an OperatorHub PR already exists.

Closes: #447

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer
- [ ] Code follows project conventions and passes linting
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
