### PR TITLE
[IGNORE] allow optional colon in commit message

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,6 +1,6 @@
 parserPreset:
   parserOpts:
-    headerPattern: '^\[(FEATURE|ENHANCEMENT|BUGFIX|BREAKINGCHANGE|DOC|IGNORE)\]\s(.+)$'
+    headerPattern: '^\[(FEATURE|ENHANCEMENT|BUGFIX|BREAKINGCHANGE|DOC|IGNORE)\]:?\s(.+)$'
     headerCorrespondence:
       - type
       - subject


### PR DESCRIPTION
# Description

Allow optional colon for commit lint

## Type of change

- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `BREAKINGCHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `DOC` (documentation only)
- [x] `IGNORE` (tooling, build system, CI, etc.)

## Verification

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer
- [x] Code follows project conventions and passes linting
- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
