### PR TITLE
[IGNORE] Optmize PR CI with changed file filters

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -3,26 +3,198 @@ name: changed-files
 on:
   workflow_call:
     outputs:
-      non-markdown-files:
-        description: "Non-empty if non-markdown files changed"
-        value: ${{ jobs.changed-files.outputs.non-markdown-files }}
+      go:
+        description: "Whether Go source, dependencies, or Go lint configuration changed"
+        value: ${{ jobs.changed-files.outputs.go }}
+      api:
+        description: "Whether API definitions or API docs inputs changed"
+        value: ${{ jobs.changed-files.outputs.api }}
+      manifests:
+        description: "Whether generated manifests, bundle, or manifest inputs changed"
+        value: ${{ jobs.changed-files.outputs.manifests }}
+      jsonnet:
+        description: "Whether jsonnet sources or alerting rule tests changed"
+        value: ${{ jobs.changed-files.outputs.jsonnet }}
+      shell:
+        description: "Whether shell scripts or shell formatting inputs changed"
+        value: ${{ jobs.changed-files.outputs.shell }}
+      e2e:
+        description: "Whether operator runtime, manifests, images, or e2e tests changed"
+        value: ${{ jobs.changed-files.outputs.e2e }}
+      docs:
+        description: "Whether markdown docs or markdown validation inputs changed"
+        value: ${{ jobs.changed-files.outputs.docs }}
+      metrics_docs:
+        description: "Whether metrics code or metrics documentation inputs changed"
+        value: ${{ jobs.changed-files.outputs.metrics_docs }}
+      ci:
+        description: "Whether PR changes require the full build/image CI job"
+        value: ${{ jobs.changed-files.outputs.ci }}
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   changed-files:
     outputs:
-      non-markdown-files: ${{ steps.changed-files.outputs.non-markdown-files }}
+      go: ${{ steps.filter.outputs.go || steps.all.outputs.go }}
+      api: ${{ steps.filter.outputs.api || steps.all.outputs.api }}
+      manifests: ${{ steps.filter.outputs.manifests || steps.all.outputs.manifests }}
+      jsonnet: ${{ steps.filter.outputs.jsonnet || steps.all.outputs.jsonnet }}
+      shell: ${{ steps.filter.outputs.shell || steps.all.outputs.shell }}
+      e2e: ${{ steps.filter.outputs.e2e || steps.all.outputs.e2e }}
+      docs: ${{ steps.filter.outputs.docs || steps.all.outputs.docs }}
+      metrics_docs: ${{ steps.filter.outputs.metrics_docs || steps.all.outputs.metrics_docs }}
+      ci: ${{ steps.filter.outputs.ci || steps.all.outputs.ci }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: get changed files
-        id: changed-files
+
+      - name: filter pull request changes
+        if: ${{ github.event_name == 'pull_request' }}
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.golangci*'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/go.yaml'
+
+            api:
+              - 'api/**'
+              - '.custom-gcl.yml'
+              - '.golangci-kube-api-linter.yml'
+              - 'docs/api.md'
+              - 'docs/config/api-docs-config.yaml'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/docs.yaml'
+
+            manifests:
+              - 'api/**'
+              - 'bundle/**'
+              - 'bundle.yaml'
+              - 'bundle.Dockerfile'
+              - 'config/**'
+              - 'hack/**'
+              - 'jsonnet/**'
+              - 'PROJECT'
+              - 'VERSION'
+              - 'Dockerfile*'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/go.yaml'
+
+            jsonnet:
+              - 'jsonnet/**'
+              - 'test/promtool/**'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/go.yaml'
+
+            shell:
+              - 'scripts/**/*.sh'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/go.yaml'
+
+            e2e:
+              - '**/*.go'
+              - 'api/**'
+              - 'bundle/**'
+              - 'bundle.yaml'
+              - 'bundle.Dockerfile'
+              - 'config/**'
+              - 'controllers/**'
+              - 'internal/**'
+              - 'test/e2e/**'
+              - '.github/env'
+              - 'Dockerfile*'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/e2e.yaml'
+
+            docs:
+              - '**/*.md'
+              - 'docs/**'
+              - '.mdox.validate.yaml'
+              - '.github/actions/mdox-cache/**'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/docs.yaml'
+
+            metrics_docs:
+              - 'internal/metrics/**'
+              - 'scripts/generate-metrics-docs/**'
+              - 'docs/metrics.md'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/docs.yaml'
+
+            ci:
+              - '**/*.go'
+              - 'api/**'
+              - 'bundle/**'
+              - 'bundle.yaml'
+              - 'bundle.Dockerfile'
+              - 'config/**'
+              - 'controllers/**'
+              - 'internal/**'
+              - 'jsonnet/**'
+              - 'scripts/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'PROJECT'
+              - 'VERSION'
+              - '.goreleaser*'
+              - 'Dockerfile*'
+              - 'Makefile'
+              - 'Makefile.tools'
+              - '.github/tools-cache/**'
+              - '.github/workflows/changed-files.yaml'
+              - '.github/workflows/ci.yaml'
+
+      - name: enable all filters for non-PR events
+        if: ${{ github.event_name != 'pull_request' }}
+        id: all
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "non-markdown-files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -iv '\.md$' | xargs)" >> "$GITHUB_OUTPUT"
-          else
-            # Always run on push and merge_group events
-            echo "non-markdown-files=true" >> "$GITHUB_OUTPUT"
-          fi
+          {
+            echo "go=true"
+            echo "api=true"
+            echo "manifests=true"
+            echo "jsonnet=true"
+            echo "shell=true"
+            echo "e2e=true"
+            echo "docs=true"
+            echo "metrics_docs=true"
+            echo "ci=true"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
 
 jobs:
+  changed-files:
+    uses: ./.github/workflows/changed-files.yaml
+
   build:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.ci == 'true' }}
     name: "go and github release"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.ref_name != 'main' }}
 
 jobs:
+  changed-files:
+    uses: ./.github/workflows/changed-files.yaml
+
   check-api-docs:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.api == 'true' }}
     name: 'check API docs are up-to-date'
     runs-on: ubuntu-latest
     steps:
@@ -29,9 +34,27 @@ jobs:
         uses: ./.github/tools-cache
       - name: check API docs are up-to-date
         run: make check-api-docs
+
+  check-metrics-docs:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.metrics_docs == 'true' }}
+    name: 'check metrics docs are up-to-date'
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+      - uses: perses/github-actions@v0.12.0
+      - uses: ./.github/perses-ci/actions/setup_environment
+        with:
+          enable_go: true
+      - name: Install all tools
+        uses: ./.github/tools-cache
       - name: check metrics docs are up-to-date
         run: make check-metrics-docs
+
   check-docs:
+    needs: changed-files
+    if: ${{ needs.changed-files.outputs.docs == 'true' }}
     name: 'check markdown formatting and links'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/changed-files.yaml
   e2e:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.e2e == 'true' }}
     name: "kuttl e2e tests"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/changed-files.yaml
   gofmt:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.go == 'true' || needs.changed-files.outputs.shell == 'true' }}
     name: "check code format"
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
         run: make tidy
   test-unit:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.go == 'true' }}
     name: "unit tests"
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
         run: make test-unit
   test-integration:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.go == 'true' || needs.changed-files.outputs.manifests == 'true' }}
     name: "integration tests"
     runs-on: ubuntu-latest
     steps:
@@ -69,7 +69,7 @@ jobs:
         run: make test-integration
   lint-api:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.api == 'true' }}
     name: "kube-api-linter"
     runs-on: ubuntu-latest
     steps:
@@ -85,7 +85,7 @@ jobs:
         run: make lint-api
   lint:
     needs: changed-files
-    if: ${{ needs.changed-files.outputs.non-markdown-files }}
+    if: ${{ needs.changed-files.outputs.go == 'true' || needs.changed-files.outputs.manifests == 'true' || needs.changed-files.outputs.jsonnet == 'true' || needs.changed-files.outputs.shell == 'true' }}
     name: lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses-operator/blob/main/CONTRIBUTING.md
-->

# Description

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

This PR adds a reusable changed file bucket for workflows so expensive jobs only run when their relevant inputs change. This avoids running Go, e2e,docs, image build validation for PRs that only touch unrelated files such as templates, CI, docs etc...

We keep push, tag and merge_group events on full validation by enabling all filter outside pull requests events. This preserves the existing main and release branch safety guarantees while reducing unnecessary  PR CI work.

Closes: #ISSUE-NUMBER

## Type of change

<!-- What type of changes does your code introduce? Put an `x` in the box that applies. -->

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

<!-- How did you test it? How do you know it works? -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
