### PR TITLE
[FEATURE] Add priorityClassName to Perses spec

### DIFF
--- a/api/v1alpha1/perses_conversion.go
+++ b/api/v1alpha1/perses_conversion.go
@@ -44,7 +44,7 @@ func (dst *Perses) ConvertFrom(srcRaw conv.Hub) error {
 // Convert_v1alpha2_PersesSpec_To_v1alpha1_PersesSpec converts a PersesSpec from v1alpha2 to v1alpha1.
 func Convert_v1alpha2_PersesSpec_To_v1alpha1_PersesSpec(in *v1alpha2.PersesSpec, out *PersesSpec, s conversion.Scope) error {
 	// NOTE: The following v1alpha2 fields are not supported in v1alpha1 and will be dropped during conversion:
-	// PodSecurityContext, LogLevel, LogMethodTrace, Provisioning, Volumes, VolumeMounts, Env, EnvFrom
+	// PodSecurityContext, LogLevel, LogMethodTrace, Provisioning, Volumes, VolumeMounts, Env, EnvFrom, PriorityClassName
 	return autoConvert_v1alpha2_PersesSpec_To_v1alpha1_PersesSpec(in, out, s)
 }
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1005,6 +1005,7 @@ func autoConvert_v1alpha2_PersesSpec_To_v1alpha1_PersesSpec(in *v1alpha2.PersesS
 	out.NodeSelector = in.NodeSelector
 	out.Tolerations = in.Tolerations
 	out.Affinity = in.Affinity
+	// WARNING: in.PriorityClassName requires manual conversion: does not exist in peer-type
 	if err := v1.Convert_Pointer_string_To_string(&in.Image, &out.Image, s); err != nil {
 		return err
 	}

--- a/api/v1alpha2/perses_types.go
+++ b/api/v1alpha2/perses_types.go
@@ -65,6 +65,11 @@ type PersesSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// priorityClassName assigns the pods to a PriorityClass, influencing scheduling and preemption
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +kubebuilder:validation:MinLength=1
+	// +optional
+	PriorityClassName *string `json:"priorityClassName,omitempty"`
 	// image specifies the container image that should be used for the Perses deployment
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -655,6 +655,11 @@ func (in *PersesSpec) DeepCopyInto(out *PersesSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PriorityClassName != nil {
+		in, out := &in.PriorityClassName, &out.PriorityClassName
+		*out = new(string)
+		**out = **in
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -6239,6 +6239,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: priorityClassName assigns the pods to a PriorityClass,
+                  influencing scheduling and preemption
+                minLength: 1
+                type: string
               provisioning:
                 description: provisioning configuration for provisioning secrets
                 properties:

--- a/bundle/manifests/perses.dev_perses.yaml
+++ b/bundle/manifests/perses.dev_perses.yaml
@@ -6228,6 +6228,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: priorityClassName assigns the pods to a PriorityClass,
+                  influencing scheduling and preemption
+                minLength: 1
+                type: string
               provisioning:
                 description: provisioning configuration for provisioning secrets
                 properties:

--- a/config/crd/bases/perses.dev_perses.yaml
+++ b/config/crd/bases/perses.dev_perses.yaml
@@ -6217,6 +6217,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: priorityClassName assigns the pods to a PriorityClass,
+                  influencing scheduling and preemption
+                minLength: 1
+                type: string
               provisioning:
                 description: provisioning configuration for provisioning secrets
                 properties:

--- a/controllers/perses/deployment_controller.go
+++ b/controllers/perses/deployment_controller.go
@@ -211,6 +211,10 @@ func (r *PersesReconciler) createPersesDeployment(
 		dep.Spec.Template.Spec.ServiceAccountName = *perses.Spec.ServiceAccountName
 	}
 
+	if perses.Spec.PriorityClassName != nil && *perses.Spec.PriorityClassName != "" {
+		dep.Spec.Template.Spec.PriorityClassName = *perses.Spec.PriorityClassName
+	}
+
 	// Set the ownerRef for the Deployment
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
 	if err := ctrl.SetControllerReference(perses, dep, r.Scheme); err != nil {

--- a/controllers/perses/statefulset_controller.go
+++ b/controllers/perses/statefulset_controller.go
@@ -231,6 +231,10 @@ func (r *PersesReconciler) createPersesStatefulSet(
 		sts.Spec.Template.Spec.ServiceAccountName = *perses.Spec.ServiceAccountName
 	}
 
+	if perses.Spec.PriorityClassName != nil && *perses.Spec.PriorityClassName != "" {
+		sts.Spec.Template.Spec.PriorityClassName = *perses.Spec.PriorityClassName
+	}
+
 	// Set the ownerRef for the StatefulSet
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/
 	if err := ctrl.SetControllerReference(perses, sts, r.Scheme); err != nil {

--- a/controllers/perses_controller_test.go
+++ b/controllers/perses_controller_test.go
@@ -73,6 +73,7 @@ var _ = Describe("Perses controller", func() {
 							},
 						},
 						ServiceAccountName: ptr.To("perses-service-account"),
+						PriorityClassName:  ptr.To("system-cluster-critical"),
 						Replicas:           &replicas,
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -191,6 +192,9 @@ var _ = Describe("Perses controller", func() {
 					}
 					if found.Spec.Template.Spec.ServiceAccountName != "perses-service-account" {
 						return fmt.Errorf("The service account used in the StatefulSet is not the one defined in the custom resource")
+					}
+					if found.Spec.Template.Spec.PriorityClassName != "system-cluster-critical" {
+						return fmt.Errorf("The priority class name used in the StatefulSet is not the one defined in the custom resource")
 					}
 					if value, ok := found.ObjectMeta.Annotations["testing"]; ok {
 						if value != "true" {
@@ -1091,6 +1095,64 @@ var _ = Describe("Perses controller", func() {
 				}
 				if !slices.Contains(args, "--web.tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384") {
 					return fmt.Errorf("missing --web.tls-cipher-suites arg in %v", args)
+				}
+				return nil
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("Deleting the custom resource")
+			persesToDelete := &persesv1alpha2.Perses{}
+			Expect(k8sClient.Get(ctx, typeNamespaceName, persesToDelete)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, persesToDelete)).To(Succeed())
+		})
+
+		It("should set priorityClassName on the Deployment when configured", func() {
+			const PersesPriorityDeployName = "perses-priority-deployment"
+			typeNamespaceName := types.NamespacedName{Name: PersesPriorityDeployName, Namespace: persesNamespace}
+
+			By("Creating a Perses CR with emptyDir storage (triggers Deployment) and a priorityClassName")
+			perses := &persesv1alpha2.Perses{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PersesPriorityDeployName,
+					Namespace: persesNamespace,
+				},
+				Spec: persesv1alpha2.PersesSpec{
+					Image:             ptr.To(persesImage),
+					PriorityClassName: ptr.To("system-cluster-critical"),
+					Config: persesv1alpha2.PersesConfig{
+						Config: persesconfig.Config{
+							Database: persesconfig.Database{
+								File: &persesconfig.File{
+									Folder: "/etc/perses/storage",
+								},
+							},
+						},
+					},
+					Storage: &persesv1alpha2.StorageConfiguration{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, perses)).To(Succeed())
+
+			persesReconciler := &persescontroller.PersesReconciler{
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+			}
+
+			By("Reconciling and checking that the Deployment has the priorityClassName")
+			Eventually(func() error {
+				if _, err := persesReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespaceName,
+				}); err != nil {
+					return err
+				}
+				found := &appsv1.Deployment{}
+				if err := k8sClient.Get(ctx, typeNamespaceName, found); err != nil {
+					return err
+				}
+				if found.Spec.Template.Spec.PriorityClassName != "system-cluster-critical" {
+					return fmt.Errorf("the priority class name used in the Deployment is not the one defined in the custom resource")
 				}
 				return nil
 			}, time.Minute, time.Second).Should(Succeed())

--- a/docs/api.md
+++ b/docs/api.md
@@ -406,6 +406,7 @@ _Appears in:_
 | `nodeSelector` _object (keys:string, values:string)_ | nodeSelector constrains pods to nodes with matching labels |  | Optional: \{\} <br /> |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#toleration-v1-core) array_ | tolerations allow pods to schedule onto nodes with matching taints |  | Optional: \{\} <br /> |
 | `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#affinity-v1-core)_ | affinity specifies the pod's scheduling constraints |  | Optional: \{\} <br /> |
+| `priorityClassName` _string_ | priorityClassName assigns the pods to a PriorityClass, influencing scheduling and preemption |  | MinLength: 1 <br />Optional: \{\} <br /> |
 | `image` _string_ | image specifies the container image that should be used for the Perses deployment |  | Optional: \{\} <br /> |
 | `service` _[PersesService](#persesservice)_ | service specifies the service configuration for the Perses instance |  | Optional: \{\} <br /> |
 | `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.36/#probe-v1-core)_ | livenessProbe specifies the liveness probe configuration for the Perses container |  | Optional: \{\} <br /> |

--- a/jsonnet/examples/0persesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesCustomResourceDefinition.yaml
@@ -5858,6 +5858,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: priorityClassName assigns the pods to a PriorityClass, influencing scheduling and preemption
+                minLength: 1
+                type: string
               provisioning:
                 description: provisioning configuration for provisioning secrets
                 properties:

--- a/jsonnet/generated/perses.dev_perses-crd.json
+++ b/jsonnet/generated/perses.dev_perses-crd.json
@@ -6200,6 +6200,11 @@
                     },
                     "type": "object"
                   },
+                  "priorityClassName": {
+                    "description": "priorityClassName assigns the pods to a PriorityClass, influencing scheduling and preemption",
+                    "minLength": 1,
+                    "type": "string"
+                  },
                   "provisioning": {
                     "description": "provisioning configuration for provisioning secrets",
                     "properties": {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

Allow assigning Perses pods to a PriorityClass via `spec.priorityClassName`. The field is included in both the Deployment and StatefulSet pod templates, mirroring the existing `serviceAccountName` handling.

Added to the `v1alpha2` (storage version) `PersesSpec` as an optional `*string`, matching the pointer convention of the neighboring optional scalar fields.

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
