### PR TITLE
[IGNORE] add commit lint checks

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,25 @@
+parserPreset:
+  parserOpts:
+    headerPattern: '^\[(FEATURE|ENHANCEMENT|BUGFIX|BREAKINGCHANGE|DOC|IGNORE)\]\s(.+)$'
+    headerCorrespondence:
+      - type
+      - subject
+
+rules:
+  type-case:
+    - 0
+  type-enum:
+    - 2
+    - always
+    - - FEATURE
+      - ENHANCEMENT
+      - BUGFIX
+      - BREAKINGCHANGE
+      - DOC
+      - IGNORE
+  type-empty:
+    - 2
+    - never
+  subject-empty:
+    - 2
+    - never

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -1,0 +1,26 @@
+name: commit-lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  commit-lint:
+    if: github.event_name == 'pull_request' && github.actor != 'github-actions[bot]'
+    name: commit lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1


### PR DESCRIPTION
Add commitlint configuration and a checks workflow to validate that PR commit messages follow the project's [CATALOG_ENTRY] convention.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
