### PR TITLE
[FEATURE] add PersesGlobalDatasource CRD and RBAC roles to libsonnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,6 +472,12 @@ bundle-check: bundle
 .PHONY: jsonnet-check
 jsonnet-check: manifests
 	git diff --exit-code jsonnet/generated jsonnet/examples
+	@if [ -n "$$(git ls-files --others --exclude-standard jsonnet/generated jsonnet/examples)" ]; then \
+		echo "ERROR: untracked files found in jsonnet/generated or jsonnet/examples:"; \
+		git ls-files --others --exclude-standard jsonnet/generated jsonnet/examples; \
+		echo "Please commit the new generated files."; \
+		exit 1; \
+	fi
 
 .PHONY: bundle-build
 bundle-build: generate bundle ## Build the bundle image.

--- a/jsonnet/examples/0persesglobaldatasourcesCustomResourceDefinition.yaml
+++ b/jsonnet/examples/0persesglobaldatasourcesCustomResourceDefinition.yaml
@@ -1,0 +1,425 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: persesglobaldatasources.perses.dev
+spec:
+  group: perses.dev
+  names:
+    kind: PersesGlobalDatasource
+    listKind: PersesGlobalDatasourceList
+    plural: persesglobaldatasources
+    shortNames:
+    - pergds
+    singular: persesglobaldatasource
+  scope: Cluster
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PersesGlobalDatasource is the Schema for the PersesGlobalDatasources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the PersesGlobalDatasource resource
+            properties:
+              client:
+                description: client specifies authentication and TLS configuration for the datasource
+                properties:
+                  basicAuth:
+                    description: basicAuth provides username/password authentication configuration for the Perses client
+                    properties:
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      passwordPath:
+                        description: |-
+                          passwordPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the password is stored
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                      username:
+                        description: username is the username credential for basic authentication
+                        minLength: 1
+                        type: string
+                    required:
+                    - passwordPath
+                    - type
+                    - username
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
+                  kubernetesAuth:
+                    description: kubernetesAuth enables Kubernetes native authentication for the Perses client
+                    properties:
+                      enable:
+                        description: enable determines whether Kubernetes authentication is enabled for the Perses client
+                        type: boolean
+                    type: object
+                  oauth:
+                    description: oauth provides OAuth 2.0 authentication configuration for the Perses client
+                    properties:
+                      authStyle:
+                        description: |-
+                          authStyle specifies how the endpoint wants the client ID and client secret sent
+                          The zero value means to auto-detect
+                        format: int32
+                        type: integer
+                      clientIDPath:
+                        description: |-
+                          clientIDPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client ID is stored
+                        type: string
+                      clientSecretPath:
+                        description: |-
+                          clientSecretPath specifies the key name within the secret/configmap or filesystem path
+                          (depending on SecretSource.Type) where the OAuth client secret is stored
+                        type: string
+                      endpointParams:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: endpointParams specifies additional parameters to include in requests to the token endpoint
+                        type: object
+                      name:
+                        description: |-
+                          name is the name of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                          Required when Type is "secret" or "configmap", ignored when Type is "file"
+                        minLength: 1
+                        type: string
+                      scopes:
+                        description: scopes specifies optional requested permissions for the OAuth token
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      tokenURL:
+                        description: |-
+                          tokenURL is the OAuth 2.0 provider's token endpoint URL
+                          This is a constant specific to each OAuth provider
+                        minLength: 1
+                        type: string
+                      type:
+                        description: type specifies the source type for secret data (secret, configmap, or file)
+                        enum:
+                        - secret
+                        - configmap
+                        - file
+                        type: string
+                    required:
+                    - tokenURL
+                    - type
+                    type: object
+                    x-kubernetes-validations:
+                    - message: name is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                    - message: namespace is required when type is secret or configmap
+                      rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
+                  tls:
+                    description: tls provides TLS/SSL configuration for secure connections to Perses
+                    properties:
+                      caCert:
+                        description: caCert specifies the CA certificate to verify the Perses server's certificate
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
+                      enable:
+                        description: enable determines whether TLS is enabled for connections to Perses
+                        type: boolean
+                      insecureSkipVerify:
+                        description: |-
+                          insecureSkipVerify determines whether to skip verification of the Perses server's certificate
+                          Setting this to true is insecure and should only be used for testing
+                        type: boolean
+                      userCert:
+                        description: userCert specifies the client certificate and key for mutual TLS (mTLS) authentication
+                        properties:
+                          certPath:
+                            description: |-
+                              certPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the certificate is stored
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              namespace is the namespace of the Kubernetes Secret or ConfigMap resource
+                              Required when Type is "secret" or "configmap", ignored when Type is "file"
+                            minLength: 1
+                            type: string
+                          privateKeyPath:
+                            description: |-
+                              privateKeyPath specifies the key name within the secret/configmap or filesystem path
+                              (depending on SecretSource.Type) where the private key is stored
+                              Required for client certificates (UserCert), optional for CA certificates (CaCert)
+                            type: string
+                          type:
+                            description: type specifies the source type for secret data (secret, configmap, or file)
+                            enum:
+                            - secret
+                            - configmap
+                            - file
+                            type: string
+                        required:
+                        - certPath
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: name is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.name)
+                        - message: namespace is required when type is secret or configmap
+                          rule: self.type != 'secret' && self.type != 'configmap' || has(self.__namespace__)
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: kubernetesAuth and oauth are mutually exclusive; both cannot be enabled simultaneously
+                  rule: '!(has(self.kubernetesAuth) && has(self.kubernetesAuth.enable) && self.kubernetesAuth.enable == true && has(self.oauth))'
+                - message: kubernetesAuth and basicAuth are mutually exclusive; both cannot be enabled simultaneously
+                  rule: '!(has(self.kubernetesAuth) && has(self.kubernetesAuth.enable) && self.kubernetesAuth.enable == true && has(self.basicAuth))'
+                - message: oauth and basicAuth are mutually exclusive; both cannot be enabled simultaneously
+                  rule: '!(has(self.basicAuth) && has(self.oauth))'
+              config:
+                description: config specifies the Perses datasource configuration
+                properties:
+                  default:
+                    type: boolean
+                  display:
+                    properties:
+                      description:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  plugin:
+                    description: |-
+                      Plugin will contain the datasource configuration.
+                      The data typed is available in Cue.
+                    properties:
+                      kind:
+                        description: Kind is the type of the plugin (e.g., Panel, Variable, Datasource, etc.).
+                        type: string
+                      metadata:
+                        description: Metadata is an optional field that contains additional information such as version and registry of the plugin.
+                        properties:
+                          registry:
+                            description: 'Registry is optional. If not provided, it means the default registry is: "perses.dev".'
+                            type: string
+                          version:
+                            description: |-
+                              Version is optional. If not provided, it means the latest version available in the Perses instance.
+                              Version needs to follow the semantic versioning format (e.g., "1.0.0" or "v1.0.0")
+                            type: string
+                        type: object
+                      spec:
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                    - kind
+                    - spec
+                    type: object
+                required:
+                - default
+                - plugin
+                type: object
+              instanceSelector:
+                description: instanceSelector selects Perses instances where this datasource will be created
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - config
+            type: object
+          status:
+            description: status is the observed state of the PersesGlobalDatasource resource
+            properties:
+              conditions:
+                description: conditions represent the latest observations of the PersesGlobalDatasource resource state
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/jsonnet/examples/persesGlobalDatasourceEditorRole.yaml
+++ b/jsonnet/examples/persesGlobalDatasourceEditorRole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: perses-operator
+    app.kubernetes.io/instance: persesglobaldatasource-editor-role
+    app.kubernetes.io/name: perses-operator
+    app.kubernetes.io/part-of: perses-operator
+    app.kubernetes.io/version: v0.5.0
+  name: persesglobaldatasource-editor-role
+rules:
+- apiGroups:
+  - perses.dev
+  resources:
+  - persesglobaldatasources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - perses.dev
+  resources:
+  - persesglobaldatasources/status
+  verbs:
+  - get

--- a/jsonnet/examples/persesGlobalDatasourceViewerRole.yaml
+++ b/jsonnet/examples/persesGlobalDatasourceViewerRole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: perses-operator
+    app.kubernetes.io/instance: persesglobaldatasource-viewer-role
+    app.kubernetes.io/name: perses-operator
+    app.kubernetes.io/part-of: perses-operator
+    app.kubernetes.io/version: v0.5.0
+  name: persesglobaldatasource-viewer-role
+rules:
+- apiGroups:
+  - perses.dev
+  resources:
+  - persesglobaldatasources
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - perses.dev
+  resources:
+  - persesglobaldatasources/status
+  verbs:
+  - get

--- a/jsonnet/perses-operator.libsonnet
+++ b/jsonnet/perses-operator.libsonnet
@@ -30,6 +30,7 @@ function(params) {
   '0persesCustomResourceDefinition': import 'generated/perses.dev_perses-crd.json',
   '0persesdashboardsCustomResourceDefinition': import 'generated/perses.dev_persesdashboards-crd.json',
   '0persesdatasourcesCustomResourceDefinition': import 'generated/perses.dev_persesdatasources-crd.json',
+  '0persesglobaldatasourcesCustomResourceDefinition': import 'generated/perses.dev_persesglobaldatasources-crd.json',
 
   local deployment_gen = import 'generated/manager.json',
   local service_account_gen = import 'generated/service_account.json',
@@ -39,6 +40,8 @@ function(params) {
   local persesdashboard_editor_role_gen = import 'generated/persesdashboard_editor_role.json',
   local persesdatasource_viewer_role_gen = import 'generated/persesdatasource_viewer_role.json',
   local persesdatasource_editor_role_gen = import 'generated/persesdatasource_editor_role.json',
+  local persesglobaldatasource_viewer_role_gen = import 'generated/persesglobaldatasource_viewer_role.json',
+  local persesglobaldatasource_editor_role_gen = import 'generated/persesglobaldatasource_editor_role.json',
   local leader_election_role_gen = import 'generated/leader_election_role.json',
   local leader_election_role_binding_gen = import 'generated/leader_election_role_binding.json',
   local role_binding_gen = import 'generated/role_binding.json',
@@ -134,6 +137,26 @@ function(params) {
       labels: po.config.commonLabels {
         'app.kubernetes.io/component': 'rbac',
         'app.kubernetes.io/instance': 'persesdatasource-viewer-role',
+      },
+    },
+  },
+
+  persesGlobalDatasourceEditorRole: persesglobaldatasource_editor_role_gen {
+    metadata+: {
+      name: 'persesglobaldatasource-editor-role',
+      labels: po.config.commonLabels {
+        'app.kubernetes.io/component': 'rbac',
+        'app.kubernetes.io/instance': 'persesglobaldatasource-editor-role',
+      },
+    },
+  },
+
+  persesGlobalDatasourceViewerRole: persesglobaldatasource_viewer_role_gen {
+    metadata+: {
+      name: 'persesglobaldatasource-viewer-role',
+      labels: po.config.commonLabels {
+        'app.kubernetes.io/component': 'rbac',
+        'app.kubernetes.io/instance': 'persesglobaldatasource-viewer-role',
       },
     },
   },


### PR DESCRIPTION
The generated perses.dev_persesglobaldatasources-crd.json and the GlobalDatasource editor/viewer role JSON files already exist in the jsonnet/generated/ directory but were not imported or exported by perses-operator.libsonnet.

This allows consumers of the libsonnet (e.g. kube-prometheus addons) to deploy PersesGlobalDatasource resources without importing the CRD directly from the generated path.

<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

Related-to https://github.com/prometheus-operator/kube-prometheus/issues/2654

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
