### PR TITLE
[IGNORE] Use repo commitlint config in CI job

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -24,3 +24,5 @@ jobs:
           fetch-depth: 0
       - name: Lint commit messages
         uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+        with:
+          configFile: ./.commitlintrc.yaml


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull 
request. -->

This commit configure the commit lint workload to load the repository's .commitlintrc.yaml file explicitly.
This ensure CI validates commit messages against the project's documented convention instead of falling back to the action's default conventional commit rules

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
