### PR TITLE
[FEATURE] add a resource_namespace to managed resources metric

### DIFF
--- a/controllers/dashboards/persesdashboard_controller.go
+++ b/controllers/dashboards/persesdashboard_controller.go
@@ -126,9 +126,9 @@ func (r *PersesDashboardReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if reconcileErr != nil {
 			reason := string(common.ExtractReason(reconcileErr, "reconciliation_failed"))
 			r.Metrics.ReconcileErrors("persesdashboard", reason).Inc()
-			r.Metrics.SetFailedResources(objKey, "dashboard", 1)
+			r.Metrics.SetFailedResources(objKey, "dashboard", req.Namespace, 1)
 		} else {
-			r.Metrics.SetSyncedResources(objKey, "dashboard", 1)
+			r.Metrics.SetSyncedResources(objKey, "dashboard", req.Namespace, 1)
 		}
 	}
 

--- a/controllers/datasources/persesdatasource_controller.go
+++ b/controllers/datasources/persesdatasource_controller.go
@@ -126,9 +126,9 @@ func (r *PersesDatasourceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if reconcileErr != nil {
 			reason := string(common.ExtractReason(reconcileErr, "reconciliation_failed"))
 			r.Metrics.ReconcileErrors("persesdatasource", reason).Inc()
-			r.Metrics.SetFailedResources(objKey, "datasource", 1)
+			r.Metrics.SetFailedResources(objKey, "datasource", req.Namespace, 1)
 		} else {
-			r.Metrics.SetSyncedResources(objKey, "datasource", 1)
+			r.Metrics.SetSyncedResources(objKey, "datasource", req.Namespace, 1)
 		}
 	}
 

--- a/controllers/globaldatasources/persesglobaldatasource_controller.go
+++ b/controllers/globaldatasources/persesglobaldatasource_controller.go
@@ -126,9 +126,9 @@ func (r *PersesGlobalDatasourceReconciler) Reconcile(ctx context.Context, req ct
 		if reconcileErr != nil {
 			reason := string(common.ExtractReason(reconcileErr, "reconciliation_failed"))
 			r.Metrics.ReconcileErrors("persesglobaldatasource", reason).Inc()
-			r.Metrics.SetFailedResources(objKey, "globaldatasource", 1)
+			r.Metrics.SetFailedResources(objKey, "globaldatasource", "", 1)
 		} else {
-			r.Metrics.SetSyncedResources(objKey, "globaldatasource", 1)
+			r.Metrics.SetSyncedResources(objKey, "globaldatasource", "", 1)
 		}
 	}
 

--- a/controllers/perses/perses_controller.go
+++ b/controllers/perses/perses_controller.go
@@ -157,9 +157,9 @@ func (r *PersesReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if reconcileErr != nil {
 			reason := string(common.ExtractReason(reconcileErr, "reconciliation_failed"))
 			r.Metrics.ReconcileErrors("perses", reason).Inc()
-			r.Metrics.SetFailedResources(objKey, "perses", 1)
+			r.Metrics.SetFailedResources(objKey, "perses", req.Namespace, 1)
 		} else {
-			r.Metrics.SetSyncedResources(objKey, "perses", 1)
+			r.Metrics.SetSyncedResources(objKey, "perses", req.Namespace, 1)
 		}
 	}
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,6 +39,7 @@ Number of resources managed by the operator per state (synced/failed)
 
 - `resource`
 - `state`
+- `resource_namespace`
 
 
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -24,7 +24,7 @@ var (
 	resourcesDesc = prometheus.NewDesc(
 		"perses_operator_managed_resources",
 		"Number of resources managed by the operator per state (synced/failed)",
-		[]string{"resource", "state"},
+		[]string{"resource", "state", "resource_namespace"},
 		nil,
 	)
 )
@@ -47,8 +47,9 @@ type Metrics struct {
 }
 
 type resourceKey struct {
-	resource string
-	state    resourceState
+	resource  string
+	state     resourceState
+	namespace string
 }
 
 type resourceState int
@@ -141,13 +142,15 @@ func (m *Metrics) Ready(controller string) prometheus.Gauge {
 }
 
 // SetSyncedResources sets the number of resources that synced successfully for the given object's key.
-func (m *Metrics) SetSyncedResources(objKey, resource string, v int) {
-	m.setResources(objKey, resourceKey{resource: resource, state: synced}, v)
+// The namespace parameter is the Kubernetes namespace of the resource (empty for cluster-scoped resources).
+func (m *Metrics) SetSyncedResources(objKey, resource, namespace string, v int) {
+	m.setResources(objKey, resourceKey{resource: resource, state: synced, namespace: namespace}, v)
 }
 
 // SetFailedResources sets the number of resources that failed to sync for the given object's key.
-func (m *Metrics) SetFailedResources(objKey, resource string, v int) {
-	m.setResources(objKey, resourceKey{resource: resource, state: failed}, v)
+// The namespace parameter is the Kubernetes namespace of the resource (empty for cluster-scoped resources).
+func (m *Metrics) SetFailedResources(objKey, resource, namespace string, v int) {
+	m.setResources(objKey, resourceKey{resource: resource, state: failed, namespace: namespace}, v)
 }
 
 // ForgetObject removes all resource entries for the given object key.
@@ -196,6 +199,7 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 			float64(total),
 			rKey.resource,
 			rKey.state.String(),
+			rKey.namespace,
 		)
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -212,9 +212,9 @@ func TestManagedResourcesCollector(t *testing.T) {
 	reg.MustRegister(m)
 
 	// Set synced and failed resources
-	m.SetSyncedResources("perses-dev/perses-sample", "perses", 1)
-	m.SetSyncedResources("perses-dev/dashboard-1", "dashboard", 1)
-	m.SetFailedResources("perses-dev/dashboard-2", "dashboard", 1)
+	m.SetSyncedResources("perses-dev/perses-sample", "perses", "perses-dev", 1)
+	m.SetSyncedResources("perses-dev/dashboard-1", "dashboard", "perses-dev", 1)
+	m.SetFailedResources("perses-dev/dashboard-2", "dashboard", "perses-dev", 1)
 
 	// Collect metrics
 	metricCh := make(chan prometheus.Metric, 10)
@@ -239,16 +239,16 @@ func TestSetSyncedAndFailedResources(t *testing.T) {
 	}
 
 	// Set multiple resources
-	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
-	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
-	m.SetFailedResources("ns1/resource3", "dashboard", 1)
+	m.SetSyncedResources("ns1/resource1", "dashboard", "ns1", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", "ns1", 1)
+	m.SetFailedResources("ns1/resource3", "dashboard", "ns1", 1)
 
 	// Verify internal state
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	syncedKey := resourceKey{resource: "dashboard", state: synced}
-	failedKey := resourceKey{resource: "dashboard", state: failed}
+	syncedKey := resourceKey{resource: "dashboard", state: synced, namespace: "ns1"}
+	failedKey := resourceKey{resource: "dashboard", state: failed, namespace: "ns1"}
 
 	assert.Len(t, m.resources[syncedKey], 2, "Should have 2 synced resources")
 	assert.Len(t, m.resources[failedKey], 1, "Should have 1 failed resource")
@@ -310,10 +310,10 @@ func TestForgetObject(t *testing.T) {
 	}
 
 	// Set synced and failed entries for multiple objects
-	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
-	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
-	m.SetFailedResources("ns1/resource1", "dashboard", 1)
-	m.SetSyncedResources("ns2/resource3", "datasource", 1)
+	m.SetSyncedResources("ns1/resource1", "dashboard", "ns1", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", "ns1", 1)
+	m.SetFailedResources("ns1/resource1", "dashboard", "ns1", 1)
+	m.SetSyncedResources("ns2/resource3", "datasource", "ns2", 1)
 
 	// Forget resource1
 	m.ForgetObject("ns1/resource1")
@@ -322,9 +322,9 @@ func TestForgetObject(t *testing.T) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	syncedDashboard := resourceKey{resource: "dashboard", state: synced}
-	failedDashboard := resourceKey{resource: "dashboard", state: failed}
-	syncedDatasource := resourceKey{resource: "datasource", state: synced}
+	syncedDashboard := resourceKey{resource: "dashboard", state: synced, namespace: "ns1"}
+	failedDashboard := resourceKey{resource: "dashboard", state: failed, namespace: "ns1"}
+	syncedDatasource := resourceKey{resource: "datasource", state: synced, namespace: "ns2"}
 
 	assert.Equal(t, 1, len(m.resources[syncedDashboard]), "Should have 1 synced dashboard after forget")
 	assert.Equal(t, 1, len(m.resources[syncedDatasource]), "Datasource should be unaffected")
@@ -347,9 +347,9 @@ func TestForgetObjectCollectOutput(t *testing.T) {
 	}
 	reg.MustRegister(m)
 
-	m.SetSyncedResources("ns1/resource1", "dashboard", 1)
-	m.SetSyncedResources("ns1/resource2", "dashboard", 1)
-	m.SetFailedResources("ns1/resource3", "dashboard", 1)
+	m.SetSyncedResources("ns1/resource1", "dashboard", "ns1", 1)
+	m.SetSyncedResources("ns1/resource2", "dashboard", "ns1", 1)
+	m.SetFailedResources("ns1/resource3", "dashboard", "ns1", 1)
 
 	// Forget resource1 and resource3
 	m.ForgetObject("ns1/resource1")
@@ -360,7 +360,7 @@ func TestForgetObjectCollectOutput(t *testing.T) {
 	expected := `
 		# HELP perses_operator_managed_resources Number of resources managed by the operator per state (synced/failed)
 		# TYPE perses_operator_managed_resources gauge
-		perses_operator_managed_resources{resource="dashboard",state="synced"} 1
+		perses_operator_managed_resources{resource="dashboard",resource_namespace="ns1",state="synced"} 1
 	`
 	err := testutil.CollectAndCompare(m, strings.NewReader(expected))
 	assert.NoError(t, err)
@@ -375,8 +375,8 @@ func TestForgetObjectConcurrency(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func(id int) {
 			key := "test/resource"
-			m.SetSyncedResources(key, "dashboard", id)
-			m.SetFailedResources(key, "datasource", id)
+			m.SetSyncedResources(key, "dashboard", "test", id)
+			m.SetFailedResources(key, "datasource", "test", id)
 			m.ForgetObject(key)
 			done <- true
 		}(i)
@@ -400,8 +400,8 @@ func TestMetricsConcurrency(t *testing.T) {
 	done := make(chan bool)
 	for i := 0; i < 10; i++ {
 		go func(id int) {
-			m.SetSyncedResources("test/resource", "dashboard", id)
-			m.SetFailedResources("test/resource2", "datasource", id)
+			m.SetSyncedResources("test/resource", "dashboard", "test", id)
+			m.SetFailedResources("test/resource2", "datasource", "test", id)
 			done <- true
 		}(i)
 	}

--- a/jsonnet/examples/prometheusRule.yaml
+++ b/jsonnet/examples/prometheusRule.yaml
@@ -63,7 +63,7 @@ spec:
         severity: warning
     - alert: PersesOperatorResourceSyncFailures
       annotations:
-        description: Perses operator in {{ $labels.namespace }} namespace has {{ printf "%.0f" $value }} {{ $labels.resource }} resources in failed state.
+        description: Perses operator in {{ $labels.namespace }} namespace has {{ printf "%.0f" $value }} {{ $labels.resource }} resources in failed state (resource namespace {{ $labels.resource_namespace }}).
         summary: Resources failing to sync by Perses operator
       expr: |
         min_over_time(perses_operator_managed_resources{state="failed",job="perses-operator"}[5m]) > 0

--- a/jsonnet/mixin/alerts/alerts.libsonnet
+++ b/jsonnet/mixin/alerts/alerts.libsonnet
@@ -88,7 +88,7 @@
             },
             annotations: {
               summary: 'Resources failing to sync by Perses operator',
-              description: 'Perses operator in {{ $labels.namespace }} namespace has {{ printf "%.0f" $value }} {{ $labels.resource }} resources in failed state.',
+              description: 'Perses operator in {{ $labels.namespace }} namespace has {{ printf "%.0f" $value }} {{ $labels.resource }} resources in failed state (resource namespace {{ $labels.resource_namespace }}).',
             },
           },
         ],

--- a/scripts/generate-metrics-docs/main.go
+++ b/scripts/generate-metrics-docs/main.go
@@ -64,7 +64,7 @@ func parseMetrics() []Metric {
 			Name:   "perses_operator_managed_resources",
 			Type:   "Gauge",
 			Help:   "Number of resources managed by the operator per state (synced/failed)",
-			Labels: []string{"resource", "state"},
+			Labels: []string{"resource", "state", "resource_namespace"},
 		},
 		{
 			Name:   "perses_operator_reconcile_operations_total",

--- a/test/promtool/alerts_test.yaml
+++ b/test/promtool/alerts_test.yaml
@@ -156,7 +156,7 @@ tests:
   # PersesOperatorResourceSyncFailures: fires when failed resources > 0 for 5m
   - interval: 1m
     input_series:
-      - series: 'perses_operator_managed_resources{job="perses-operator",state="failed",namespace="perses-dev",resource="dashboard"}'
+      - series: 'perses_operator_managed_resources{job="perses-operator",state="failed",namespace="perses-dev",resource="dashboard",resource_namespace="perses-dev"}'
         values: "2 2 2 2 2 2 2 2 2 2"
     alert_rule_test:
       - eval_time: 10m
@@ -168,14 +168,15 @@ tests:
               state: failed
               namespace: perses-dev
               resource: dashboard
+              resource_namespace: perses-dev
             exp_annotations:
               summary: "Resources failing to sync by Perses operator"
-              description: "Perses operator in perses-dev namespace has 2 dashboard resources in failed state."
+              description: "Perses operator in perses-dev namespace has 2 dashboard resources in failed state (resource namespace perses-dev)."
 
   # PersesOperatorResourceSyncFailures: does NOT fire when state=synced
   - interval: 1m
     input_series:
-      - series: 'perses_operator_managed_resources{job="perses-operator",state="synced",namespace="perses-dev",resource="dashboard"}'
+      - series: 'perses_operator_managed_resources{job="perses-operator",state="synced",namespace="perses-dev",resource="dashboard",resource_namespace="perses-dev"}'
         values: "5 5 5 5 5 5 5 5 5 5"
     alert_rule_test:
       - eval_time: 10m


### PR DESCRIPTION
# Description

Add a `resource_namespace` metric label to identify the managed resources per namespace, if a resource is global the value is an epmty string

## Type of change

- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [ ] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
